### PR TITLE
ci: run Semgrep rootless to stop _work pollution on self-hosted runners

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -125,14 +125,20 @@ jobs:
     name: Semgrep SAST
     runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || fromJSON('["self-hosted","Linux"]') }}
     timeout-minutes: 20
-    container:
-      image: semgrep/semgrep
     steps:
       - uses: actions/checkout@v4
+      # Run semgrep via `docker run --user` rather than a `container:` job, so
+      # output files are owned by the runner user. A `container:` job runs as
+      # root and litters the shared self-hosted `_work` dir with root-owned
+      # files that break later (non-container) jobs' checkout step.
       - name: Semgrep scan (SARIF)
-        run: semgrep scan --config auto --sarif --output semgrep.sarif
-        env:
-          SEMGREP_RULES: "p/default p/security-audit p/secrets"
+        run: |
+          docker run --rm \
+            --user "$(id -u):$(id -g)" \
+            -v "${{ github.workspace }}:/src" \
+            -w /src \
+            semgrep/semgrep \
+            semgrep scan --config auto --sarif --output semgrep.sarif
       - name: Upload Semgrep SARIF
         if: always()
         uses: github/codeql-action/upload-sarif@v3

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -135,6 +135,7 @@ jobs:
         run: |
           docker run --rm \
             --user "$(id -u):$(id -g)" \
+            -e HOME=/src \
             -v "${{ github.workspace }}:/src" \
             -w /src \
             semgrep/semgrep \


### PR DESCRIPTION
## Summary

On the self-hosted **janus** runners, jobs intermittently failed at the *Checkout* step:

> `fatal: Unable to create '.../_work/.../.git/index.lock': Permission denied`
> `EACCES: permission denied, unlink '.../.claude/api_alignment_infrastructure_audit.md'`

**Root cause:** the Semgrep `container:` job runs as **root** inside Docker and writes root-owned files into the shared `_work` directory. Subsequent non-container jobs on the same runner (which run as the `scttfrdmn` user) then can't overwrite/remove those files during checkout. (Found 10,501 root-owned files in one runner's `_work`.)

## Fix
Replace the Semgrep `container:` job with a `run:` step that invokes `docker run --user $(id -u):$(id -g) semgrep/semgrep`, so all output is owned by the runner user. Behaviour on GitHub-hosted runners is unchanged.

The existing root-owned cruft was also cleared from all 6 janus runners' `_work` dirs (infra, out of band).

## Why this only showed on janus
GitHub-hosted runners are ephemeral, so root pollution never persists between jobs. Self-hosted runners reuse `_work`, so it accumulates.

## Status of the broader CI bring-up
With this + the Maven-on-janus install (infra), the self-hosted security pipeline is green except `govulncheck`, which is a **real vulnerability finding** (tracked separately), not a CI defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)