### PR TITLE
fix(examples): clear last 3 critical vuln alerts (example stubs)

### DIFF
--- a/examples/apps/code-review-bot/go/go.mod
+++ b/examples/apps/code-review-bot/go/go.mod
@@ -4,6 +4,6 @@ go 1.21
 
 require (
 	github.com/anthropics/agenkit-go v0.46.0
-	google.golang.org/grpc v1.60.1
+	google.golang.org/grpc v1.80.0
 	google.golang.org/protobuf v1.32.0
 )

--- a/examples/apps/customer-support/go/go.mod
+++ b/examples/apps/customer-support/go/go.mod
@@ -4,6 +4,6 @@ go 1.21
 
 require (
 	github.com/agenkit/agenkit-go v0.46.0
-	google.golang.org/grpc v1.59.0
+	google.golang.org/grpc v1.80.0
 	google.golang.org/protobuf v1.31.0
 )

--- a/examples/deployment/cloudflare-workers/package.json
+++ b/examples/deployment/cloudflare-workers/package.json
@@ -45,7 +45,7 @@
     "@typescript-eslint/parser": "^6.17.0",
     "prettier": "^3.1.1",
     "typescript": "^5.3.3",
-    "vitest": "^1.1.0",
+    "vitest": "^3.2.6",
     "wrangler": "^3.78.0"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

Clears the final 3 **critical** Dependabot alerts, all in example projects:
- `examples/apps/customer-support/go`: grpc v1.59.0 → v1.80.0 (#113)
- `examples/apps/code-review-bot/go`: grpc v1.60.1 → v1.80.0 (#111)
- `examples/deployment/cloudflare-workers`: vitest ^1.1.0 → ^3.2.6 (#134)

## Caveat (transparent)
These examples reference a **placeholder module path** (`github.com/agenkit/agenkit-go`, which doesn't exist — the real path is `github.com/scttfrdmn/agenkit/agenkit-go`) and **do not build as-is**. The change updates the declared version pins so the advisories close; it is not a functional build fix. Correcting the broken example module paths is tracked as a separate backlog item.

## Milestone
With this, **all 8 critical Dependabot alerts are addressed** — 5 in shipped code (real fixes, merged in #577/#578/#580) + these 3 example-stub pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)