### PR TITLE
ci: route self-hosted jobs to Linux (janus) runners

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,8 +36,10 @@ jobs:
       # Use the repo's locked black (via uv) so CI and local `make format`
       # never disagree on formatting — pinning avoids version skew where a
       # newer black reformats files the locked version leaves alone.
+      # --extra dev installs black (a dev dependency); without it uv can't
+      # find black to run.
       - name: Check Python formatting (Black)
-        run: uv run black --check agenkit/ tests/ || (echo "❌ Python code not formatted. Run 'make format' to fix" && exit 1)
+        run: uv run --extra dev black --check agenkit/ tests/ || (echo "❌ Python code not formatted. Run 'make format' to fix" && exit 1)
 
       - name: Check Go formatting (gofmt)
         working-directory: agenkit-go

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,12 +23,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-          cache: 'pip'
-
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
@@ -36,11 +30,14 @@ jobs:
           cache: true
           cache-dependency-path: agenkit-go/go.sum
 
-      - name: Install Black
-        run: pip install black
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
 
+      # Use the repo's locked black (via uv) so CI and local `make format`
+      # never disagree on formatting — pinning avoids version skew where a
+      # newer black reformats files the locked version leaves alone.
       - name: Check Python formatting (Black)
-        run: black --check agenkit/ tests/ || (echo "❌ Python code not formatted. Run 'make format' to fix" && exit 1)
+        run: uv run black --check agenkit/ tests/ || (echo "❌ Python code not formatted. Run 'make format' to fix" && exit 1)
 
       - name: Check Go formatting (gofmt)
         working-directory: agenkit-go

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,9 +14,9 @@ jobs:
   # Basic formatting checks only - detailed linting runs locally
   format-check:
     name: Format Check (Python Black + Go fmt)
-    # push/schedule -> self-hosted orion (fast); PRs (incl. forks) -> hosted,
-    # so untrusted PR code never runs on the LAN runner.
-    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'orion' }}
+    # push/schedule -> self-hosted Linux (janus, fast); PRs (incl. forks) ->
+    # GitHub-hosted, so untrusted PR code never runs on the LAN runner.
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || fromJSON('["self-hosted","Linux"]') }}
     timeout-minutes: 5
 
     steps:

--- a/.github/workflows/parity-validation.yml
+++ b/.github/workflows/parity-validation.yml
@@ -14,9 +14,9 @@ on:
 jobs:
   parity-check:
     name: Feature Parity Validation
-    # push/schedule -> self-hosted orion (fast); PRs (incl. forks) -> hosted,
-    # so untrusted PR code never runs on the LAN runner.
-    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'orion' }}
+    # push/schedule -> self-hosted Linux (janus, fast); PRs (incl. forks) ->
+    # GitHub-hosted, so untrusted PR code never runs on the LAN runner.
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || fromJSON('["self-hosted","Linux"]') }}
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/parity-validation.yml
+++ b/.github/workflows/parity-validation.yml
@@ -11,6 +11,10 @@ on:
 # Always run `make test` locally before pushing.
 # See CLAUDE.md for local testing requirements.
 
+permissions:
+  contents: read
+  pull-requests: write # for the parity-summary PR comment
+
 jobs:
   parity-check:
     name: Feature Parity Validation
@@ -65,7 +69,10 @@ jobs:
           retention-days: 30
 
       - name: Comment PR with parity summary
+        # Forked PRs get a read-only token, so commenting will fail there — keep
+        # it non-fatal so a missing comment never reds the whole run.
         if: github.event_name == 'pull_request'
+        continue-on-error: true
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -45,16 +45,26 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [python, go, javascript-typescript, java]
+        # build-mode none avoids the fragile autobuild step for the languages
+        # that support it (Go included, in modern CodeQL). Java still needs a
+        # build, so it uses autobuild.
+        include:
+          - language: python
+            build-mode: none
+          - language: go
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
+          - language: java
+            build-mode: autobuild
     steps:
       - uses: actions/checkout@v4
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:
           language: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
           queries: security-extended
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
       - name: Analyze
         uses: github/codeql-action/analyze@v3
         with:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -5,11 +5,15 @@ name: Security
 # kept minimal, but security tooling runs here because it only delivers value
 # in CI (PR gating, scheduled scans, GitHub Security tab / SARIF integration).
 #
-# Runner split (public repo + self-hosted runner on orion.local):
-#   - push to main / tags / schedule  -> self-hosted `orion` (fast, our hardware)
+# Runner split (public repo + self-hosted Linux runners on janus.local):
+#   - push to main / tags / schedule  -> self-hosted [self-hosted, Linux]
+#                                         (janus, Rocky 9 + Docker — container
+#                                         jobs run natively)
 #   - pull_request (incl. forks)       -> ephemeral GitHub-hosted runner, so
 #                                         untrusted PR code never executes on the
 #                                         LAN runner.
+# Note: orion (macOS) cannot run `container:` jobs, so CI targets the Linux
+# runners; orion stays available as overflow for non-container work.
 # See: https://docs.github.com/actions/security-guides/security-hardening-for-github-actions#hardening-for-self-hosted-runners
 
 on:
@@ -36,7 +40,7 @@ jobs:
   # ---------------------------------------------------------------------------
   codeql:
     name: CodeQL (${{ matrix.language }})
-    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'orion' }}
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || fromJSON('["self-hosted","Linux"]') }}
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -62,12 +66,12 @@ jobs:
   # ---------------------------------------------------------------------------
   trivy:
     name: Trivy filesystem scan
-    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'orion' }}
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || fromJSON('["self-hosted","Linux"]') }}
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       - name: Trivy filesystem scan (SARIF)
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           scan-type: fs
           scan-ref: .
@@ -88,7 +92,7 @@ jobs:
   # ---------------------------------------------------------------------------
   govulncheck:
     name: govulncheck (Go)
-    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'orion' }}
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || fromJSON('["self-hosted","Linux"]') }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
@@ -109,7 +113,7 @@ jobs:
   # ---------------------------------------------------------------------------
   semgrep:
     name: Semgrep SAST
-    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'orion' }}
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || fromJSON('["self-hosted","Linux"]') }}
     timeout-minutes: 20
     container:
       image: semgrep/semgrep

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:
-          language: ${{ matrix.language }}
+          languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
           queries: security-extended
       - name: Analyze

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -45,16 +45,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # build-mode none avoids the fragile autobuild step for the languages
-        # that support it (Go included, in modern CodeQL). Java still needs a
-        # build, so it uses autobuild.
+        # build-mode none (buildless extraction) for interpreted languages;
+        # compiled languages (Go, Java) require autobuild — Go explicitly
+        # rejects build-mode none.
         include:
           - language: python
             build-mode: none
-          - language: go
-            build-mode: none
           - language: javascript-typescript
             build-mode: none
+          - language: go
+            build-mode: autobuild
           - language: java
             build-mode: autobuild
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-          cache: 'pip'
+          # No pip cache: this project uses uv (installed below), so there is
+          # no pip cache dir — `cache: 'pip'` fails the post-job cleanup step.
 
       - name: Set up Go 1.23
         uses: actions/setup-go@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,9 +15,9 @@ jobs:
   # Minimal smoke test - local testing is primary validation
   smoke-test:
     name: Smoke Test (Python 3.12 + Go 1.23)
-    # push/schedule -> self-hosted orion (fast); PRs (incl. forks) -> hosted,
-    # so untrusted PR code never runs on the LAN runner.
-    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || 'orion' }}
+    # push/schedule -> self-hosted Linux (janus, fast); PRs (incl. forks) ->
+    # GitHub-hosted, so untrusted PR code never runs on the LAN runner.
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || fromJSON('["self-hosted","Linux"]') }}
     timeout-minutes: 15
 
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,11 +55,15 @@ make security     # Local security scan (trivy/govulncheck/semgrep) — optional
 
 #### CI policy (updated)
 CI **is** enabled, but it is supplementary to local testing, not a substitute.
-- **Self-hosted runner**: functional CI (test, lint, parity) runs on the
-  `orion` self-hosted runner for `push`/`schedule`. **Pull requests (incl.
-  forks) run on GitHub-hosted runners** so untrusted code never executes on the
-  LAN runner — this split is encoded in every workflow's `runs-on:` and must be
-  preserved.
+- **Self-hosted runners**: functional CI + security scans run on the
+  `[self-hosted, Linux]` runners (janus.local, Rocky 9 — 6 runners) for
+  `push`/`schedule`. Linux is required because container jobs (Semgrep, Trivy,
+  CodeQL build) only run on Linux runners — the macOS `orion` runners cannot
+  run `container:` jobs and serve as overflow for non-container work only.
+  **Pull requests (incl. forks) run on GitHub-hosted runners** so untrusted
+  code never executes on the LAN runners — this split is encoded in every
+  workflow's `runs-on:` (`pull_request ? ubuntu-latest : [self-hosted, Linux]`)
+  and must be preserved.
 - **Security scanning is the sanctioned exception** to "minimal CI": CodeQL,
   Trivy, govulncheck, and Semgrep run in `.github/workflows/security.yml`, and
   SBOM generation + Sigstore signing run on release in

--- a/agenkit-go/adapter/llm/openai.go
+++ b/agenkit-go/adapter/llm/openai.go
@@ -180,9 +180,9 @@ func (o *OpenAILLM) Complete(ctx context.Context, messages []*agenkit.Message, o
 		}
 		for _, tc := range msg.ToolCalls {
 			blocks = append(blocks, map[string]interface{}{
-				"type": "tool_use",
-				"id":   tc.ID,
-				"name": tc.Function.Name,
+				"type":  "tool_use",
+				"id":    tc.ID,
+				"name":  tc.Function.Name,
 				"input": tc.Function.Arguments,
 			})
 		}

--- a/agenkit-go/benchmarks/middleware_overhead_test.go
+++ b/agenkit-go/benchmarks/middleware_overhead_test.go
@@ -91,7 +91,7 @@ func BenchmarkRetryMiddleware(b *testing.B) {
 	msg := agenkit.NewMessage("user", "test")
 
 	retryAgent := middleware.NewRetryDecorator(agent, middleware.RetryConfig{
-		MaxRetries:    3,
+		MaxRetries:        3,
 		InitialRetryDelay: 100 * time.Millisecond,
 		MaxRetryDelay:     1000 * time.Millisecond,
 	})
@@ -281,7 +281,7 @@ func BenchmarkStackedMiddleware(b *testing.B) {
 
 	// Layer 4: Retry
 	agentWithRetry := middleware.NewRetryDecorator(agentWithTimeout, middleware.RetryConfig{
-		MaxRetries:    3,
+		MaxRetries:        3,
 		InitialRetryDelay: 100 * time.Millisecond,
 		MaxRetryDelay:     1000 * time.Millisecond,
 	})
@@ -313,7 +313,7 @@ func BenchmarkMinimalStack(b *testing.B) {
 
 	// Layer 1: Retry
 	agentWithRetry := middleware.NewRetryDecorator(agent, middleware.RetryConfig{
-		MaxRetries:    3,
+		MaxRetries:        3,
 		InitialRetryDelay: 100 * time.Millisecond,
 		MaxRetryDelay:     1000 * time.Millisecond,
 	})
@@ -402,7 +402,7 @@ func BenchmarkStackedMiddlewareParallel(b *testing.B) {
 	})
 
 	agentWithRetry := middleware.NewRetryDecorator(agentWithTimeout, middleware.RetryConfig{
-		MaxRetries:    3,
+		MaxRetries:        3,
 		InitialRetryDelay: 100 * time.Millisecond,
 		MaxRetryDelay:     1000 * time.Millisecond,
 	})

--- a/agenkit-go/cross_language_tests/api_consistency_test.go
+++ b/agenkit-go/cross_language_tests/api_consistency_test.go
@@ -32,10 +32,10 @@ type ParameterNamingCategory struct {
 }
 
 type ParameterTestCase struct {
-	ID         string                 `json:"id"`
-	Name       string                 `json:"name"`
-	Component  string                 `json:"component"`
-	Parameters map[string]Parameter   `json:"parameters"`
+	ID         string               `json:"id"`
+	Name       string               `json:"name"`
+	Component  string               `json:"component"`
+	Parameters map[string]Parameter `json:"parameters"`
 }
 
 type Parameter struct {

--- a/agenkit-go/cross_language_tests/circuit_breaker_behavior_test.go
+++ b/agenkit-go/cross_language_tests/circuit_breaker_behavior_test.go
@@ -17,9 +17,9 @@ import (
 
 // CircuitBreakerTestCase represents a test case from the circuit_breaker_behavior.json fixture
 type CircuitBreakerTestCase struct {
-	ID       string `json:"id"`
-	Name     string `json:"name"`
-	Config   struct {
+	ID     string `json:"id"`
+	Name   string `json:"name"`
+	Config struct {
 		FailureThreshold  int `json:"failure_threshold"`
 		RecoveryTimeoutMS int `json:"recovery_timeout_ms"`
 		SuccessThreshold  int `json:"success_threshold"`
@@ -30,27 +30,27 @@ type CircuitBreakerTestCase struct {
 		Steps          []CircuitBreakerStep     `json:"steps,omitempty"`
 	} `json:"scenario"`
 	ExpectedBehavior *struct {
-		FinalState                     string   `json:"final_state"`
-		TotalRequests                  int      `json:"total_requests,omitempty"`
-		SuccessfulRequests             int      `json:"successful_requests,omitempty"`
-		FailedRequests                 int      `json:"failed_requests,omitempty"`
-		RejectedRequests               int      `json:"rejected_requests,omitempty"`
-		AllRequestsCompleted           bool     `json:"all_requests_completed,omitempty"`
-		StateTransitions               []string `json:"state_transitions,omitempty"`
-		FourthRequestRejected          bool     `json:"fourth_request_rejected,omitempty"`
-		RecoverySuccessful             bool     `json:"recovery_successful,omitempty"`
-		TotalSuccessfulInHalfOpen      int      `json:"total_successful_in_half_open,omitempty"`
-		CircuitFullyRecovered          bool     `json:"circuit_fully_recovered,omitempty"`
-		ReopenedAfterPartialRecovery   bool     `json:"reopened_after_partial_recovery,omitempty"`
-		AllRejectedWhileOpen           bool     `json:"all_rejected_while_open,omitempty"`
+		FinalState                   string   `json:"final_state"`
+		TotalRequests                int      `json:"total_requests,omitempty"`
+		SuccessfulRequests           int      `json:"successful_requests,omitempty"`
+		FailedRequests               int      `json:"failed_requests,omitempty"`
+		RejectedRequests             int      `json:"rejected_requests,omitempty"`
+		AllRequestsCompleted         bool     `json:"all_requests_completed,omitempty"`
+		StateTransitions             []string `json:"state_transitions,omitempty"`
+		FourthRequestRejected        bool     `json:"fourth_request_rejected,omitempty"`
+		RecoverySuccessful           bool     `json:"recovery_successful,omitempty"`
+		TotalSuccessfulInHalfOpen    int      `json:"total_successful_in_half_open,omitempty"`
+		CircuitFullyRecovered        bool     `json:"circuit_fully_recovered,omitempty"`
+		ReopenedAfterPartialRecovery bool     `json:"reopened_after_partial_recovery,omitempty"`
+		AllRejectedWhileOpen         bool     `json:"all_rejected_while_open,omitempty"`
 	} `json:"expected_behavior,omitempty"`
 	ExpectedMetrics *struct {
-		TotalRequests      int              `json:"total_requests"`
-		SuccessfulRequests int              `json:"successful_requests"`
-		FailedRequests     int              `json:"failed_requests"`
-		RejectedRequests   int              `json:"rejected_requests"`
-		StateChanges       map[string]int   `json:"state_changes"`
-		FinalState         string           `json:"final_state"`
+		TotalRequests      int            `json:"total_requests"`
+		SuccessfulRequests int            `json:"successful_requests"`
+		FailedRequests     int            `json:"failed_requests"`
+		RejectedRequests   int            `json:"rejected_requests"`
+		StateChanges       map[string]int `json:"state_changes"`
+		FinalState         string         `json:"final_state"`
 	} `json:"expected_metrics,omitempty"`
 }
 

--- a/agenkit-go/cross_language_tests/rate_limiter_behavior_test.go
+++ b/agenkit-go/cross_language_tests/rate_limiter_behavior_test.go
@@ -51,13 +51,13 @@ func (m *MockRateLimiterAgent) Process(ctx context.Context, message *agenkit.Mes
 
 // RateLimiterTestCase represents a rate limiter test case from fixtures.
 type RateLimiterTestCase struct {
-	ID       string `json:"id"`
-	Name     string `json:"name"`
-	Config   struct {
-		Rate             float64  `json:"rate"`
-		Capacity         int      `json:"capacity"`
-		TokensPerRequest int      `json:"tokens_per_request"`
-		MaxWaitMs        *int     `json:"max_wait_ms"`
+	ID     string `json:"id"`
+	Name   string `json:"name"`
+	Config struct {
+		Rate             float64 `json:"rate"`
+		Capacity         int     `json:"capacity"`
+		TokensPerRequest int     `json:"tokens_per_request"`
+		MaxWaitMs        *int    `json:"max_wait_ms"`
 	} `json:"config"`
 	Scenario struct {
 		Requests []struct {
@@ -83,18 +83,18 @@ type RateLimiterTestCase struct {
 		BurstHandled         bool `json:"burst_handled,omitempty"`
 	} `json:"expected_behavior,omitempty"`
 	ExpectedMetrics *struct {
-		TotalRequests           int `json:"total_requests"`
-		AllowedRequests         int `json:"allowed_requests"`
-		RejectedRequests        int `json:"rejected_requests"`
+		TotalRequests            int `json:"total_requests"`
+		AllowedRequests          int `json:"allowed_requests"`
+		RejectedRequests         int `json:"rejected_requests"`
 		TotalWaitTimeGreaterThan int `json:"total_wait_time_greater_than"`
 	} `json:"expected_metrics,omitempty"`
 }
 
 // RateLimiterFixtures represents the rate limiter test fixtures file.
 type RateLimiterFixtures struct {
-	Version     string                    `json:"version"`
-	Description string                    `json:"description"`
-	TestCases   []RateLimiterTestCase     `json:"test_cases"`
+	Version     string                `json:"version"`
+	Description string                `json:"description"`
+	TestCases   []RateLimiterTestCase `json:"test_cases"`
 }
 
 func loadRateLimiterFixtures(t *testing.T) *RateLimiterFixtures {

--- a/agenkit-go/cross_language_tests/retry_behavior_test.go
+++ b/agenkit-go/cross_language_tests/retry_behavior_test.go
@@ -23,19 +23,19 @@ type RetryBehaviorFixtures struct {
 }
 
 type RetryBehaviorTest struct {
-	ID               string               `json:"id"`
-	Name             string               `json:"name"`
-	Config           RetryConfigData      `json:"config"`
-	Scenario         RetryScenario        `json:"scenario"`
-	ExpectedBehavior map[string]any       `json:"expected_behavior,omitempty"`
-	ExpectedMetrics  map[string]any       `json:"expected_metrics,omitempty"`
+	ID               string          `json:"id"`
+	Name             string          `json:"name"`
+	Config           RetryConfigData `json:"config"`
+	Scenario         RetryScenario   `json:"scenario"`
+	ExpectedBehavior map[string]any  `json:"expected_behavior,omitempty"`
+	ExpectedMetrics  map[string]any  `json:"expected_metrics,omitempty"`
 }
 
 type RetryConfigData struct {
-	MaxRetries          int     `json:"max_retries"`
-	InitialBackoffMs    int     `json:"initial_backoff_ms"`
-	MaxBackoffMs        int     `json:"max_backoff_ms"`
-	BackoffMultiplier   float64 `json:"backoff_multiplier"`
+	MaxRetries        int     `json:"max_retries"`
+	InitialBackoffMs  int     `json:"initial_backoff_ms"`
+	MaxBackoffMs      int     `json:"max_backoff_ms"`
+	BackoffMultiplier float64 `json:"backoff_multiplier"`
 }
 
 type RetryScenario struct {
@@ -115,10 +115,10 @@ func TestRetryBehavior_SuccessFirstAttempt(t *testing.T) {
 
 	// Create retry config
 	config := middleware.RetryConfig{
-		MaxRetries:          testCase.Config.MaxRetries,
-		InitialRetryDelay:   time.Duration(testCase.Config.InitialBackoffMs) * time.Millisecond,
-		MaxRetryDelay:       time.Duration(testCase.Config.MaxBackoffMs) * time.Millisecond,
-		RetryMultiplier:     testCase.Config.BackoffMultiplier,
+		MaxRetries:        testCase.Config.MaxRetries,
+		InitialRetryDelay: time.Duration(testCase.Config.InitialBackoffMs) * time.Millisecond,
+		MaxRetryDelay:     time.Duration(testCase.Config.MaxBackoffMs) * time.Millisecond,
+		RetryMultiplier:   testCase.Config.BackoffMultiplier,
 	}
 
 	retry := middleware.NewRetryDecorator(agent, config)
@@ -141,10 +141,10 @@ func TestRetryBehavior_SuccessAfterRetry(t *testing.T) {
 
 	agent := &MockRetryAgent{Responses: testCase.Scenario.AgentResponses}
 	config := middleware.RetryConfig{
-		MaxRetries:          testCase.Config.MaxRetries,
-		InitialRetryDelay:   time.Duration(testCase.Config.InitialBackoffMs) * time.Millisecond,
-		MaxRetryDelay:       time.Duration(testCase.Config.MaxBackoffMs) * time.Millisecond,
-		RetryMultiplier:     testCase.Config.BackoffMultiplier,
+		MaxRetries:        testCase.Config.MaxRetries,
+		InitialRetryDelay: time.Duration(testCase.Config.InitialBackoffMs) * time.Millisecond,
+		MaxRetryDelay:     time.Duration(testCase.Config.MaxBackoffMs) * time.Millisecond,
+		RetryMultiplier:   testCase.Config.BackoffMultiplier,
 	}
 
 	retry := middleware.NewRetryDecorator(agent, config)
@@ -174,10 +174,10 @@ func TestRetryBehavior_RetriesExhausted(t *testing.T) {
 
 	agent := &MockRetryAgent{Responses: testCase.Scenario.AgentResponses}
 	config := middleware.RetryConfig{
-		MaxRetries:          testCase.Config.MaxRetries,
-		InitialRetryDelay:   time.Duration(testCase.Config.InitialBackoffMs) * time.Millisecond,
-		MaxRetryDelay:       time.Duration(testCase.Config.MaxBackoffMs) * time.Millisecond,
-		RetryMultiplier:     testCase.Config.BackoffMultiplier,
+		MaxRetries:        testCase.Config.MaxRetries,
+		InitialRetryDelay: time.Duration(testCase.Config.InitialBackoffMs) * time.Millisecond,
+		MaxRetryDelay:     time.Duration(testCase.Config.MaxBackoffMs) * time.Millisecond,
+		RetryMultiplier:   testCase.Config.BackoffMultiplier,
 	}
 
 	retry := middleware.NewRetryDecorator(agent, config)
@@ -199,10 +199,10 @@ func TestRetryBehavior_ExponentialBackoff(t *testing.T) {
 
 	agent := &MockRetryAgent{Responses: testCase.Scenario.AgentResponses}
 	config := middleware.RetryConfig{
-		MaxRetries:          testCase.Config.MaxRetries,
-		InitialRetryDelay:   time.Duration(testCase.Config.InitialBackoffMs) * time.Millisecond,
-		MaxRetryDelay:       time.Duration(testCase.Config.MaxBackoffMs) * time.Millisecond,
-		RetryMultiplier:     testCase.Config.BackoffMultiplier,
+		MaxRetries:        testCase.Config.MaxRetries,
+		InitialRetryDelay: time.Duration(testCase.Config.InitialBackoffMs) * time.Millisecond,
+		MaxRetryDelay:     time.Duration(testCase.Config.MaxBackoffMs) * time.Millisecond,
+		RetryMultiplier:   testCase.Config.BackoffMultiplier,
 	}
 
 	retry := middleware.NewRetryDecorator(agent, config)
@@ -236,10 +236,10 @@ func TestRetryBehavior_MaxBackoffCap(t *testing.T) {
 
 	agent := &MockRetryAgent{Responses: testCase.Scenario.AgentResponses}
 	config := middleware.RetryConfig{
-		MaxRetries:          testCase.Config.MaxRetries,
-		InitialRetryDelay:   time.Duration(testCase.Config.InitialBackoffMs) * time.Millisecond,
-		MaxRetryDelay:       time.Duration(testCase.Config.MaxBackoffMs) * time.Millisecond,
-		RetryMultiplier:     testCase.Config.BackoffMultiplier,
+		MaxRetries:        testCase.Config.MaxRetries,
+		InitialRetryDelay: time.Duration(testCase.Config.InitialBackoffMs) * time.Millisecond,
+		MaxRetryDelay:     time.Duration(testCase.Config.MaxBackoffMs) * time.Millisecond,
+		RetryMultiplier:   testCase.Config.BackoffMultiplier,
 	}
 
 	retry := middleware.NewRetryDecorator(agent, config)
@@ -279,11 +279,11 @@ func TestRetryBehavior_NonRetryableError(t *testing.T) {
 	}
 
 	config := middleware.RetryConfig{
-		MaxRetries:          testCase.Config.MaxRetries,
-		InitialRetryDelay:   time.Duration(testCase.Config.InitialBackoffMs) * time.Millisecond,
-		MaxRetryDelay:       time.Duration(testCase.Config.MaxBackoffMs) * time.Millisecond,
-		RetryMultiplier:     testCase.Config.BackoffMultiplier,
-		ShouldRetry:         shouldRetry,
+		MaxRetries:        testCase.Config.MaxRetries,
+		InitialRetryDelay: time.Duration(testCase.Config.InitialBackoffMs) * time.Millisecond,
+		MaxRetryDelay:     time.Duration(testCase.Config.MaxBackoffMs) * time.Millisecond,
+		RetryMultiplier:   testCase.Config.BackoffMultiplier,
+		ShouldRetry:       shouldRetry,
 	}
 
 	retry := middleware.NewRetryDecorator(agent, config)
@@ -306,10 +306,10 @@ func TestRetryBehavior_MetricsTracking(t *testing.T) {
 
 	agent := &MockRetryAgent{Responses: testCase.Scenario.AgentResponses}
 	config := middleware.RetryConfig{
-		MaxRetries:          testCase.Config.MaxRetries,
-		InitialRetryDelay:   time.Duration(testCase.Config.InitialBackoffMs) * time.Millisecond,
-		MaxRetryDelay:       time.Duration(testCase.Config.MaxBackoffMs) * time.Millisecond,
-		RetryMultiplier:     testCase.Config.BackoffMultiplier,
+		MaxRetries:        testCase.Config.MaxRetries,
+		InitialRetryDelay: time.Duration(testCase.Config.InitialBackoffMs) * time.Millisecond,
+		MaxRetryDelay:     time.Duration(testCase.Config.MaxBackoffMs) * time.Millisecond,
+		RetryMultiplier:   testCase.Config.BackoffMultiplier,
 	}
 
 	retry := middleware.NewRetryDecorator(agent, config)

--- a/agenkit-go/cross_language_tests/timeout_behavior_test.go
+++ b/agenkit-go/cross_language_tests/timeout_behavior_test.go
@@ -17,24 +17,24 @@ import (
 
 // TimeoutTestCase represents a test case from the timeout_behavior.json fixture
 type TimeoutTestCase struct {
-	ID       string `json:"id"`
-	Name     string `json:"name"`
-	Config   struct {
+	ID     string `json:"id"`
+	Name   string `json:"name"`
+	Config struct {
 		TimeoutMS int `json:"timeout_ms"`
 	} `json:"config"`
 	Scenario struct {
-		AgentDelayMS   int                    `json:"agent_delay_ms"`
-		AgentResponse  map[string]interface{} `json:"agent_response,omitempty"`
-		Requests       []TimeoutRequest       `json:"requests,omitempty"`
+		AgentDelayMS  int                    `json:"agent_delay_ms"`
+		AgentResponse map[string]interface{} `json:"agent_response,omitempty"`
+		Requests      []TimeoutRequest       `json:"requests,omitempty"`
 	} `json:"scenario"`
 	ExpectedBehavior *struct {
-		Successful            bool    `json:"successful"`
-		TimedOut              bool    `json:"timed_out"`
-		FinalResponse         string  `json:"final_response,omitempty"`
-		ErrorType             string  `json:"error_type,omitempty"`
-		ErrorMessageContains  string  `json:"error_message_contains,omitempty"`
-		MinElapsedMS          int64   `json:"min_elapsed_ms"`
-		MaxElapsedMS          int64   `json:"max_elapsed_ms"`
+		Successful           bool   `json:"successful"`
+		TimedOut             bool   `json:"timed_out"`
+		FinalResponse        string `json:"final_response,omitempty"`
+		ErrorType            string `json:"error_type,omitempty"`
+		ErrorMessageContains string `json:"error_message_contains,omitempty"`
+		MinElapsedMS         int64  `json:"min_elapsed_ms"`
+		MaxElapsedMS         int64  `json:"max_elapsed_ms"`
 	} `json:"expected_behavior,omitempty"`
 	ExpectedMetrics *struct {
 		TotalRequests      int     `json:"total_requests"`

--- a/agenkit-go/infrastructure/health.go
+++ b/agenkit-go/infrastructure/health.go
@@ -49,20 +49,20 @@ type HealthCheckResult struct {
 // HealthCheckConfig configures health check behavior.
 type HealthCheckConfig struct {
 	// Liveness probe settings
-	LivenessEnabled         bool
-	LivenessInterval        time.Duration
-	LivenessTimeout         time.Duration
+	LivenessEnabled          bool
+	LivenessInterval         time.Duration
+	LivenessTimeout          time.Duration
 	LivenessFailureThreshold int
 
 	// Readiness probe settings
-	ReadinessEnabled         bool
-	ReadinessInterval        time.Duration
-	ReadinessTimeout         time.Duration
+	ReadinessEnabled          bool
+	ReadinessInterval         time.Duration
+	ReadinessTimeout          time.Duration
 	ReadinessFailureThreshold int
 
 	// Startup probe settings
-	StartupEnabled         bool
-	StartupTimeout         time.Duration
+	StartupEnabled          bool
+	StartupTimeout          time.Duration
 	StartupFailureThreshold int
 
 	// Custom health check function
@@ -88,14 +88,14 @@ func DefaultHealthCheckConfig() HealthCheckConfig {
 
 // HealthMetrics tracks health check metrics.
 type HealthMetrics struct {
-	TotalChecks          map[ProbeType]int64
-	SuccessfulChecks     map[ProbeType]int64
-	FailedChecks         map[ProbeType]int64
-	LastCheckTime        map[ProbeType]time.Time
-	LastCheckDuration    map[ProbeType]float64
-	ConsecutiveFailures  map[ProbeType]int
-	UptimeStart          time.Time
-	mu                   sync.RWMutex
+	TotalChecks         map[ProbeType]int64
+	SuccessfulChecks    map[ProbeType]int64
+	FailedChecks        map[ProbeType]int64
+	LastCheckTime       map[ProbeType]time.Time
+	LastCheckDuration   map[ProbeType]float64
+	ConsecutiveFailures map[ProbeType]int
+	UptimeStart         time.Time
+	mu                  sync.RWMutex
 }
 
 // NewHealthMetrics creates new health metrics.
@@ -118,16 +118,16 @@ func (hm *HealthMetrics) GetUptime() float64 {
 
 // HealthChecker monitors agent health.
 type HealthChecker struct {
-	agent            agenkit.Agent
-	config           HealthCheckConfig
-	metrics          *HealthMetrics
-	isAlive          bool
-	isReady          bool
-	startupComplete  bool
+	agent                 agenkit.Agent
+	config                HealthCheckConfig
+	metrics               *HealthMetrics
+	isAlive               bool
+	isReady               bool
+	startupComplete       bool
 	lastSuccessfulRequest time.Time
-	mu               sync.RWMutex
-	stopChan         chan struct{}
-	wg               sync.WaitGroup
+	mu                    sync.RWMutex
+	stopChan              chan struct{}
+	wg                    sync.WaitGroup
 }
 
 // NewHealthChecker creates a new health checker.

--- a/agenkit-go/infrastructure/load_balancer.go
+++ b/agenkit-go/infrastructure/load_balancer.go
@@ -34,24 +34,24 @@ const (
 
 // AgentBackend represents a backend agent with metadata.
 type AgentBackend struct {
-	Agent              agenkit.Agent
-	Weight             int
-	Healthy            bool
-	ActiveConnections  int
-	TotalRequests      int64
-	TotalFailures      int64
-	LastHealthCheck    time.Time
+	Agent               agenkit.Agent
+	Weight              int
+	Healthy             bool
+	ActiveConnections   int
+	TotalRequests       int64
+	TotalFailures       int64
+	LastHealthCheck     time.Time
 	consecutiveFailures int
 }
 
 // LoadBalancerConfig configures the load balancer.
 type LoadBalancerConfig struct {
-	Strategy              LoadBalancingStrategy
-	HealthCheckInterval   time.Duration
-	HealthCheckTimeout    time.Duration
-	FailureThreshold      int
-	SuccessThreshold      int
-	EnableFailover        bool
+	Strategy            LoadBalancingStrategy
+	HealthCheckInterval time.Duration
+	HealthCheckTimeout  time.Duration
+	FailureThreshold    int
+	SuccessThreshold    int
+	EnableFailover      bool
 }
 
 // DefaultLoadBalancerConfig returns default configuration.
@@ -68,23 +68,23 @@ func DefaultLoadBalancerConfig() LoadBalancerConfig {
 
 // LoadBalancerMetrics tracks load balancer performance.
 type LoadBalancerMetrics struct {
-	TotalRequests      int64
-	SuccessfulRequests int64
-	FailedRequests     int64
-	FailoverAttempts   int64
+	TotalRequests        int64
+	SuccessfulRequests   int64
+	FailedRequests       int64
+	FailoverAttempts     int64
 	BackendHealthChanges map[string]int64
-	mu sync.RWMutex
+	mu                   sync.RWMutex
 }
 
 // LoadBalancer distributes requests across multiple agents.
 type LoadBalancer struct {
-	backends      []*AgentBackend
-	config        LoadBalancerConfig
-	metrics       *LoadBalancerMetrics
-	currentIndex  int
-	mu            sync.Mutex
+	backends        []*AgentBackend
+	config          LoadBalancerConfig
+	metrics         *LoadBalancerMetrics
+	currentIndex    int
+	mu              sync.Mutex
 	stopHealthCheck chan struct{}
-	wg            sync.WaitGroup
+	wg              sync.WaitGroup
 }
 
 // NewLoadBalancer creates a new load balancer.
@@ -116,9 +116,9 @@ func NewLoadBalancer(agents []agenkit.Agent, config LoadBalancerConfig, weights 
 	}
 
 	lb := &LoadBalancer{
-		backends:        backends,
-		config:          config,
-		metrics:         &LoadBalancerMetrics{
+		backends: backends,
+		config:   config,
+		metrics: &LoadBalancerMetrics{
 			BackendHealthChanges: make(map[string]int64),
 		},
 		stopHealthCheck: make(chan struct{}),
@@ -386,7 +386,7 @@ func (lb *LoadBalancer) Process(ctx context.Context, message *agenkit.Message) (
 		}
 
 		// No more failover
-		return nil,fmt.Errorf("backend %s failed: %w", backend.Agent.Name(), err)
+		return nil, fmt.Errorf("backend %s failed: %w", backend.Agent.Name(), err)
 	}
 }
 

--- a/agenkit-go/infrastructure/load_balancer_test.go
+++ b/agenkit-go/infrastructure/load_balancer_test.go
@@ -11,17 +11,17 @@ import (
 
 // mockAgentLB is a test double for the Agent interface.
 type mockAgentLB struct {
-	name        string
-	response    string
-	callCount   atomic.Int64
-	shouldFail  bool
+	name       string
+	response   string
+	callCount  atomic.Int64
+	shouldFail bool
 }
 
 func newMockAgentLB(name, response string) *mockAgentLB {
 	return &mockAgentLB{name: name, response: response}
 }
 
-func (m *mockAgentLB) Name() string { return m.name }
+func (m *mockAgentLB) Name() string           { return m.name }
 func (m *mockAgentLB) Capabilities() []string { return []string{"mock"} }
 func (m *mockAgentLB) Introspect() *agenkit.IntrospectionResult {
 	return &agenkit.IntrospectionResult{AgentName: m.name}

--- a/agenkit-go/infrastructure/retry_enhanced.go
+++ b/agenkit-go/infrastructure/retry_enhanced.go
@@ -64,108 +64,108 @@ func (ec ErrorClass) String() string {
 // ErrorStrategy defines retry strategy for specific error class.
 type ErrorStrategy struct {
 	ErrorClass        ErrorClass
-	MaxRetries       int
-	InitialRetryDelay    time.Duration
-	MaxRetryDelay        time.Duration
-	RetryMultiplier float64
+	MaxRetries        int
+	InitialRetryDelay time.Duration
+	MaxRetryDelay     time.Duration
+	RetryMultiplier   float64
 	ShouldRetry       bool
 }
 
 // RetryBudget limits retry costs.
 type RetryBudget struct {
-	MaxCost            float64
-	CurrentCost        float64
-	MaxRetriesPerHour  int64
-	RetryCount         int64
-	WindowStart        time.Time
-	mu                 sync.Mutex
+	MaxCost           float64
+	CurrentCost       float64
+	MaxRetriesPerHour int64
+	RetryCount        int64
+	WindowStart       time.Time
+	mu                sync.Mutex
 }
 
 // EnhancedRetryConfig configures enhanced retry behavior.
 type EnhancedRetryConfig struct {
 	// Basic retry settings
-	MaxRetries       int
-	InitialRetryDelay    time.Duration
-	MaxRetryDelay        time.Duration
-	RetryMultiplier float64
+	MaxRetries        int
+	InitialRetryDelay time.Duration
+	MaxRetryDelay     time.Duration
+	RetryMultiplier   float64
 
 	// Jitter settings
 	JitterType     JitterType
 	JitterMinRatio float64 // For EqualJitter
 
 	// Error-specific strategies
-	ErrorStrategies  map[ErrorClass]ErrorStrategy
-	ErrorClassifier  func(error) ErrorClass
+	ErrorStrategies map[ErrorClass]ErrorStrategy
+	ErrorClassifier func(error) ErrorClass
 
 	// Budget settings
-	EnableBudget       bool
-	CostTracker        func(agenkit.Message) float64
-	MaxCostPerHour     float64
-	MaxRetriesPerHour  int64
+	EnableBudget      bool
+	CostTracker       func(agenkit.Message) float64
+	MaxCostPerHour    float64
+	MaxRetriesPerHour int64
 
 	// Backpressure detection
-	EnableBackpressure  bool
+	EnableBackpressure    bool
 	BackpressureThreshold float64
-	BackpressureWindow  int
+	BackpressureWindow    int
 }
 
 // DefaultEnhancedRetryConfig returns default configuration with error strategies.
 func DefaultEnhancedRetryConfig() EnhancedRetryConfig {
 	config := EnhancedRetryConfig{
 		MaxRetries:            3,
-		InitialRetryDelay:         1 * time.Second,
-		MaxRetryDelay:             30 * time.Second,
-		RetryMultiplier:      2.0,
-		JitterType:             FullJitter,
-		JitterMinRatio:         0.5,
-		EnableBudget:           false,
-		MaxCostPerHour:         100.0,
-		MaxRetriesPerHour:      1000,
-		EnableBackpressure:     true,
-		BackpressureThreshold:  0.5,
-		BackpressureWindow:     100,
+		InitialRetryDelay:     1 * time.Second,
+		MaxRetryDelay:         30 * time.Second,
+		RetryMultiplier:       2.0,
+		JitterType:            FullJitter,
+		JitterMinRatio:        0.5,
+		EnableBudget:          false,
+		MaxCostPerHour:        100.0,
+		MaxRetriesPerHour:     1000,
+		EnableBackpressure:    true,
+		BackpressureThreshold: 0.5,
+		BackpressureWindow:    100,
 	}
 
 	// Default error strategies
 	config.ErrorStrategies = map[ErrorClass]ErrorStrategy{
 		Transient: {
 			ErrorClass:        Transient,
-			MaxRetries:       5,
-			InitialRetryDelay:    100 * time.Millisecond,
-			MaxRetryDelay:        5 * time.Second,
-			RetryMultiplier: 2.0,
+			MaxRetries:        5,
+			InitialRetryDelay: 100 * time.Millisecond,
+			MaxRetryDelay:     5 * time.Second,
+			RetryMultiplier:   2.0,
 			ShouldRetry:       true,
 		},
 		RateLimit: {
 			ErrorClass:        RateLimit,
-			MaxRetries:       10,
-			InitialRetryDelay:    60 * time.Second,
-			MaxRetryDelay:        300 * time.Second,
-			RetryMultiplier: 1.5,
+			MaxRetries:        10,
+			InitialRetryDelay: 60 * time.Second,
+			MaxRetryDelay:     300 * time.Second,
+			RetryMultiplier:   1.5,
 			ShouldRetry:       true,
 		},
 		Timeout: {
 			ErrorClass:        Timeout,
-			MaxRetries:       3,
-			InitialRetryDelay:    2 * time.Second,
-			MaxRetryDelay:        30 * time.Second,
-			RetryMultiplier: 2.0,
+			MaxRetries:        3,
+			InitialRetryDelay: 2 * time.Second,
+			MaxRetryDelay:     30 * time.Second,
+			RetryMultiplier:   2.0,
 			ShouldRetry:       true,
 		},
 		ServerError: {
 			ErrorClass:        ServerError,
-			MaxRetries:       3,
-			InitialRetryDelay:    5 * time.Second,
-			MaxRetryDelay:        60 * time.Second,
-			RetryMultiplier: 2.0,
+			MaxRetries:        3,
+			InitialRetryDelay: 5 * time.Second,
+			MaxRetryDelay:     60 * time.Second,
+			RetryMultiplier:   2.0,
 			ShouldRetry:       true,
 		},
 		ClientError: {
 			ErrorClass:        ClientError,
-			MaxRetries:       1,
-			InitialRetryDelay:    0,
-			MaxRetryDelay:        0,
-			RetryMultiplier: 1.0,
+			MaxRetries:        1,
+			InitialRetryDelay: 0,
+			MaxRetryDelay:     0,
+			RetryMultiplier:   1.0,
 			ShouldRetry:       false,
 		},
 	}
@@ -199,8 +199,8 @@ type EnhancedRetryDecorator struct {
 // NewEnhancedRetryDecorator creates a new enhanced retry decorator.
 func NewEnhancedRetryDecorator(agent agenkit.Agent, config EnhancedRetryConfig) *EnhancedRetryDecorator {
 	return &EnhancedRetryDecorator{
-		agent:   agent,
-		config:  config,
+		agent:  agent,
+		config: config,
 		metrics: &EnhancedRetryMetrics{
 			ErrorClassCounts: make(map[ErrorClass]int64),
 			RecentResults:    make([]bool, 0, config.BackpressureWindow),
@@ -257,10 +257,10 @@ func (erd *EnhancedRetryDecorator) getStrategy(errorClass ErrorClass) ErrorStrat
 	// Default strategy
 	return ErrorStrategy{
 		ErrorClass:        errorClass,
-		MaxRetries:       erd.config.MaxRetries,
-		InitialRetryDelay:    erd.config.InitialRetryDelay,
-		MaxRetryDelay:        erd.config.MaxRetryDelay,
-		RetryMultiplier: erd.config.RetryMultiplier,
+		MaxRetries:        erd.config.MaxRetries,
+		InitialRetryDelay: erd.config.InitialRetryDelay,
+		MaxRetryDelay:     erd.config.MaxRetryDelay,
+		RetryMultiplier:   erd.config.RetryMultiplier,
 		ShouldRetry:       true,
 	}
 }
@@ -443,7 +443,7 @@ func (erd *EnhancedRetryDecorator) Process(ctx context.Context, message *agenkit
 			erd.metrics.mu.Lock()
 			erd.metrics.FailedAfterRetries++
 			erd.metrics.mu.Unlock()
-			return nil,fmt.Errorf("non-retryable error (%s): %w", errorClass, err)
+			return nil, fmt.Errorf("non-retryable error (%s): %w", errorClass, err)
 		}
 
 		// Check if exceeded max attempts for this error class
@@ -470,7 +470,7 @@ func (erd *EnhancedRetryDecorator) Process(ctx context.Context, message *agenkit
 		// Sleep with backoff
 		select {
 		case <-ctx.Done():
-			return nil,ctx.Err()
+			return nil, ctx.Err()
 		case <-time.After(backoff):
 		}
 	}
@@ -480,7 +480,7 @@ func (erd *EnhancedRetryDecorator) Process(ctx context.Context, message *agenkit
 	erd.metrics.FailedAfterRetries++
 	erd.metrics.mu.Unlock()
 
-	return nil,fmt.Errorf("max retry attempts (%d) exceeded for %s: %w", strategy.MaxRetries, errorClass, lastError)
+	return nil, fmt.Errorf("max retry attempts (%d) exceeded for %s: %w", strategy.MaxRetries, errorClass, lastError)
 }
 
 // Metrics returns current metrics.

--- a/agenkit-go/middleware/retry_test.go
+++ b/agenkit-go/middleware/retry_test.go
@@ -48,9 +48,9 @@ func TestRetrySuccess(t *testing.T) {
 	}
 
 	retry := NewRetryDecorator(agent, RetryConfig{
-		MaxRetries:       3,
-		InitialRetryDelay:    10 * time.Millisecond,
-		RetryMultiplier: 2.0,
+		MaxRetries:        3,
+		InitialRetryDelay: 10 * time.Millisecond,
+		RetryMultiplier:   2.0,
 	})
 
 	msg := agenkit.NewMessage("user", "test")
@@ -80,9 +80,9 @@ func TestRetryMaxRetriesExceeded(t *testing.T) {
 	}
 
 	retry := NewRetryDecorator(agent, RetryConfig{
-		MaxRetries:       3,
-		InitialRetryDelay:    10 * time.Millisecond,
-		RetryMultiplier: 2.0,
+		MaxRetries:        3,
+		InitialRetryDelay: 10 * time.Millisecond,
+		RetryMultiplier:   2.0,
 	})
 
 	msg := agenkit.NewMessage("user", "test")
@@ -142,9 +142,9 @@ func TestRetryContextCancellation(t *testing.T) {
 	}
 
 	retry := NewRetryDecorator(agent, RetryConfig{
-		MaxRetries:       5,
-		InitialRetryDelay:    50 * time.Millisecond,
-		RetryMultiplier: 2.0,
+		MaxRetries:        5,
+		InitialRetryDelay: 50 * time.Millisecond,
+		RetryMultiplier:   2.0,
 	})
 
 	// Cancel after first failure
@@ -184,9 +184,9 @@ func TestRetryExponentialBackoff(t *testing.T) {
 	start := time.Now()
 
 	retry := NewRetryDecorator(agent, RetryConfig{
-		MaxRetries:       3,
-		InitialRetryDelay:    100 * time.Millisecond,
-		RetryMultiplier: 2.0,
+		MaxRetries:        3,
+		InitialRetryDelay: 100 * time.Millisecond,
+		RetryMultiplier:   2.0,
 	})
 
 	msg := agenkit.NewMessage("user", "test")
@@ -219,10 +219,10 @@ func TestRetryMaxRetryDelay(t *testing.T) {
 	}
 
 	retry := NewRetryDecorator(agent, RetryConfig{
-		MaxRetries:       4,
-		InitialRetryDelay:    100 * time.Millisecond,
-		MaxRetryDelay:        150 * time.Millisecond, // Cap backoff at 150ms
-		RetryMultiplier: 3.0,                    // Would be 300ms without cap
+		MaxRetries:        4,
+		InitialRetryDelay: 100 * time.Millisecond,
+		MaxRetryDelay:     150 * time.Millisecond, // Cap backoff at 150ms
+		RetryMultiplier:   3.0,                    // Would be 300ms without cap
 	})
 
 	start := time.Now()
@@ -295,7 +295,7 @@ func TestRetryShouldRetryPredicate(t *testing.T) {
 	// Test retriable error
 	retriableAgent := &SelectiveFailingAgent{errorType: "retriable"}
 	retry := NewRetryDecorator(retriableAgent, RetryConfig{
-		MaxRetries:    3,
+		MaxRetries:        3,
 		InitialRetryDelay: 10 * time.Millisecond,
 		ShouldRetry: func(err error) bool {
 			_, ok := err.(*RetriableError)
@@ -317,7 +317,7 @@ func TestRetryShouldRetryPredicate(t *testing.T) {
 	// Test non-retriable error
 	nonRetriableAgent := &SelectiveFailingAgent{errorType: "non-retriable"}
 	retry2 := NewRetryDecorator(nonRetriableAgent, RetryConfig{
-		MaxRetries:    3,
+		MaxRetries:        3,
 		InitialRetryDelay: 10 * time.Millisecond,
 		ShouldRetry: func(err error) bool {
 			_, ok := err.(*RetriableError)

--- a/agenkit-go/property/agent_properties_test.go
+++ b/agenkit-go/property/agent_properties_test.go
@@ -20,7 +20,7 @@ type successAgent struct {
 	name string
 }
 
-func (a *successAgent) Name() string        { return a.name }
+func (a *successAgent) Name() string           { return a.name }
 func (a *successAgent) Capabilities() []string { return []string{"mock"} }
 func (a *successAgent) Introspect() *agenkit.IntrospectionResult {
 	return agenkit.DefaultIntrospectionResult(a)
@@ -31,11 +31,11 @@ func (a *successAgent) Process(ctx context.Context, msg *agenkit.Message) (*agen
 
 // errorAgent always returns an error.
 type errorAgent struct {
-	name    string
-	errMsg  string
+	name   string
+	errMsg string
 }
 
-func (a *errorAgent) Name() string        { return a.name }
+func (a *errorAgent) Name() string           { return a.name }
 func (a *errorAgent) Capabilities() []string { return []string{"mock"} }
 func (a *errorAgent) Introspect() *agenkit.IntrospectionResult {
 	return agenkit.DefaultIntrospectionResult(a)
@@ -50,7 +50,7 @@ type echoAgent struct {
 	prefix string
 }
 
-func (a *echoAgent) Name() string        { return a.name }
+func (a *echoAgent) Name() string           { return a.name }
 func (a *echoAgent) Capabilities() []string { return []string{"echo"} }
 func (a *echoAgent) Introspect() *agenkit.IntrospectionResult {
 	return agenkit.DefaultIntrospectionResult(a)
@@ -66,7 +66,7 @@ type countingAgent struct {
 	mu        sync.Mutex
 }
 
-func (a *countingAgent) Name() string        { return a.name }
+func (a *countingAgent) Name() string           { return a.name }
 func (a *countingAgent) Capabilities() []string { return []string{"counting"} }
 func (a *countingAgent) Introspect() *agenkit.IntrospectionResult {
 	return agenkit.DefaultIntrospectionResult(a)
@@ -155,7 +155,7 @@ func TestAgentRunWithCancelledContextReturnsError(t *testing.T) {
 // ctxAwareAgent respects context cancellation.
 type ctxAwareAgent struct{ name string }
 
-func (a *ctxAwareAgent) Name() string        { return a.name }
+func (a *ctxAwareAgent) Name() string           { return a.name }
 func (a *ctxAwareAgent) Capabilities() []string { return nil }
 func (a *ctxAwareAgent) Introspect() *agenkit.IntrospectionResult {
 	return agenkit.DefaultIntrospectionResult(a)

--- a/agenkit-go/property/message_properties_test.go
+++ b/agenkit-go/property/message_properties_test.go
@@ -331,7 +331,7 @@ type mockAgentForProp struct {
 	name string
 }
 
-func (a *mockAgentForProp) Name() string        { return a.name }
+func (a *mockAgentForProp) Name() string           { return a.name }
 func (a *mockAgentForProp) Capabilities() []string { return nil }
 func (a *mockAgentForProp) Introspect() *agenkit.IntrospectionResult {
 	return agenkit.DefaultIntrospectionResult(a)

--- a/agenkit-go/protocols/agui/adapter.go
+++ b/agenkit-go/protocols/agui/adapter.go
@@ -36,11 +36,11 @@ import (
 //	    sendToFrontend(json)
 //	}
 type AGUIAdapter struct {
-	agent              agenkit.Agent
-	agentName          string
-	emitHeartbeats     bool
-	heartbeatInterval  float64
-	heartbeatSequence  int64
+	agent             agenkit.Agent
+	agentName         string
+	emitHeartbeats    bool
+	heartbeatInterval float64
+	heartbeatSequence int64
 }
 
 // AGUIAdapterConfig holds configuration for AGUIAdapter

--- a/agenkit-go/protocols/agui/transports/http_test.go
+++ b/agenkit-go/protocols/agui/transports/http_test.go
@@ -60,11 +60,11 @@ func TestSSEFormatter_FormatEvent(t *testing.T) {
 	formatter := SSEFormatter{}
 
 	tests := []struct {
-		name              string
-		event             agui.AGUIEvent
-		includeEventName  bool
-		wantContains      []string
-		wantNotContains   []string
+		name             string
+		event            agui.AGUIEvent
+		includeEventName bool
+		wantContains     []string
+		wantNotContains  []string
 	}{
 		{
 			name:             "TextMessageChunk without event name",
@@ -179,12 +179,12 @@ func TestAGUISSEHandler_ServeHTTP_Success(t *testing.T) {
 	body := rr.Body.String()
 
 	expectedPatterns := []string{
-		"data:",                     // SSE format
-		"metadata",                  // MetadataEvent
-		"text_message_start",        // TextMessageStart
-		"text_message_chunk",        // TextMessageChunk
-		"text_message_complete",     // TextMessageComplete
-		"stream_complete",           // Completion comment
+		"data:",                 // SSE format
+		"metadata",              // MetadataEvent
+		"text_message_start",    // TextMessageStart
+		"text_message_chunk",    // TextMessageChunk
+		"text_message_complete", // TextMessageComplete
+		"stream_complete",       // Completion comment
 	}
 
 	for _, pattern := range expectedPatterns {

--- a/agenkit-go/skills/agent_test.go
+++ b/agenkit-go/skills/agent_test.go
@@ -26,7 +26,7 @@ func (e *echoAgent) Process(_ context.Context, msg *agenkit.Message) (*agenkit.M
 	return out, nil
 }
 
-func (e *echoAgent) Capabilities() []string               { return []string{} }
+func (e *echoAgent) Capabilities() []string { return []string{} }
 func (e *echoAgent) Introspect() *agenkit.IntrospectionResult {
 	return agenkit.DefaultIntrospectionResult(e)
 }

--- a/agenkit-go/techniques/reasoning/graph_of_thought_test.go
+++ b/agenkit-go/techniques/reasoning/graph_of_thought_test.go
@@ -202,10 +202,10 @@ func TestGenerateThoughts(t *testing.T) {
 // TestIdentifyConnections tests identifying logical connections between thoughts.
 func TestIdentifyConnections(t *testing.T) {
 	tests := []struct {
-		name       string
-		response   string
+		name         string
+		response     string
 		expectedEdge EdgeType
-		expectError bool
+		expectError  bool
 	}{
 		{
 			name:         "Support relationship",
@@ -272,9 +272,9 @@ func TestIdentifyConnections(t *testing.T) {
 func TestBuildGraph(t *testing.T) {
 	baseAgent := &mockGraphAgent{
 		responses: map[string]string{
-			"Premises": "1. Machine learning uses algorithms\n2. Algorithms process data",
-			"New thoughts": "- ML can predict outcomes\n- Data quality matters",
-			"relationship": "SUPPORT",
+			"Premises":         "1. Machine learning uses algorithms\n2. Algorithms process data",
+			"New thoughts":     "- ML can predict outcomes\n- Data quality matters",
+			"relationship":     "SUPPORT",
 			"Final conclusion": "Machine learning is powerful but requires good data",
 		},
 	}
@@ -378,9 +378,9 @@ func TestAggregatePaths(t *testing.T) {
 func TestProcess(t *testing.T) {
 	baseAgent := &mockGraphAgent{
 		responses: map[string]string{
-			"Premises": "1. Premise A\n2. Premise B",
-			"New thoughts": "- Thought 1\n- Thought 2",
-			"relationship": "SUPPORT",
+			"Premises":         "1. Premise A\n2. Premise B",
+			"New thoughts":     "- Thought 1\n- Thought 2",
+			"relationship":     "SUPPORT",
 			"Final conclusion": "This is the answer",
 		},
 	}
@@ -434,9 +434,9 @@ func TestProcess(t *testing.T) {
 func TestProcessWithCycleDetection(t *testing.T) {
 	baseAgent := &mockGraphAgent{
 		responses: map[string]string{
-			"Premises": "1. Start point",
-			"New thoughts": "- Step 1",
-			"relationship": "SUPPORT",
+			"Premises":         "1. Start point",
+			"New thoughts":     "- Step 1",
+			"relationship":     "SUPPORT",
 			"Final conclusion": "End point",
 		},
 	}

--- a/agenkit-go/techniques/reasoning/plan_and_solve.go
+++ b/agenkit-go/techniques/reasoning/plan_and_solve.go
@@ -48,10 +48,10 @@ type SolverFunc func(ctx context.Context, step *PlanStep, previousResults []stri
 
 // PlanAndSolveConfig configures the Plan-and-Solve agent
 type PlanAndSolveConfig struct {
-	Planner          PlannerFunc
-	Solver           SolverFunc
-	ValidatePlan     bool
-	AllowReplanning  bool
+	Planner         PlannerFunc
+	Solver          SolverFunc
+	ValidatePlan    bool
+	AllowReplanning bool
 }
 
 // PlanAndSolveAgent implements the Plan-and-Solve technique
@@ -312,13 +312,13 @@ Improved Plan:`, problem, plan.ValidationNotes)
 	}
 
 	metadata := map[string]interface{}{
-		"technique":         "plan_and_solve",
-		"plan_steps":        planSteps,
-		"execution_steps":   executionResults,
-		"num_steps":         len(plan.Steps),
-		"validated":         plan.Validated,
-		"validation_notes":  plan.ValidationNotes,
-		"allow_replanning":  a.allowReplanning,
+		"technique":        "plan_and_solve",
+		"plan_steps":       planSteps,
+		"execution_steps":  executionResults,
+		"num_steps":        len(plan.Steps),
+		"validated":        plan.Validated,
+		"validation_notes": plan.ValidationNotes,
+		"allow_replanning": a.allowReplanning,
 	}
 
 	return &agenkit.Message{

--- a/agenkit-go/techniques/reasoning/reasoning_graph.go
+++ b/agenkit-go/techniques/reasoning/reasoning_graph.go
@@ -403,12 +403,12 @@ func (g *ReasoningGraph) GetPathScore(path []int) float64 {
 
 // GraphStatistics contains statistics about the reasoning graph.
 type GraphStatistics struct {
-	NumNodes       int
-	NumEdges       int
-	NodeTypes      map[string]int
-	EdgeTypes      map[string]int
-	HasCycles      bool
-	AvgConfidence  float64
+	NumNodes      int
+	NumEdges      int
+	NodeTypes     map[string]int
+	EdgeTypes     map[string]int
+	HasCycles     bool
+	AvgConfidence float64
 }
 
 // Statistics returns statistics about the graph.

--- a/agenkit/adapters/llm/__init__.py
+++ b/agenkit/adapters/llm/__init__.py
@@ -105,6 +105,8 @@ try:
         VLLMConnector,
     )
 
-    __all__.extend(["VLLMConnector", "SGLangConnector", "TensorRTLLMConnector", "DeepSpeedConnector"])
+    __all__.extend(
+        ["VLLMConnector", "SGLangConnector", "TensorRTLLMConnector", "DeepSpeedConnector"]
+    )
 except ImportError:
     pass

--- a/agenkit/adapters/llm/openai.py
+++ b/agenkit/adapters/llm/openai.py
@@ -106,7 +106,6 @@ class OpenAILLM(LLM):
         """Return the model identifier."""
         return self._model
 
-
     async def complete(
         self,
         messages: list[Message],

--- a/agenkit/adapters/python/remote_agent.py
+++ b/agenkit/adapters/python/remote_agent.py
@@ -118,7 +118,8 @@ class RemoteAgent(Agent):
                 if hasattr(self._transport, "send_framed_envelope"):
                     # FAST PATH: Send dict directly (skip JSON encoding/decoding)
                     await asyncio.wait_for(
-                        self._transport.send_framed_envelope(request), timeout=self._timeout_ms / 1000.0
+                        self._transport.send_framed_envelope(request),
+                        timeout=self._timeout_ms / 1000.0,
                     )
                     response = await asyncio.wait_for(
                         self._transport.receive_framed_envelope(), timeout=self._timeout_ms / 1000.0
@@ -127,7 +128,8 @@ class RemoteAgent(Agent):
                     # SLOW PATH: Encode to JSON for backward compatibility
                     request_bytes = encode_bytes(request)
                     await asyncio.wait_for(
-                        self._transport.send_framed(request_bytes), timeout=self._timeout_ms / 1000.0
+                        self._transport.send_framed(request_bytes),
+                        timeout=self._timeout_ms / 1000.0,
                     )
 
                     response_bytes = await asyncio.wait_for(
@@ -190,14 +192,16 @@ class RemoteAgent(Agent):
                 if hasattr(self._transport, "send_framed_envelope"):
                     # FAST PATH: Send dict directly (skip JSON encoding/decoding)
                     await asyncio.wait_for(
-                        self._transport.send_framed_envelope(request), timeout=self._timeout_ms / 1000.0
+                        self._transport.send_framed_envelope(request),
+                        timeout=self._timeout_ms / 1000.0,
                     )
 
                     # Receive stream chunks
                     while True:
                         # Receive next frame (dict directly, no JSON decoding)
                         response = await asyncio.wait_for(
-                            self._transport.receive_framed_envelope(), timeout=self._timeout_ms / 1000.0
+                            self._transport.receive_framed_envelope(),
+                            timeout=self._timeout_ms / 1000.0,
                         )
 
                         # Handle response type
@@ -229,7 +233,8 @@ class RemoteAgent(Agent):
                     # SLOW PATH: Encode to JSON for backward compatibility
                     request_bytes = encode_bytes(request)
                     await asyncio.wait_for(
-                        self._transport.send_framed(request_bytes), timeout=self._timeout_ms / 1000.0
+                        self._transport.send_framed(request_bytes),
+                        timeout=self._timeout_ms / 1000.0,
                     )
 
                     # Receive stream chunks

--- a/agenkit/checkpointing/storage.py
+++ b/agenkit/checkpointing/storage.py
@@ -291,5 +291,7 @@ class LocalCheckpointStorage(CheckpointStorage):
 
 
 # Deprecated aliases — use new names in new code.
-InMemoryCheckpointStorage = MemoryCheckpointStorage  # Deprecated: Use MemoryCheckpointStorage instead.
+InMemoryCheckpointStorage = (
+    MemoryCheckpointStorage  # Deprecated: Use MemoryCheckpointStorage instead.
+)
 FileCheckpointStorage = LocalCheckpointStorage  # Deprecated: Use LocalCheckpointStorage instead.

--- a/agenkit/evaluation/recorder.py
+++ b/agenkit/evaluation/recorder.py
@@ -400,6 +400,7 @@ class SessionRecorder:
 FileRecordingStorage = LocalRecordingStorage  # Deprecated: Use LocalRecordingStorage instead.
 InMemoryRecordingStorage = MemoryRecordingStorage  # Deprecated: Use MemoryRecordingStorage instead.
 
+
 class SessionReplay:
     """
     Replay recorded sessions for analysis and A/B testing.

--- a/agenkit/infrastructure/health.py
+++ b/agenkit/infrastructure/health.py
@@ -404,33 +404,43 @@ class HealthChecker:
         for probe_type, count in self._metrics.total_checks.items():
             lines.append(f'agenkit_health_checks_total{{probe="{probe_type.value}"}} {count}')
 
-        lines.extend([
-            "",
-            "# HELP agenkit_health_check_failures_total Total number of failed health checks",
-            "# TYPE agenkit_health_check_failures_total counter",
-        ])
+        lines.extend(
+            [
+                "",
+                "# HELP agenkit_health_check_failures_total Total number of failed health checks",
+                "# TYPE agenkit_health_check_failures_total counter",
+            ]
+        )
 
         for probe_type, count in self._metrics.failed_checks.items():
-            lines.append(f'agenkit_health_check_failures_total{{probe="{probe_type.value}"}} {count}')
+            lines.append(
+                f'agenkit_health_check_failures_total{{probe="{probe_type.value}"}} {count}'
+            )
 
-        lines.extend([
-            "",
-            "# HELP agenkit_health_check_duration_ms Duration of last health check in milliseconds",
-            "# TYPE agenkit_health_check_duration_ms gauge",
-        ])
+        lines.extend(
+            [
+                "",
+                "# HELP agenkit_health_check_duration_ms Duration of last health check in milliseconds",
+                "# TYPE agenkit_health_check_duration_ms gauge",
+            ]
+        )
 
         for probe_type, duration in self._metrics.last_check_duration.items():
-            lines.append(f'agenkit_health_check_duration_ms{{probe="{probe_type.value}"}} {duration}')
+            lines.append(
+                f'agenkit_health_check_duration_ms{{probe="{probe_type.value}"}} {duration}'
+            )
 
-        lines.extend([
-            "",
-            "# HELP agenkit_agent_uptime_seconds Uptime in seconds",
-            "# TYPE agenkit_agent_uptime_seconds gauge",
-            f"agenkit_agent_uptime_seconds {self._metrics.get_uptime()}",
-            "",
-            "# HELP agenkit_agent_healthy Agent health status (1=healthy, 0=unhealthy)",
-            "# TYPE agenkit_agent_healthy gauge",
-            f"agenkit_agent_healthy {1 if self.is_healthy else 0}",
-        ])
+        lines.extend(
+            [
+                "",
+                "# HELP agenkit_agent_uptime_seconds Uptime in seconds",
+                "# TYPE agenkit_agent_uptime_seconds gauge",
+                f"agenkit_agent_uptime_seconds {self._metrics.get_uptime()}",
+                "",
+                "# HELP agenkit_agent_healthy Agent health status (1=healthy, 0=unhealthy)",
+                "# TYPE agenkit_agent_healthy gauge",
+                f"agenkit_agent_healthy {1 if self.is_healthy else 0}",
+            ]
+        )
 
         return "\n".join(lines) + "\n"

--- a/agenkit/infrastructure/load_balancer.py
+++ b/agenkit/infrastructure/load_balancer.py
@@ -118,7 +118,9 @@ class LoadBalancer(Agent):
         if weights is None:
             weights = [1] * len(agents)
         elif len(weights) != len(agents):
-            raise ValueError(f"Weights length ({len(weights)}) must match agents length ({len(agents)})")
+            raise ValueError(
+                f"Weights length ({len(weights)}) must match agents length ({len(agents)})"
+            )
 
         self._backends = [
             AgentBackend(agent=agent, weight=weight)
@@ -311,7 +313,9 @@ class LoadBalancer(Agent):
 
             # Avoid retrying same backend
             if backend.agent.name in attempted_backends:
-                if not self._config.enable_failover or len(attempted_backends) >= len(self._backends):
+                if not self._config.enable_failover or len(attempted_backends) >= len(
+                    self._backends
+                ):
                     raise Exception(f"All backends attempted: {attempted_backends}")
 
                 # Try next backend

--- a/agenkit/infrastructure/retry_enhanced.py
+++ b/agenkit/infrastructure/retry_enhanced.py
@@ -423,4 +423,6 @@ class EnhancedRetryDecorator(Agent):
                 f"Max retry attempts ({strategy.max_retries}) exceeded for {error_class.value}: {last_error}"
             ) from last_error
 
-        raise Exception(f"Max retry attempts ({self._config.max_retries}) exceeded: {last_error}") from last_error
+        raise Exception(
+            f"Max retry attempts ({self._config.max_retries}) exceeded: {last_error}"
+        ) from last_error

--- a/agenkit/middleware/caching.py
+++ b/agenkit/middleware/caching.py
@@ -55,7 +55,9 @@ class AsyncRWLock:
                         self._readers -= 1
                     if self._readers == 0:
                         self._write_ok.notify()
-            except Exception:  # noqa: BLE001 — last-ditch cleanup during CancelledError, all exceptions must be suppressed
+            except (
+                Exception
+            ):  # noqa: BLE001 — last-ditch cleanup during CancelledError, all exceptions must be suppressed
                 pass
             raise
 
@@ -86,7 +88,9 @@ class AsyncRWLock:
                     self._writer = False
                     self._read_ok.notify_all()
                     self._write_ok.notify()
-            except Exception:  # noqa: BLE001 — last-ditch cleanup during CancelledError, all exceptions must be suppressed
+            except (
+                Exception
+            ):  # noqa: BLE001 — last-ditch cleanup during CancelledError, all exceptions must be suppressed
                 pass
             raise
 

--- a/agenkit/middleware/circuit_breaker.py
+++ b/agenkit/middleware/circuit_breaker.py
@@ -207,9 +207,7 @@ class CircuitBreakerDecorator(Agent):
         # Attempt request with timeout
         try:
             timeout_seconds = self._config.timeout_ms / 1000.0
-            result = await asyncio.wait_for(
-                self._agent.process(message), timeout=timeout_seconds
-            )
+            result = await asyncio.wait_for(self._agent.process(message), timeout=timeout_seconds)
 
             async with self._lock:
                 await self._on_success()

--- a/agenkit/middleware/rate_limiter.py
+++ b/agenkit/middleware/rate_limiter.py
@@ -18,7 +18,9 @@ class RateLimiterConfig:
     rate: float = 10.0  # Tokens per second
     capacity: int = 10  # Maximum burst capacity
     tokens_per_request: int = 1  # Tokens consumed per request
-    max_wait_ms: int | None = None  # Maximum milliseconds to wait for tokens (None = wait indefinitely)
+    max_wait_ms: int | None = (
+        None  # Maximum milliseconds to wait for tokens (None = wait indefinitely)
+    )
 
     def __post_init__(self):
         """Validate configuration."""

--- a/agenkit/protocols/agui/events.py
+++ b/agenkit/protocols/agui/events.py
@@ -99,9 +99,7 @@ class RunFinishedEvent(BaseEvent):
     type: Literal[EventType.RUN_FINISHED] = EventType.RUN_FINISHED
     thread_id: str = Field(description="Thread identifier")
     run_id: str = Field(description="Run identifier")
-    result: Optional[dict[str, Any]] = Field(
-        default=None, description="Final result of the run"
-    )
+    result: Optional[dict[str, Any]] = Field(default=None, description="Final result of the run")
 
 
 class RunErrorEvent(BaseEvent):
@@ -118,9 +116,7 @@ class StepStartedEvent(BaseEvent):
 
     type: Literal[EventType.STEP_STARTED] = EventType.STEP_STARTED
     step_name: str = Field(description="Name of the processing step")
-    metadata: Optional[dict[str, Any]] = Field(
-        default=None, description="Additional step metadata"
-    )
+    metadata: Optional[dict[str, Any]] = Field(default=None, description="Additional step metadata")
 
 
 class StepFinishedEvent(BaseEvent):
@@ -142,9 +138,7 @@ class TextMessageStartEvent(BaseEvent):
     type: Literal[EventType.TEXT_MESSAGE_START] = EventType.TEXT_MESSAGE_START
     message_id: str = Field(description="Unique message identifier")
     role: str = Field(description="Message role (assistant, user, system)")
-    metadata: Optional[dict[str, Any]] = Field(
-        default=None, description="Message metadata"
-    )
+    metadata: Optional[dict[str, Any]] = Field(default=None, description="Message metadata")
 
 
 class TextMessageContentEvent(BaseEvent):
@@ -160,9 +154,7 @@ class TextMessageEndEvent(BaseEvent):
 
     type: Literal[EventType.TEXT_MESSAGE_END] = EventType.TEXT_MESSAGE_END
     message_id: str = Field(description="Message identifier")
-    metadata: Optional[dict[str, Any]] = Field(
-        default=None, description="Final message metadata"
-    )
+    metadata: Optional[dict[str, Any]] = Field(default=None, description="Final message metadata")
 
 
 class TextMessageChunkEvent(BaseEvent):
@@ -193,9 +185,7 @@ class ToolCallStartEvent(BaseEvent):
     type: Literal[EventType.TOOL_CALL_START] = EventType.TOOL_CALL_START
     tool_call_id: str = Field(description="Unique tool call identifier")
     tool_call_name: str = Field(description="Name of the tool being called")
-    parent_message_id: Optional[str] = Field(
-        default=None, description="Parent message ID"
-    )
+    parent_message_id: Optional[str] = Field(default=None, description="Parent message ID")
 
 
 class ToolCallArgsEvent(BaseEvent):
@@ -218,12 +208,8 @@ class ToolCallProgressEvent(BaseEvent):
 
     type: Literal[EventType.TOOL_CALL_PROGRESS] = EventType.TOOL_CALL_PROGRESS
     tool_call_id: str = Field(description="Tool call identifier")
-    progress: float = Field(
-        description="Progress percentage (0.0 to 1.0)", ge=0.0, le=1.0
-    )
-    status: Optional[str] = Field(
-        default=None, description="Human-readable status message"
-    )
+    progress: float = Field(description="Progress percentage (0.0 to 1.0)", ge=0.0, le=1.0)
+    status: Optional[str] = Field(default=None, description="Human-readable status message")
     metadata: Optional[dict[str, Any]] = Field(
         default=None, description="Additional progress metadata"
     )
@@ -244,9 +230,7 @@ class ToolCallChunkEvent(BaseEvent):
 
     type: Literal[EventType.TOOL_CALL_CHUNK] = EventType.TOOL_CALL_CHUNK
     tool_call_id: str = Field(description="Tool call identifier")
-    tool_call_name: Optional[str] = Field(
-        default=None, description="Tool name (for first chunk)"
-    )
+    tool_call_name: Optional[str] = Field(default=None, description="Tool name (for first chunk)")
     delta: Optional[str] = Field(default=None, description="Argument delta")
     is_first: bool = Field(default=False, description="Whether this is the first chunk")
     is_last: bool = Field(default=False, description="Whether this is the last chunk")

--- a/agenkit/protocols/agui/multimodal.py
+++ b/agenkit/protocols/agui/multimodal.py
@@ -170,7 +170,9 @@ def image_file(path: str | Path) -> ImageBase64ContentPart:
     return ImageBase64ContentPart(image_base64=image_data, mime_type=mime_type)
 
 
-def file_url(url: str, filename: Optional[str] = None, mime_type: Optional[str] = None) -> FileURLContentPart:
+def file_url(
+    url: str, filename: Optional[str] = None, mime_type: Optional[str] = None
+) -> FileURLContentPart:
     """Create a file URL content part.
 
     Args:

--- a/agenkit/protocols/agui/state.py
+++ b/agenkit/protocols/agui/state.py
@@ -112,9 +112,7 @@ class StateManager:
         if old_value is None:
             self._pending_operations.append({"op": "add", "path": path, "value": value})
         else:
-            self._pending_operations.append(
-                {"op": "replace", "path": path, "value": value}
-            )
+            self._pending_operations.append({"op": "replace", "path": path, "value": value})
 
     def remove(self, path: str) -> None:
         """Remove a value at a path.

--- a/agenkit/protocols/mcp/client.py
+++ b/agenkit/protocols/mcp/client.py
@@ -86,9 +86,7 @@ class StdioClient(MCPClient):
 
         resp = await self._send("initialize", _INIT_PARAMS)
         if resp.error:
-            raise RuntimeError(
-                f"mcp initialize error {resp.error.code}: {resp.error.message}"
-            )
+            raise RuntimeError(f"mcp initialize error {resp.error.code}: {resp.error.message}")
         result = resp.result or {}
         info = result.get("serverInfo", {})
         self._server_info = MCPServerInfo(
@@ -99,9 +97,7 @@ class StdioClient(MCPClient):
     async def list_tools(self) -> list[MCPTool]:
         resp = await self._send("tools/list", None)
         if resp.error:
-            raise RuntimeError(
-                f"mcp tools/list error {resp.error.code}: {resp.error.message}"
-            )
+            raise RuntimeError(f"mcp tools/list error {resp.error.code}: {resp.error.message}")
         result = resp.result or {}
         return [
             MCPTool(
@@ -115,9 +111,7 @@ class StdioClient(MCPClient):
     async def call_tool(self, name: str, args: dict[str, Any]) -> MCPToolResult:
         resp = await self._send("tools/call", {"name": name, "arguments": args})
         if resp.error:
-            raise RuntimeError(
-                f"mcp tools/call error {resp.error.code}: {resp.error.message}"
-            )
+            raise RuntimeError(f"mcp tools/call error {resp.error.code}: {resp.error.message}")
         result = resp.result or {}
         return _parse_tool_result(result)
 
@@ -136,9 +130,7 @@ class StdioClient(MCPClient):
 
     # ── Internal ──────────────────────────────────────────────────────────────
 
-    async def _send(
-        self, method: str, params: dict[str, Any] | None
-    ) -> _JSONRPCResponse:
+    async def _send(self, method: str, params: dict[str, Any] | None) -> _JSONRPCResponse:
         async with self._lock:
             self._next_id += 1
             req = _JSONRPCRequest(
@@ -181,9 +173,7 @@ class HTTPClient(MCPClient):
         self._http = httpx.AsyncClient(timeout=self._timeout)
         resp = await self._send("initialize", _INIT_PARAMS)
         if resp.error:
-            raise RuntimeError(
-                f"mcp initialize error {resp.error.code}: {resp.error.message}"
-            )
+            raise RuntimeError(f"mcp initialize error {resp.error.code}: {resp.error.message}")
         result = resp.result or {}
         info = result.get("serverInfo", {})
         self._server_info = MCPServerInfo(
@@ -194,9 +184,7 @@ class HTTPClient(MCPClient):
     async def list_tools(self) -> list[MCPTool]:
         resp = await self._send("tools/list", None)
         if resp.error:
-            raise RuntimeError(
-                f"mcp tools/list error {resp.error.code}: {resp.error.message}"
-            )
+            raise RuntimeError(f"mcp tools/list error {resp.error.code}: {resp.error.message}")
         result = resp.result or {}
         return [
             MCPTool(
@@ -210,9 +198,7 @@ class HTTPClient(MCPClient):
     async def call_tool(self, name: str, args: dict[str, Any]) -> MCPToolResult:
         resp = await self._send("tools/call", {"name": name, "arguments": args})
         if resp.error:
-            raise RuntimeError(
-                f"mcp tools/call error {resp.error.code}: {resp.error.message}"
-            )
+            raise RuntimeError(f"mcp tools/call error {resp.error.code}: {resp.error.message}")
         result = resp.result or {}
         return _parse_tool_result(result)
 
@@ -226,9 +212,7 @@ class HTTPClient(MCPClient):
 
     # ── Internal ──────────────────────────────────────────────────────────────
 
-    async def _send(
-        self, method: str, params: dict[str, Any] | None
-    ) -> _JSONRPCResponse:
+    async def _send(self, method: str, params: dict[str, Any] | None) -> _JSONRPCResponse:
         self._next_id += 1
         req = _JSONRPCRequest(
             jsonrpc="2.0",

--- a/agenkit/protocols/mcp/server.py
+++ b/agenkit/protocols/mcp/server.py
@@ -71,9 +71,7 @@ class MCPServer:
         finally:
             writer.close()
 
-    async def handle_request(
-        self, req: _JSONRPCRequest
-    ) -> _JSONRPCResponse:
+    async def handle_request(self, req: _JSONRPCRequest) -> _JSONRPCResponse:
         """Dispatch one JSON-RPC request and return the response.
 
         This method is public for direct use in tests without needing
@@ -98,9 +96,7 @@ class MCPServer:
 
     # ── Private helpers ───────────────────────────────────────────────────────
 
-    async def _handle_line(
-        self, raw: bytes, writer: asyncio.StreamWriter
-    ) -> None:
+    async def _handle_line(self, raw: bytes, writer: asyncio.StreamWriter) -> None:
         try:
             data = json.loads(raw)
             req = _JSONRPCRequest(
@@ -121,9 +117,7 @@ class MCPServer:
         resp = await self.handle_request(req)
         self._write_response(resp, writer)
 
-    def _write_response(
-        self, resp: _JSONRPCResponse, writer: asyncio.StreamWriter
-    ) -> None:
+    def _write_response(self, resp: _JSONRPCResponse, writer: asyncio.StreamWriter) -> None:
         d: dict[str, Any] = {"jsonrpc": resp.jsonrpc, "id": resp.id}
         if resp.error is not None:
             d["error"] = {"code": resp.error.code, "message": resp.error.message}
@@ -140,21 +134,11 @@ class MCPServer:
         return _JSONRPCResponse(jsonrpc="2.0", id=req.id, result=result)
 
     def _handle_tools_list(self, req: _JSONRPCRequest) -> _JSONRPCResponse:
-        tools = [
-            MCPTool(name=t.name, description=t.description)
-            for t in self._tools.values()
-        ]
-        result = {
-            "tools": [
-                {"name": t.name, "description": t.description}
-                for t in tools
-            ]
-        }
+        tools = [MCPTool(name=t.name, description=t.description) for t in self._tools.values()]
+        result = {"tools": [{"name": t.name, "description": t.description} for t in tools]}
         return _JSONRPCResponse(jsonrpc="2.0", id=req.id, result=result)
 
-    async def _handle_tools_call(
-        self, req: _JSONRPCRequest
-    ) -> _JSONRPCResponse:
+    async def _handle_tools_call(self, req: _JSONRPCRequest) -> _JSONRPCResponse:
         params = req.params or {}
         name = params.get("name", "")
         args: dict[str, Any] = params.get("arguments", {})
@@ -164,9 +148,7 @@ class MCPServer:
             return _JSONRPCResponse(
                 jsonrpc="2.0",
                 id=req.id,
-                error=_JSONRPCError(
-                    code=-32602, message=f"unknown tool: {name}"
-                ),
+                error=_JSONRPCError(code=-32602, message=f"unknown tool: {name}"),
             )
 
         try:
@@ -187,9 +169,7 @@ class MCPServer:
         return _make_tool_call_response(req.id, mcp_result)
 
 
-def _make_tool_call_response(
-    req_id: int, result: MCPToolResult
-) -> _JSONRPCResponse:
+def _make_tool_call_response(req_id: int, result: MCPToolResult) -> _JSONRPCResponse:
     return _JSONRPCResponse(
         jsonrpc="2.0",
         id=req_id,

--- a/agenkit/protocols/mcp/types.py
+++ b/agenkit/protocols/mcp/types.py
@@ -117,9 +117,7 @@ class MCPClient(ABC):
         """Return the tools advertised by the server."""
 
     @abstractmethod
-    async def call_tool(
-        self, name: str, args: dict[str, Any]
-    ) -> MCPToolResult:
+    async def call_tool(self, name: str, args: dict[str, Any]) -> MCPToolResult:
         """Invoke a named tool with the given arguments."""
 
     @property

--- a/agenkit/skills/agent.py
+++ b/agenkit/skills/agent.py
@@ -65,9 +65,7 @@ class SkillEnabledAgent(Agent):
         will include ``active_skills``.
         """
         query = str(message.content) if message.content is not None else ""
-        relevant = self._registry.find_relevant_skills(
-            query, max_results=self._max_active_skills
-        )
+        relevant = self._registry.find_relevant_skills(query, max_results=self._max_active_skills)
 
         if relevant:
             skill_blocks = "\n\n".join(skill.to_prompt() for skill in relevant)

--- a/agenkit/skills/loader.py
+++ b/agenkit/skills/loader.py
@@ -66,9 +66,7 @@ class AgentSkill:
         # Split on "---" delimiters. File must start with "---".
         parts = raw.split("---", 2)
         if len(parts) < 3:
-            raise ValueError(
-                f"Invalid SKILL.md in {skill_dir}: missing frontmatter delimiters"
-            )
+            raise ValueError(f"Invalid SKILL.md in {skill_dir}: missing frontmatter delimiters")
 
         frontmatter_text = parts[1].strip()
         instructions = parts[2].strip()
@@ -76,26 +74,18 @@ class AgentSkill:
         try:
             fm = yaml.safe_load(frontmatter_text)
         except yaml.YAMLError as exc:
-            raise ValueError(
-                f"Invalid YAML frontmatter in {skill_dir}/SKILL.md: {exc}"
-            ) from exc
+            raise ValueError(f"Invalid YAML frontmatter in {skill_dir}/SKILL.md: {exc}") from exc
 
         if not isinstance(fm, dict):
-            raise ValueError(
-                f"Invalid frontmatter in {skill_dir}/SKILL.md: expected YAML mapping"
-            )
+            raise ValueError(f"Invalid frontmatter in {skill_dir}/SKILL.md: expected YAML mapping")
 
         name = fm.get("name")
         if not name:
-            raise ValueError(
-                f"Missing required field 'name' in {skill_dir}/SKILL.md"
-            )
+            raise ValueError(f"Missing required field 'name' in {skill_dir}/SKILL.md")
 
         description = fm.get("description")
         if not description:
-            raise ValueError(
-                f"Missing required field 'description' in {skill_dir}/SKILL.md"
-            )
+            raise ValueError(f"Missing required field 'description' in {skill_dir}/SKILL.md")
 
         return cls(
             name=str(name),
@@ -154,9 +144,7 @@ class SkillRegistry:
                 except ValueError as exc:
                     logger.warning("skipping skill directory %s: %s", entry, exc)
 
-    def find_relevant_skills(
-        self, query: str, max_results: int = 5
-    ) -> list[AgentSkill]:
+    def find_relevant_skills(self, query: str, max_results: int = 5) -> list[AgentSkill]:
         """
         Return skills most relevant to the given query string.
 

--- a/tests/adapters/llm/test_validation.py
+++ b/tests/adapters/llm/test_validation.py
@@ -102,12 +102,16 @@ class TestBaseLLMValidation:
 
     def test_presence_penalty_validation_too_low(self, llm):
         """Test that presence_penalty below -2 raises ValueError."""
-        with pytest.raises(ValueError, match=r"presence_penalty must be between -2 and 2, got -2\.5"):
+        with pytest.raises(
+            ValueError, match=r"presence_penalty must be between -2 and 2, got -2\.5"
+        ):
             llm._validate_llm_params(temperature=1.0, max_tokens=None, presence_penalty=-2.5)
 
     def test_presence_penalty_validation_too_high(self, llm):
         """Test that presence_penalty above 2 raises ValueError."""
-        with pytest.raises(ValueError, match=r"presence_penalty must be between -2 and 2, got 2\.5"):
+        with pytest.raises(
+            ValueError, match=r"presence_penalty must be between -2 and 2, got 2\.5"
+        ):
             llm._validate_llm_params(temperature=1.0, max_tokens=None, presence_penalty=2.5)
 
     def test_presence_penalty_validation_valid_range(self, llm):
@@ -148,6 +152,7 @@ class TestAdapterValidationIntegration:
     @pytest.mark.asyncio
     async def test_openai_complete_validates_temperature(self, openai_llm, monkeypatch):
         """Test that complete() validates temperature before calling API."""
+
         # Mock the API call to fail if it's reached
         def mock_create(*args, **kwargs):
             pytest.fail("API should not be called when validation fails")
@@ -163,6 +168,7 @@ class TestAdapterValidationIntegration:
     @pytest.mark.asyncio
     async def test_openai_complete_validates_max_tokens(self, openai_llm, monkeypatch):
         """Test that complete() validates max_tokens before calling API."""
+
         def mock_create(*args, **kwargs):
             pytest.fail("API should not be called when validation fails")
 
@@ -177,6 +183,7 @@ class TestAdapterValidationIntegration:
     @pytest.mark.asyncio
     async def test_openai_stream_validates_temperature(self, openai_llm, monkeypatch):
         """Test that stream() validates temperature before calling API."""
+
         def mock_create(*args, **kwargs):
             pytest.fail("API should not be called when validation fails")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,7 +63,8 @@ def cleanup_async_resources():
         loop = asyncio.get_event_loop()
         if not loop.is_closed():
             tasks = [
-                t for t in asyncio.all_tasks(loop)
+                t
+                for t in asyncio.all_tasks(loop)
                 if not t.done() and t != asyncio.current_task(loop)
             ]
             for task in tasks:

--- a/tests/cross_language/test_api_consistency.py
+++ b/tests/cross_language/test_api_consistency.py
@@ -32,7 +32,8 @@ class TestParameterNaming:
     def test_retry_parameter_names(self):
         """Verify RetryDecorator uses consistent parameter names."""
         test_case = next(
-            tc for tc in API_FIXTURES["test_categories"]["parameter_naming"]["test_cases"]
+            tc
+            for tc in API_FIXTURES["test_categories"]["parameter_naming"]["test_cases"]
             if tc["id"] == "retry_parameter_names"
         )
 
@@ -45,8 +46,7 @@ class TestParameterNaming:
 
         # Check max_retries
         expected_name = params["max_retries"]["expected_names"]["python"]
-        assert expected_name in param_names, \
-            f"RetryConfig should have parameter '{expected_name}'"
+        assert expected_name in param_names, f"RetryConfig should have parameter '{expected_name}'"
 
         # NOTE: We allow deprecated parameters during the transition period (v0.50.0)
         # These will be removed in v0.51.0
@@ -54,13 +54,11 @@ class TestParameterNaming:
 
         # Check initial_delay
         expected_name = params["initial_delay"]["expected_names"]["python"]
-        assert expected_name in param_names, \
-            f"RetryConfig should have parameter '{expected_name}'"
+        assert expected_name in param_names, f"RetryConfig should have parameter '{expected_name}'"
 
         # Check max_delay
         expected_name = params["max_delay"]["expected_names"]["python"]
-        assert expected_name in param_names, \
-            f"RetryConfig should have parameter '{expected_name}'"
+        assert expected_name in param_names, f"RetryConfig should have parameter '{expected_name}'"
 
     def test_retry_parameter_transition(self):
         """Verify new parameter names exist (deprecated names removed in v0.51.0)."""
@@ -77,12 +75,15 @@ class TestParameterNaming:
         assert "max_attempts" not in param_names, "Deprecated max_attempts should be removed"
         assert "initial_backoff" not in param_names, "Deprecated initial_backoff should be removed"
         assert "max_backoff" not in param_names, "Deprecated max_backoff should be removed"
-        assert "backoff_multiplier" not in param_names, "Deprecated backoff_multiplier should be removed"
+        assert (
+            "backoff_multiplier" not in param_names
+        ), "Deprecated backoff_multiplier should be removed"
 
     def test_timeout_parameter_names(self):
         """Verify TimeoutMiddleware parameter names clearly indicate units."""
         test_case = next(
-            tc for tc in API_FIXTURES["test_categories"]["parameter_naming"]["test_cases"]
+            tc
+            for tc in API_FIXTURES["test_categories"]["parameter_naming"]["test_cases"]
             if tc["id"] == "timeout_parameter_names"
         )
 
@@ -93,8 +94,7 @@ class TestParameterNaming:
         # Python should use timeout_ms or timeout (with timedelta support)
         # Check that at least one timeout-related parameter exists
         timeout_params = [p for p in param_names if "timeout" in p.lower()]
-        assert len(timeout_params) > 0, \
-            "TimeoutConfig should have timeout-related parameters"
+        assert len(timeout_params) > 0, "TimeoutConfig should have timeout-related parameters"
 
         # If using primitive (not timedelta), should indicate unit
         # This is a soft check - we're validating the pattern exists
@@ -109,7 +109,8 @@ class TestDefaultValues:
     def test_timeout_defaults(self):
         """Verify TimeoutMiddleware default timeout is 30 seconds."""
         test_case = next(
-            tc for tc in API_FIXTURES["test_categories"]["default_values"]["test_cases"]
+            tc
+            for tc in API_FIXTURES["test_categories"]["default_values"]["test_cases"]
             if tc["id"] == "timeout_defaults"
         )
 
@@ -120,21 +121,23 @@ class TestDefaultValues:
 
         # Convert to milliseconds for comparison
         # Python uses float seconds by default
-        if hasattr(config, 'timeout_ms'):
+        if hasattr(config, "timeout_ms"):
             actual_ms = config.timeout_ms
-        elif hasattr(config, 'timeout'):
+        elif hasattr(config, "timeout"):
             # Assuming timeout is in seconds
             actual_ms = config.timeout * 1000
         else:
             pytest.fail("TimeoutConfig has no recognizable timeout attribute")
 
-        assert actual_ms == expected_ms, \
-            f"TimeoutConfig default should be {expected_ms}ms (30 seconds), got {actual_ms}ms"
+        assert (
+            actual_ms == expected_ms
+        ), f"TimeoutConfig default should be {expected_ms}ms (30 seconds), got {actual_ms}ms"
 
     def test_retry_defaults(self):
         """Verify RetryMiddleware default configuration values."""
         test_case = next(
-            tc for tc in API_FIXTURES["test_categories"]["default_values"]["test_cases"]
+            tc
+            for tc in API_FIXTURES["test_categories"]["default_values"]["test_cases"]
             if tc["id"] == "retry_defaults"
         )
 
@@ -143,47 +146,46 @@ class TestDefaultValues:
 
         # Check max_retries
         expected_max_retries = defaults["max_retries"]["value"]
-        assert config.max_retries == expected_max_retries, \
-            f"max_retries default should be {expected_max_retries}"
+        assert (
+            config.max_retries == expected_max_retries
+        ), f"max_retries default should be {expected_max_retries}"
 
         # Check initial_delay (convert to ms)
         expected_initial_delay_ms = defaults["initial_delay"]["value_ms"]
-        if hasattr(config, 'initial_delay_ms'):
+        if hasattr(config, "initial_delay_ms"):
             actual_delay_ms = config.initial_delay_ms
-        elif hasattr(config, 'initial_delay'):
+        elif hasattr(config, "initial_delay"):
             actual_delay_ms = config.initial_delay * 1000
         else:
             pytest.fail("RetryConfig has no recognizable initial_delay attribute")
 
-        assert actual_delay_ms == expected_initial_delay_ms, \
-            f"initial_delay default should be {expected_initial_delay_ms}ms"
+        assert (
+            actual_delay_ms == expected_initial_delay_ms
+        ), f"initial_delay default should be {expected_initial_delay_ms}ms"
 
         # Check max_delay (convert to ms)
         expected_max_delay_ms = defaults["max_delay"]["value_ms"]
-        if hasattr(config, 'max_delay_ms'):
+        if hasattr(config, "max_delay_ms"):
             actual_max_delay_ms = config.max_delay_ms
-        elif hasattr(config, 'max_delay'):
+        elif hasattr(config, "max_delay"):
             actual_max_delay_ms = config.max_delay * 1000
         else:
             pytest.fail("RetryConfig has no recognizable max_delay attribute")
 
-        assert actual_max_delay_ms == expected_max_delay_ms, \
-            f"max_delay default should be {expected_max_delay_ms}ms"
+        assert (
+            actual_max_delay_ms == expected_max_delay_ms
+        ), f"max_delay default should be {expected_max_delay_ms}ms"
 
         # Check multiplier
         expected_multiplier = defaults["multiplier"]["value"]
-        assert config.multiplier == expected_multiplier, \
-            f"multiplier default should be {expected_multiplier}"
+        assert (
+            config.multiplier == expected_multiplier
+        ), f"multiplier default should be {expected_multiplier}"
 
     def test_retry_using_new_parameter_names(self):
         """Verify RetryConfig works correctly when using new parameter names."""
         # Use new parameter names explicitly
-        config = RetryConfig(
-            max_retries=5,
-            initial_delay=0.5,
-            max_delay=20.0,
-            multiplier=3.0
-        )
+        config = RetryConfig(max_retries=5, initial_delay=0.5, max_delay=20.0, multiplier=3.0)
 
         assert config.max_retries == 5, "max_retries should be set correctly"
         assert config.initial_delay == 0.5, "initial_delay should be set correctly"
@@ -197,7 +199,8 @@ class TestDefaultValues:
     def test_rate_limiter_defaults(self):
         """Verify RateLimiterMiddleware default configuration values."""
         test_case = next(
-            tc for tc in API_FIXTURES["test_categories"]["default_values"]["test_cases"]
+            tc
+            for tc in API_FIXTURES["test_categories"]["default_values"]["test_cases"]
             if tc["id"] == "rate_limiter_defaults"
         )
 
@@ -206,18 +209,21 @@ class TestDefaultValues:
 
         # Check rate
         expected_rate = defaults["rate"]["value"]
-        assert config.rate == expected_rate, \
-            f"rate default should be {expected_rate} requests/second"
+        assert (
+            config.rate == expected_rate
+        ), f"rate default should be {expected_rate} requests/second"
 
         # Check capacity
         expected_capacity = defaults["capacity"]["value"]
-        assert config.capacity == expected_capacity, \
-            f"capacity default should be {expected_capacity}"
+        assert (
+            config.capacity == expected_capacity
+        ), f"capacity default should be {expected_capacity}"
 
     def test_circuit_breaker_defaults(self):
         """Verify CircuitBreakerMiddleware default configuration values."""
         test_case = next(
-            tc for tc in API_FIXTURES["test_categories"]["default_values"]["test_cases"]
+            tc
+            for tc in API_FIXTURES["test_categories"]["default_values"]["test_cases"]
             if tc["id"] == "circuit_breaker_defaults"
         )
 
@@ -226,37 +232,41 @@ class TestDefaultValues:
 
         # Check failure_threshold
         expected_failure_threshold = defaults["failure_threshold"]["value"]
-        assert config.failure_threshold == expected_failure_threshold, \
-            f"failure_threshold default should be {expected_failure_threshold}"
+        assert (
+            config.failure_threshold == expected_failure_threshold
+        ), f"failure_threshold default should be {expected_failure_threshold}"
 
         # Check success_threshold
         expected_success_threshold = defaults["success_threshold"]["value"]
-        assert config.success_threshold == expected_success_threshold, \
-            f"success_threshold default should be {expected_success_threshold}"
+        assert (
+            config.success_threshold == expected_success_threshold
+        ), f"success_threshold default should be {expected_success_threshold}"
 
         # Check timeout (convert to ms)
         expected_timeout_ms = defaults["timeout"]["value_ms"]
-        if hasattr(config, 'timeout_ms'):
+        if hasattr(config, "timeout_ms"):
             actual_timeout_ms = config.timeout_ms
-        elif hasattr(config, 'timeout'):
+        elif hasattr(config, "timeout"):
             actual_timeout_ms = config.timeout * 1000
         else:
             pytest.fail("CircuitBreakerConfig has no recognizable timeout attribute")
 
-        assert actual_timeout_ms == expected_timeout_ms, \
-            f"timeout default should be {expected_timeout_ms}ms"
+        assert (
+            actual_timeout_ms == expected_timeout_ms
+        ), f"timeout default should be {expected_timeout_ms}ms"
 
         # Check recovery_timeout (convert to ms)
         expected_recovery_ms = defaults["recovery_timeout"]["value_ms"]
-        if hasattr(config, 'recovery_timeout_ms'):
+        if hasattr(config, "recovery_timeout_ms"):
             actual_recovery_ms = config.recovery_timeout_ms
-        elif hasattr(config, 'recovery_timeout'):
+        elif hasattr(config, "recovery_timeout"):
             actual_recovery_ms = config.recovery_timeout * 1000
         else:
             pytest.fail("CircuitBreakerConfig has no recognizable recovery_timeout attribute")
 
-        assert actual_recovery_ms == expected_recovery_ms, \
-            f"recovery_timeout default should be {expected_recovery_ms}ms"
+        assert (
+            actual_recovery_ms == expected_recovery_ms
+        ), f"recovery_timeout default should be {expected_recovery_ms}ms"
 
 
 class TestInterfaceSignatures:
@@ -272,15 +282,17 @@ class TestInterfaceSignatures:
 
         # Python should have: self, params (dict[str, Any])
         assert "self" in params
-        assert "params" in params or "kwargs" in params, \
-            "Tool.execute should accept params or **kwargs"
+        assert (
+            "params" in params or "kwargs" in params
+        ), "Tool.execute should accept params or **kwargs"
 
         # Check return type annotation if available
         if sig.return_annotation != inspect.Signature.empty:
             # Should return ToolResult (or awaitable ToolResult for async)
             return_type_str = str(sig.return_annotation)
-            assert "ToolResult" in return_type_str, \
-                f"Tool.execute should return ToolResult, got {return_type_str}"
+            assert (
+                "ToolResult" in return_type_str
+            ), f"Tool.execute should return ToolResult, got {return_type_str}"
 
     def test_agent_process_signature(self):
         """Verify Agent.process() method signature matches specification."""
@@ -292,14 +304,14 @@ class TestInterfaceSignatures:
 
         # Python should have: self, message (Message)
         assert "self" in params
-        assert "message" in params, \
-            "Agent.process should accept message parameter"
+        assert "message" in params, "Agent.process should accept message parameter"
 
         # Check return type annotation if available
         if sig.return_annotation != inspect.Signature.empty:
             return_type_str = str(sig.return_annotation)
-            assert "Message" in return_type_str, \
-                f"Agent.process should return Message, got {return_type_str}"
+            assert (
+                "Message" in return_type_str
+            ), f"Agent.process should return Message, got {return_type_str}"
 
 
 class TestErrorTypes:
@@ -312,8 +324,7 @@ class TestErrorTypes:
         # Should be able to instantiate with message
         error = TimeoutError("Test timeout")
 
-        assert str(error) == "Test timeout", \
-            "TimeoutError should have message"
+        assert str(error) == "Test timeout", "TimeoutError should have message"
 
     def test_max_retries_exceeded_error_exists(self):
         """Verify MaxRetriesExceeded error type exists."""
@@ -322,7 +333,5 @@ class TestErrorTypes:
         # Should be able to instantiate with message and attempts
         error = MaxRetriesExceededError("Max retries exceeded", attempts=3)
 
-        assert str(error) == "Max retries exceeded", \
-            "MaxRetriesExceededError should have message"
-        assert error.attempts == 3, \
-            "MaxRetriesExceededError should track number of attempts"
+        assert str(error) == "Max retries exceeded", "MaxRetriesExceededError should have message"
+        assert error.attempts == 3, "MaxRetriesExceededError should track number of attempts"

--- a/tests/cross_language/test_message_serialization.py
+++ b/tests/cross_language/test_message_serialization.py
@@ -75,8 +75,7 @@ class TestMessageSerialization:
     def test_assistant_message_with_metadata(self, message_test_cases):
         """Test assistant message with metadata."""
         test_case = next(
-            tc for tc in message_test_cases
-            if tc["id"] == "assistant_message_with_metadata"
+            tc for tc in message_test_cases if tc["id"] == "assistant_message_with_metadata"
         )
 
         msg_data = test_case["message"]
@@ -120,10 +119,7 @@ class TestMessageSerialization:
 
     def test_tool_message_structured(self, message_test_cases):
         """Test tool message with structured content."""
-        test_case = next(
-            tc for tc in message_test_cases
-            if tc["id"] == "tool_message_structured"
-        )
+        test_case = next(tc for tc in message_test_cases if tc["id"] == "tool_message_structured")
 
         msg_data = test_case["message"]
         msg = Message(
@@ -250,10 +246,7 @@ class TestMessageSerialization:
 
     def test_numeric_metadata(self, message_test_cases):
         """Test message with various numeric metadata types."""
-        test_case = next(
-            tc for tc in message_test_cases
-            if tc["id"] == "numeric_metadata"
-        )
+        test_case = next(tc for tc in message_test_cases if tc["id"] == "numeric_metadata")
 
         msg_data = test_case["message"]
         msg = Message(
@@ -296,9 +289,7 @@ class TestMessageSerialization:
             try:
                 validate(instance=serialized, schema=MESSAGE_SCHEMA)
             except ValidationError as e:
-                pytest.fail(
-                    f"Test case '{test_case['id']}' failed schema validation: {e.message}"
-                )
+                pytest.fail(f"Test case '{test_case['id']}' failed schema validation: {e.message}")
 
             # Verify core properties match
             assert serialized["role"] == msg_data["role"]
@@ -318,7 +309,11 @@ class TestMessageSerialization:
             result["metadata"] = msg.metadata
 
         if hasattr(msg, "timestamp") and msg.timestamp:
-            result["timestamp"] = msg.timestamp.isoformat() if hasattr(msg.timestamp, "isoformat") else str(msg.timestamp)
+            result["timestamp"] = (
+                msg.timestamp.isoformat()
+                if hasattr(msg.timestamp, "isoformat")
+                else str(msg.timestamp)
+            )
 
         return result
 

--- a/tests/cross_language/test_retry_behavior.py
+++ b/tests/cross_language/test_retry_behavior.py
@@ -60,8 +60,7 @@ class TestRetryBehavior:
     async def test_success_first_attempt(self):
         """Verify successful first attempt requires no retries."""
         test_case = next(
-            tc for tc in RETRY_FIXTURES["test_cases"]
-            if tc["id"] == "retry_success_first_attempt"
+            tc for tc in RETRY_FIXTURES["test_cases"] if tc["id"] == "retry_success_first_attempt"
         )
 
         # Create agent with responses from scenario
@@ -73,7 +72,7 @@ class TestRetryBehavior:
             max_retries=config_data["max_retries"],
             initial_delay=config_data["initial_backoff_ms"] / 1000.0,
             max_delay=config_data["max_backoff_ms"] / 1000.0,
-            multiplier=config_data["backoff_multiplier"]
+            multiplier=config_data["backoff_multiplier"],
         )
         retry = RetryDecorator(agent, config)
 
@@ -90,8 +89,7 @@ class TestRetryBehavior:
     async def test_success_after_retry(self):
         """Verify success after one failed attempt."""
         test_case = next(
-            tc for tc in RETRY_FIXTURES["test_cases"]
-            if tc["id"] == "retry_success_second_attempt"
+            tc for tc in RETRY_FIXTURES["test_cases"] if tc["id"] == "retry_success_second_attempt"
         )
 
         agent = MockAgent(test_case["scenario"]["agent_responses"])
@@ -100,7 +98,7 @@ class TestRetryBehavior:
             max_retries=config_data["max_retries"],
             initial_delay=config_data["initial_backoff_ms"] / 1000.0,
             max_delay=config_data["max_backoff_ms"] / 1000.0,
-            multiplier=config_data["backoff_multiplier"]
+            multiplier=config_data["backoff_multiplier"],
         )
         retry = RetryDecorator(agent, config)
 
@@ -118,16 +116,14 @@ class TestRetryBehavior:
         # Verify delay is within expected range
         min_delay = expected.get("min_total_delay_ms", 0)
         max_delay = expected.get("max_total_delay_ms", float("inf"))
-        assert min_delay <= elapsed_ms <= max_delay * 1.5, \
-            f"Delay {elapsed_ms}ms not in range [{min_delay}, {max_delay}]"
+        assert (
+            min_delay <= elapsed_ms <= max_delay * 1.5
+        ), f"Delay {elapsed_ms}ms not in range [{min_delay}, {max_delay}]"
 
     @pytest.mark.asyncio
     async def test_retries_exhausted(self):
         """Verify failure when all retries exhausted."""
-        test_case = next(
-            tc for tc in RETRY_FIXTURES["test_cases"]
-            if tc["id"] == "retry_exhausted"
-        )
+        test_case = next(tc for tc in RETRY_FIXTURES["test_cases"] if tc["id"] == "retry_exhausted")
 
         agent = MockAgent(test_case["scenario"]["agent_responses"])
         config_data = test_case["config"]
@@ -135,7 +131,7 @@ class TestRetryBehavior:
             max_retries=config_data["max_retries"],
             initial_delay=config_data["initial_backoff_ms"] / 1000.0,
             max_delay=config_data["max_backoff_ms"] / 1000.0,
-            multiplier=config_data["backoff_multiplier"]
+            multiplier=config_data["backoff_multiplier"],
         )
         retry = RetryDecorator(agent, config)
 
@@ -153,8 +149,7 @@ class TestRetryBehavior:
     async def test_exponential_backoff(self):
         """Verify exponential backoff timing."""
         test_case = next(
-            tc for tc in RETRY_FIXTURES["test_cases"]
-            if tc["id"] == "retry_exponential_backoff"
+            tc for tc in RETRY_FIXTURES["test_cases"] if tc["id"] == "retry_exponential_backoff"
         )
 
         agent = MockAgent(test_case["scenario"]["agent_responses"])
@@ -163,7 +158,7 @@ class TestRetryBehavior:
             max_retries=config_data["max_retries"],
             initial_delay=config_data["initial_backoff_ms"] / 1000.0,
             max_delay=config_data["max_backoff_ms"] / 1000.0,
-            multiplier=config_data["backoff_multiplier"]
+            multiplier=config_data["backoff_multiplier"],
         )
         retry = RetryDecorator(agent, config)
 
@@ -182,15 +177,15 @@ class TestRetryBehavior:
         # Expected: 100ms + 200ms + 400ms = 700ms
         min_delay = expected.get("min_total_delay_ms", 0)
         max_delay = expected.get("max_total_delay_ms", float("inf"))
-        assert min_delay <= elapsed_ms <= max_delay * 1.5, \
-            f"Delay {elapsed_ms}ms not in range [{min_delay}, {max_delay}]"
+        assert (
+            min_delay <= elapsed_ms <= max_delay * 1.5
+        ), f"Delay {elapsed_ms}ms not in range [{min_delay}, {max_delay}]"
 
     @pytest.mark.asyncio
     async def test_max_backoff_cap(self):
         """Verify backoff is capped at max_backoff."""
         test_case = next(
-            tc for tc in RETRY_FIXTURES["test_cases"]
-            if tc["id"] == "retry_max_backoff_capped"
+            tc for tc in RETRY_FIXTURES["test_cases"] if tc["id"] == "retry_max_backoff_capped"
         )
 
         agent = MockAgent(test_case["scenario"]["agent_responses"])
@@ -199,7 +194,7 @@ class TestRetryBehavior:
             max_retries=config_data["max_retries"],
             initial_delay=config_data["initial_backoff_ms"] / 1000.0,
             max_delay=config_data["max_backoff_ms"] / 1000.0,
-            multiplier=config_data["backoff_multiplier"]
+            multiplier=config_data["backoff_multiplier"],
         )
         retry = RetryDecorator(agent, config)
 
@@ -218,15 +213,15 @@ class TestRetryBehavior:
         # Verify capped backoff: 100ms + 200ms (capped) + 200ms (capped) + 200ms (capped) = 700ms
         min_delay = expected.get("min_total_delay_ms", 0)
         max_delay = expected.get("max_total_delay_ms", float("inf"))
-        assert min_delay <= elapsed_ms <= max_delay * 1.5, \
-            f"Delay {elapsed_ms}ms not in range [{min_delay}, {max_delay}]"
+        assert (
+            min_delay <= elapsed_ms <= max_delay * 1.5
+        ), f"Delay {elapsed_ms}ms not in range [{min_delay}, {max_delay}]"
 
     @pytest.mark.asyncio
     async def test_non_retryable_error(self):
         """Verify non-retryable errors fail immediately."""
         test_case = next(
-            tc for tc in RETRY_FIXTURES["test_cases"]
-            if tc["id"] == "retry_non_retryable_error"
+            tc for tc in RETRY_FIXTURES["test_cases"] if tc["id"] == "retry_non_retryable_error"
         )
 
         agent = MockAgent(test_case["scenario"]["agent_responses"])
@@ -241,7 +236,7 @@ class TestRetryBehavior:
             initial_delay=config_data["initial_backoff_ms"] / 1000.0,
             max_delay=config_data["max_backoff_ms"] / 1000.0,
             multiplier=config_data["backoff_multiplier"],
-            should_retry=should_retry
+            should_retry=should_retry,
         )
         retry = RetryDecorator(agent, config)
 
@@ -259,8 +254,7 @@ class TestRetryBehavior:
     async def test_metrics_tracking(self):
         """Verify retry metrics are tracked correctly."""
         test_case = next(
-            tc for tc in RETRY_FIXTURES["test_cases"]
-            if tc["id"] == "retry_metrics_tracking"
+            tc for tc in RETRY_FIXTURES["test_cases"] if tc["id"] == "retry_metrics_tracking"
         )
 
         agent = MockAgent(test_case["scenario"]["agent_responses"])
@@ -269,7 +263,7 @@ class TestRetryBehavior:
             max_retries=config_data["max_retries"],
             initial_delay=config_data["initial_backoff_ms"] / 1000.0,
             max_delay=config_data["max_backoff_ms"] / 1000.0,
-            multiplier=config_data["backoff_multiplier"]
+            multiplier=config_data["backoff_multiplier"],
         )
         retry = RetryDecorator(agent, config)
 

--- a/tests/frameworks/fixtures/mock_providers.py
+++ b/tests/frameworks/fixtures/mock_providers.py
@@ -10,7 +10,9 @@ from agenkit.adapters.llm import LLM
 class MockLLM(LLM):
     """Mock LLM that returns pre-configured responses without API calls."""
 
-    def __init__(self, responses: list[str] | None = None, default_response: str = "mock response") -> None:
+    def __init__(
+        self, responses: list[str] | None = None, default_response: str = "mock response"
+    ) -> None:
         """Create mock LLM with configurable responses."""
         self._responses = responses or []
         self._default_response = default_response

--- a/tests/frameworks/test_minicrew_compatibility.py
+++ b/tests/frameworks/test_minicrew_compatibility.py
@@ -26,7 +26,9 @@ class TestCrewTask:
     def test_creation(self) -> None:
         """CrewTask can be created with description and agent."""
         llm = MockLLM()
-        agent = CrewAgent(role="Researcher", goal="Research things", backstory="Experienced", llm=llm)
+        agent = CrewAgent(
+            role="Researcher", goal="Research things", backstory="Experienced", llm=llm
+        )
         task = CrewTask(description="Research AI trends", agent=agent)
         assert task.description == "Research AI trends"
         assert task.agent is agent
@@ -43,9 +45,7 @@ class TestCrewTask:
         llm = MockLLM()
         agent = CrewAgent(role="Analyst", goal="Analyze", backstory="Sharp", llm=llm)
         upstream = CrewTask(description="Gather data", agent=agent)
-        downstream = CrewTask(
-            description="Analyze data", agent=agent, context=[upstream]
-        )
+        downstream = CrewTask(description="Analyze data", agent=agent, context=[upstream])
         assert len(downstream.context) == 1
         assert downstream.context[0] is upstream
 
@@ -128,9 +128,7 @@ class TestCrewSequential:
         """tasks_completed equals the number of tasks submitted."""
         llm = MockLLM(default_response="ok")
         agent = CrewAgent(role="Worker", goal="Work", backstory="Diligent", llm=llm)
-        tasks = [
-            CrewTask(description=f"Task {i}", agent=agent) for i in range(3)
-        ]
+        tasks = [CrewTask(description=f"Task {i}", agent=agent) for i in range(3)]
         crew = Crew(agents=[agent], tasks=tasks)
         result = await crew.kickoff()
         assert result["tasks_completed"] == 3
@@ -182,9 +180,7 @@ class TestCrewParallel:
             CrewAgent(role=f"Agent {i}", goal="Work", backstory="Focused", llm=llm)
             for i in range(3)
         ]
-        tasks = [
-            CrewTask(description=f"Task {i}", agent=agents[i]) for i in range(3)
-        ]
+        tasks = [CrewTask(description=f"Task {i}", agent=agents[i]) for i in range(3)]
         crew = Crew(agents=agents, tasks=tasks, process="parallel")
         result = await crew.kickoff()
         assert result["process"] == "parallel"

--- a/tests/middleware/test_retry.py
+++ b/tests/middleware/test_retry.py
@@ -39,9 +39,7 @@ async def test_retry_success():
         fail_count=2, success_msg="success after retries", failure_msg="temporary failure"
     )
 
-    retry = RetryDecorator(
-        agent, RetryConfig(max_retries=3, initial_delay=0.01, multiplier=2.0)
-    )
+    retry = RetryDecorator(agent, RetryConfig(max_retries=3, initial_delay=0.01, multiplier=2.0))
 
     msg = Message(role="user", content="test")
     response = await retry.process(msg)
@@ -57,9 +55,7 @@ async def test_retry_max_retries_exceeded():
         fail_count=10, success_msg="should not succeed", failure_msg="persistent failure"
     )
 
-    retry = RetryDecorator(
-        agent, RetryConfig(max_retries=3, initial_delay=0.01, multiplier=2.0)
-    )
+    retry = RetryDecorator(agent, RetryConfig(max_retries=3, initial_delay=0.01, multiplier=2.0))
 
     msg = Message(role="user", content="test")
 
@@ -77,9 +73,7 @@ async def test_retry_immediate_success():
         fail_count=0, success_msg="immediate success", failure_msg="should not fail"
     )
 
-    retry = RetryDecorator(
-        agent, RetryConfig(max_retries=3, initial_delay=0.01, multiplier=2.0)
-    )
+    retry = RetryDecorator(agent, RetryConfig(max_retries=3, initial_delay=0.01, multiplier=2.0))
 
     msg = Message(role="user", content="test")
     response = await retry.process(msg)

--- a/tests/parity/test_feature_detection.py
+++ b/tests/parity/test_feature_detection.py
@@ -307,9 +307,9 @@ class TestFeatureManifest:
             for category, items in features.items():
                 if isinstance(items, list):
                     # Check for duplicates
-                    assert len(items) == len(set(items)), (
-                        f"Duplicates found in {lang}.{category}: {items}"
-                    )
+                    assert len(items) == len(
+                        set(items)
+                    ), f"Duplicates found in {lang}.{category}: {items}"
 
 
 @pytest.mark.parametrize(

--- a/tests/parity/test_matrix_generation.py
+++ b/tests/parity/test_matrix_generation.py
@@ -104,9 +104,7 @@ class TestMatrixMarkdownGeneration:
 
     def test_generate_feature_matrix(self, feature_manifest, test_report):
         """Verify matrix markdown is generated."""
-        matrix_md = matrix_generator.generate_feature_matrix(
-            feature_manifest, test_report
-        )
+        matrix_md = matrix_generator.generate_feature_matrix(feature_manifest, test_report)
 
         # Should be non-empty string
         assert isinstance(matrix_md, str)
@@ -119,9 +117,7 @@ class TestMatrixMarkdownGeneration:
 
     def test_matrix_contains_language_names(self, feature_manifest, test_report):
         """Verify matrix includes all language names."""
-        matrix_md = matrix_generator.generate_feature_matrix(
-            feature_manifest, test_report
-        )
+        matrix_md = matrix_generator.generate_feature_matrix(feature_manifest, test_report)
 
         languages = ["Python", "Go", "TypeScript", "Rust", "C++", "Zig"]
 
@@ -130,9 +126,7 @@ class TestMatrixMarkdownGeneration:
 
     def test_matrix_contains_status_indicators(self, feature_manifest, test_report):
         """Verify matrix uses status indicators."""
-        matrix_md = matrix_generator.generate_feature_matrix(
-            feature_manifest, test_report
-        )
+        matrix_md = matrix_generator.generate_feature_matrix(feature_manifest, test_report)
 
         # Should contain status indicators
         assert "✅" in matrix_md  # Implemented
@@ -158,7 +152,10 @@ class TestGapAnalysis:
         gap_md = matrix_generator.generate_gap_analysis(feature_manifest)
 
         # If TypeScript has gaps (which it does), they should be listed
-        if feature_manifest["summary"]["total"]["typescript"] < feature_manifest["summary"]["total"]["python"]:
+        if (
+            feature_manifest["summary"]["total"]["typescript"]
+            < feature_manifest["summary"]["total"]["python"]
+        ):
             assert "## Typescript Gaps" in gap_md
 
     def test_gap_analysis_excludes_python(self, feature_manifest):
@@ -229,9 +226,7 @@ class TestDataIntegrity:
                 total == manifest_total
             ), f"{lang}: matrix shows {total} but manifest has {manifest_total}"
 
-    def test_parity_percentages_calculated_correctly(
-        self, feature_manifest, test_report
-    ):
+    def test_parity_percentages_calculated_correctly(self, feature_manifest, test_report):
         """Verify parity percentages are calculated correctly."""
         matrix_data = matrix_generator.build_matrix_data(feature_manifest, test_report)
 
@@ -241,9 +236,7 @@ class TestDataIntegrity:
 
         for stat in matrix_data["summary_stats"]:
             if python_total > 0:
-                expected_parity = round(
-                    stat["total_features"] / python_total * 100, 1
-                )
+                expected_parity = round(stat["total_features"] / python_total * 100, 1)
                 assert (
                     abs(stat["parity_percent"] - expected_parity) < 0.1
                 ), f"{stat['language']}: parity mismatch"

--- a/tests/protocols/test_agui_standard.py
+++ b/tests/protocols/test_agui_standard.py
@@ -162,9 +162,7 @@ async def test_adapter_basic_streaming():
     assert events[1].role == "assistant"
 
     # Collect all content
-    content = "".join(
-        e.delta for e in events if isinstance(e, TextMessageContentEvent)
-    )
+    content = "".join(e.delta for e in events if isinstance(e, TextMessageContentEvent))
     assert "Echo: Hello" in content
 
 

--- a/tests/protocols/test_mcp.py
+++ b/tests/protocols/test_mcp.py
@@ -110,9 +110,7 @@ def test_jsonrpc_request_to_dict() -> None:
 
 def test_jsonrpc_request_to_dict_with_params() -> None:
     """_JSONRPCRequest.to_dict() includes params when set."""
-    req = _JSONRPCRequest(
-        jsonrpc="2.0", id=1, method="tools/call", params={"name": "echo"}
-    )
+    req = _JSONRPCRequest(jsonrpc="2.0", id=1, method="tools/call", params={"name": "echo"})
     d = req.to_dict()
     assert d["params"] == {"name": "echo"}
 

--- a/tests/skills/test_skill_agent.py
+++ b/tests/skills/test_skill_agent.py
@@ -14,16 +14,12 @@ from agenkit.skills.loader import SkillRegistry
 # ---------------------------------------------------------------------------
 
 
-def make_skill_dir(tmp_path: Path, name: str, description: str, body: str = "Instructions here.") -> Path:
+def make_skill_dir(
+    tmp_path: Path, name: str, description: str, body: str = "Instructions here."
+) -> Path:
     skill_dir = tmp_path / name
     skill_dir.mkdir()
-    content = (
-        "---\n"
-        f"name: {name}\n"
-        f"description: {description}\n"
-        "---\n"
-        f"{body}"
-    )
+    content = "---\n" f"name: {name}\n" f"description: {description}\n" "---\n" f"{body}"
     (skill_dir / "SKILL.md").write_text(content, encoding="utf-8")
     return skill_dir
 

--- a/tests/skills/test_skill_loader.py
+++ b/tests/skills/test_skill_loader.py
@@ -12,17 +12,13 @@ from agenkit.skills.loader import AgentSkill, SkillRegistry
 # ---------------------------------------------------------------------------
 
 
-def make_skill_dir(tmp_path: Path, name: str, description: str, body: str = "Instructions here.") -> Path:
+def make_skill_dir(
+    tmp_path: Path, name: str, description: str, body: str = "Instructions here."
+) -> Path:
     """Create a minimal valid skill directory inside tmp_path."""
     skill_dir = tmp_path / name
     skill_dir.mkdir()
-    content = (
-        "---\n"
-        f"name: {name}\n"
-        f"description: {description}\n"
-        "---\n"
-        f"{body}"
-    )
+    content = "---\n" f"name: {name}\n" f"description: {description}\n" "---\n" f"{body}"
     (skill_dir / "SKILL.md").write_text(content, encoding="utf-8")
     return skill_dir
 
@@ -33,7 +29,9 @@ def make_skill_dir(tmp_path: Path, name: str, description: str, body: str = "Ins
 
 
 def test_load_skill_valid(tmp_path: Path) -> None:
-    skill_dir = make_skill_dir(tmp_path, "pdf-processing", "Extract text from PDFs.", "# PDF\nDo stuff.")
+    skill_dir = make_skill_dir(
+        tmp_path, "pdf-processing", "Extract text from PDFs.", "# PDF\nDo stuff."
+    )
     skill = AgentSkill.from_directory(skill_dir)
 
     assert skill.name == "pdf-processing"

--- a/tests/test_api_standardization.py
+++ b/tests/test_api_standardization.py
@@ -13,13 +13,19 @@ import warnings
 import pytest
 
 from agenkit import Message
-from agenkit.patterns import ConversationalAgent, ConversationalAgentConfig, ReActConfig, RouterConfig
+from agenkit.patterns import (
+    ConversationalAgent,
+    ConversationalAgentConfig,
+    ReActConfig,
+    RouterConfig,
+)
 from agenkit.patterns.memory import MemoryEntry, MemoryHierarchy, WorkingMemory
 
 
 # ---------------------------------------------------------------------------
 # Shared mock LLM (no real API calls)
 # ---------------------------------------------------------------------------
+
 
 class MockChatLLM:
     """Minimal mock implementing the LLMClient protocol (chat method)."""
@@ -36,6 +42,7 @@ class MockChatLLM:
 # ---------------------------------------------------------------------------
 # Group 1: ConversationalAgentConfig — 6 tests
 # ---------------------------------------------------------------------------
+
 
 class TestConversationalAgentConfig:
     """Tests for the new ConversationalAgentConfig dataclass."""
@@ -137,6 +144,7 @@ class TestConversationalAgentConfig:
 # Group 2: Deprecation warnings — 4 tests
 # ---------------------------------------------------------------------------
 
+
 class TestDeprecationWarnings:
     """Deprecation warning behavior for ConversationalAgent."""
 
@@ -174,6 +182,7 @@ class TestDeprecationWarnings:
 # ---------------------------------------------------------------------------
 # Group 3: MemoryHierarchy session_id deprecation — 4 tests
 # ---------------------------------------------------------------------------
+
 
 class TestMemorySessionIdDeprecation:
     """session_id deprecation warnings in MemoryHierarchy.store()."""
@@ -220,6 +229,7 @@ class TestMemorySessionIdDeprecation:
 # Group 4: Canonical defaults — 8 tests
 # ---------------------------------------------------------------------------
 
+
 class TestCanonicalDefaults:
     """Verify canonical default values match cross-language specification."""
 
@@ -262,12 +272,14 @@ class TestCanonicalDefaults:
         # without constructing RouterAgent to avoid needing a classifier
         import inspect
         from agenkit.patterns.router import RouterConfig as RC
+
         fields = {f.name: f.default for f in RC.__dataclass_fields__.values()}
         assert fields["default_key"] is None
 
     def test_react_config_max_steps_default(self) -> None:
         """ReActConfig max_steps defaults to 10."""
         import inspect
+
         fields = {f.name: f.default for f in ReActConfig.__dataclass_fields__.values()}
         assert fields["max_steps"] == 10
 

--- a/tests/test_parity_validation.py
+++ b/tests/test_parity_validation.py
@@ -205,7 +205,9 @@ def test_no_missing_languages(parity_report: dict[str, Any]) -> None:
 
     # Warn about other missing languages but don't fail
     if missing:
-        pytest.skip(f"Some languages not yet in parity report: {missing}. This is OK during development.")
+        pytest.skip(
+            f"Some languages not yet in parity report: {missing}. This is OK during development."
+        )
 
 
 def test_python_is_reference(parity_report: dict[str, Any]) -> None:
@@ -269,9 +271,7 @@ def test_all_languages_have_patterns(parity_report: dict[str, Any]) -> None:
             # TypeScript counts are file-based estimates, may show 0 in categories
             continue
 
-        python_patterns = parity_report["languages"]["python"]["categories"][
-            "patterns"
-        ]
+        python_patterns = parity_report["languages"]["python"]["categories"]["patterns"]
         pattern_parity = (pattern_tests / python_patterns) * 100 if pattern_tests > 0 else 0
 
         min_pattern_parity = min_pattern_parity_by_lang.get(language, 1.0)
@@ -307,9 +307,7 @@ def test_no_negative_test_counts(parity_report: dict[str, Any]) -> None:
 
         categories = lang_data.get("categories", {})
         for cat_name, cat_count in categories.items():
-            assert cat_count >= 0, (
-                f"{lang_name}/{cat_name} has negative count: {cat_count}"
-            )
+            assert cat_count >= 0, f"{lang_name}/{cat_name} has negative count: {cat_count}"
 
 
 def test_zig_infrastructure_complete(parity_report: dict[str, Any]) -> None:
@@ -364,9 +362,9 @@ def test_cpp_test_counting_fixed(parity_report: dict[str, Any]) -> None:
 
     # Check the note was updated
     cpp_note = parity_report["languages"]["cpp"].get("note", "")
-    assert "individual TEST()" in cpp_note or "TEST() macros" in cpp_note, (
-        f"C++ note should mention individual tests: {cpp_note}"
-    )
+    assert (
+        "individual TEST()" in cpp_note or "TEST() macros" in cpp_note
+    ), f"C++ note should mention individual tests: {cpp_note}"
 
 
 @pytest.mark.slow
@@ -424,8 +422,7 @@ def test_all_languages_positive_counts(parity_report: dict[str, Any]) -> None:
 
         total = lang_data.get("total", 0)
         assert total > 0, (
-            f"{lang_name.upper()} has zero tests. "
-            "This suggests a counting or build issue."
+            f"{lang_name.upper()} has zero tests. " "This suggests a counting or build issue."
         )
 
 


### PR DESCRIPTION
## Summary

The CI/security workflows merged in #564 assumed a **Linux** self-hosted runner, but `orion.local` is **macOS/arm64**. macOS runners cannot execute `container:` jobs (GitHub platform rule: *"Container operations are only supported on Linux runners"*), so the Semgrep and Trivy jobs failed.

This repoints all `push`/`schedule` jobs to **`[self-hosted, Linux]`**, served by 6 runners now registered on **`janus.local`** (Rocky Linux 9, 32c/62GB, Docker + Go/Node/Cargo/Java present), where the container-based security scans run natively.

## Changes
- `security.yml`, `test.yml`, `lint.yml`, `parity-validation.yml`: `runs-on` for self-hosted jobs → `pull_request ? ubuntu-latest : [self-hosted, Linux]`.
- PRs (incl. forks) still run on GitHub-hosted runners — fork-safety split preserved.
- `CLAUDE.md`: CI policy updated to describe the janus-Linux / orion-overflow topology.

## Infra changes made out-of-band (not in this diff)
- **10 self-hosted runners online**: 6 on janus (`[self-hosted, Linux, X64]`) + 4 on orion (`[self-hosted, macOS, ARM64, orion]`).
- janus runner services required an SELinux relabel (`bin_t`) to start under systemd on Rocky 9 (was `status=203/EXEC`).
- orion runners: fixed launchd `.path` to include `/opt/homebrew/bin` so Docker/Homebrew tools resolve.

## Why orion stays
orion remains registered as overflow for any future macOS-specific jobs; it just can't host `container:` jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)