### PR TITLE
fix(ts): repair broken agenkit-ts build (33 → 0 tsc errors)

### DIFF
--- a/agenkit-ts/src/__tests__/chaos/chaos_agents.ts
+++ b/agenkit-ts/src/__tests__/chaos/chaos_agents.ts
@@ -52,7 +52,7 @@ export class ChaosAgent implements Agent {
   }
 
   get capabilities(): string[] {
-    return this.agent.capabilities;
+    return this.agent.capabilities ?? [];
   }
 
   setCrashAfter(count: number): void {
@@ -148,7 +148,7 @@ export class FlakeyAgent implements Agent {
   }
 
   get capabilities(): string[] {
-    return this.agent.capabilities;
+    return this.agent.capabilities ?? [];
   }
 
   reset(): void {
@@ -190,7 +190,7 @@ export class OverloadedAgent implements Agent {
   }
 
   get capabilities(): string[] {
-    return this.agent.capabilities;
+    return this.agent.capabilities ?? [];
   }
 
   isOverloaded(): boolean {

--- a/agenkit-ts/src/evaluation/index.ts
+++ b/agenkit-ts/src/evaluation/index.ts
@@ -183,7 +183,7 @@ export {
   type PatternTestCase,
   type TestCaseResult,
   type BenchmarkResult,
-  type SuiteResult,
+  type SuiteResult as PatternSuiteResult,
 } from './pattern-benchmarks';
 
 // Context metrics

--- a/agenkit-ts/src/infrastructure/health.ts
+++ b/agenkit-ts/src/infrastructure/health.ts
@@ -6,7 +6,7 @@
  * - Prometheus metrics export
  */
 
-import type { Agent, Message } from '../core';
+import type { Agent, Message } from '../core/interfaces';
 
 /**
  * Health status values.
@@ -194,9 +194,9 @@ export class HealthChecker {
     this.trackCheckStarted(probeType);
 
     try {
-      // Basic liveness: Can we call methods?
-      this.agent.name();
-      this.agent.capabilities();
+      // Basic liveness: can we access the agent's identity/capabilities?
+      void this.agent.name;
+      void this.agent.capabilities;
 
       // Custom check if provided
       if (this.config.customCheck && !this.config.customCheck(this.agent)) {

--- a/agenkit-ts/src/infrastructure/load-balancer.ts
+++ b/agenkit-ts/src/infrastructure/load-balancer.ts
@@ -7,7 +7,7 @@
  * - Thread-safe for concurrent requests
  */
 
-import type { Agent, Message } from '../core';
+import type { Agent, Message } from '../core/interfaces';
 
 /**
  * Load balancing algorithm strategy.
@@ -132,14 +132,14 @@ export class LoadBalancer implements Agent {
     this.currentIndex = 0;
   }
 
-  name(): string {
+  get name(): string {
     return `LoadBalancer(${this.backends.length} backends)`;
   }
 
-  capabilities(): string[] {
+  get capabilities(): string[] {
     const capsMap = new Map<string, boolean>();
     for (const backend of this.backends) {
-      for (const cap of backend.agent.capabilities()) {
+      for (const cap of backend.agent.capabilities ?? []) {
         capsMap.set(cap, true);
       }
     }
@@ -151,7 +151,7 @@ export class LoadBalancer implements Agent {
    */
   getBackendStats(): BackendStats[] {
     return this.backends.map((backend) => ({
-      name: backend.agent.name(),
+      name: backend.agent.name,
       healthy: backend.healthy,
       weight: backend.weight,
       activeConnections: backend.activeConnections,
@@ -207,7 +207,7 @@ export class LoadBalancer implements Agent {
         backend.consecutiveFailures = 0;
         if (!backend.healthy && backend.consecutiveFailures === 0) {
           backend.healthy = true;
-          this.trackHealthChange(backend.agent.name(), 'recovered');
+          this.trackHealthChange(backend.agent.name, 'recovered');
         }
       } catch {
         // Failure
@@ -216,7 +216,7 @@ export class LoadBalancer implements Agent {
 
         if (backend.healthy && backend.consecutiveFailures >= this.config.failureThreshold) {
           backend.healthy = false;
-          this.trackHealthChange(backend.agent.name(), 'unhealthy');
+          this.trackHealthChange(backend.agent.name, 'unhealthy');
         }
       }
     }
@@ -307,14 +307,14 @@ export class LoadBalancer implements Agent {
       }
 
       // Avoid retrying same backend
-      if (attempted.has(backend.agent.name())) {
+      if (attempted.has(backend.agent.name)) {
         if (!this.config.enableFailover || attempted.size >= this.backends.length) {
           throw new Error('All backends attempted');
         }
         continue;
       }
 
-      attempted.add(backend.agent.name());
+      attempted.add(backend.agent.name);
 
       // Track request
       backend.activeConnections++;
@@ -338,7 +338,7 @@ export class LoadBalancer implements Agent {
         // Check if should mark unhealthy
         if (backend.totalFailures >= this.config.failureThreshold) {
           backend.healthy = false;
-          this.trackHealthChange(backend.agent.name(), 'unhealthy');
+          this.trackHealthChange(backend.agent.name, 'unhealthy');
         }
 
         // Try failover if enabled
@@ -348,7 +348,7 @@ export class LoadBalancer implements Agent {
         }
 
         // No more failover
-        throw new Error(`Backend ${backend.agent.name()} failed: ${error}`);
+        throw new Error(`Backend ${backend.agent.name} failed: ${error}`);
       }
     }
   }

--- a/agenkit-ts/src/infrastructure/retry-enhanced.ts
+++ b/agenkit-ts/src/infrastructure/retry-enhanced.ts
@@ -7,7 +7,7 @@
  * - Detailed metrics
  */
 
-import type { Agent, Message } from '../core';
+import type { Agent, Message } from '../core/interfaces';
 
 /**
  * Jitter types for retry backoff.
@@ -203,12 +203,12 @@ export class EnhancedRetryDecorator implements Agent {
     };
   }
 
-  name(): string {
-    return this.agent.name();
+  get name(): string {
+    return this.agent.name;
   }
 
-  capabilities(): string[] {
-    return this.agent.capabilities();
+  get capabilities(): string[] {
+    return this.agent.capabilities ?? [];
   }
 
   private classifyError(error: Error): ErrorClass {

--- a/agenkit-ts/src/llm/openai-compatible.ts
+++ b/agenkit-ts/src/llm/openai-compatible.ts
@@ -223,15 +223,18 @@ export class OpenAICompatibleAgent implements Agent {
   async process(message: Message): Promise<Message> {
     const openaiMessage = this.toOpenAIMessage(message);
 
-    const response = await this.client.chat.completions.create({
+    // Spreading `...this.options` defeats TS's literal-narrowing on
+    // `stream: false`, so the result is typed as the streaming/non-streaming
+    // union. We pass stream:false, so assert the non-streaming response.
+    const response = (await this.client.chat.completions.create({
       model: this.model,
       messages: [openaiMessage],
       temperature: this.temperature,
       max_tokens: this.maxTokens,
       top_p: this.topP,
-      stream: false,
       ...this.options,
-    });
+      stream: false,
+    })) as OpenAI.Chat.ChatCompletion;
 
     // Check for valid response
     if (!response.choices || response.choices.length === 0) {
@@ -279,15 +282,17 @@ export class OpenAICompatibleAgent implements Agent {
   ): AsyncGenerator<Message, void, undefined> {
     const openaiMessage = this.toOpenAIMessage(message);
 
-    const stream = await this.client.chat.completions.create({
+    // See process(): the options spread defeats stream-literal narrowing, so
+    // assert the streaming response type (we pass stream:true).
+    const stream = (await this.client.chat.completions.create({
       model: this.model,
       messages: [openaiMessage],
       temperature: this.temperature,
       max_tokens: this.maxTokens,
       top_p: this.topP,
-      stream: true,
       ...this.options,
-    });
+      stream: true,
+    })) as AsyncIterable<OpenAI.Chat.ChatCompletionChunk>;
 
     for await (const chunk of stream) {
       const delta = chunk.choices[0]?.delta;

--- a/agenkit-ts/src/memory/integrations.ts
+++ b/agenkit-ts/src/memory/integrations.ts
@@ -440,7 +440,7 @@ export class ChromaDBVectorStore implements VectorStore {
       const docId = this.generateDocId(sessionId, item.messageId);
       ids.push(docId);
       embeddings.push(item.embedding);
-      documents.push(item.message.content);
+      documents.push(String(item.message.content));
 
       const chromaMetadata = {
         session_id: sessionId,

--- a/agenkit-ts/src/memory/redisMemory.ts
+++ b/agenkit-ts/src/memory/redisMemory.ts
@@ -123,7 +123,7 @@ export class RedisMemory implements Memory {
   private serializeMessage(message: Message, metadata: Record<string, unknown> = {}): string {
     const data: StoredMessage = {
       role: message.role,
-      content: message.content,
+      content: String(message.content),
       metadata,
     };
     return JSON.stringify(data);
@@ -274,7 +274,7 @@ export class RedisMemory implements Memory {
 
     for (let i = 0; i < maxMessages; i++) {
       const msg = messages[i];
-      let preview = msg.content;
+      let preview = String(msg.content);
       if (preview.length > 100) {
         preview = preview.substring(0, 100) + '...';
       }

--- a/agenkit-ts/src/memory/vector-memory.ts
+++ b/agenkit-ts/src/memory/vector-memory.ts
@@ -619,7 +619,7 @@ export class VectorMemory implements Memory {
 
   async store(sessionId: string, message: Message, metadata?: Record<string, unknown>): Promise<void> {
     // Generate embedding
-    const embedding = await this.embeddings.embed(message.content);
+    const embedding = await this.embeddings.embed(String(message.content));
 
     // Store with unique timestamp (ensure strictly increasing)
     const messageId = this.generateId();
@@ -673,7 +673,7 @@ export class VectorMemory implements Memory {
     }>,
   ): Promise<void> {
     // Generate all embeddings in parallel
-    const embeddings = await Promise.all(items.map((item) => this.embeddings.embed(item.message.content)));
+    const embeddings = await Promise.all(items.map((item) => this.embeddings.embed(String(item.message.content))));
 
     // Prepare batch items
     const batchItems = items.map((item, index) => {
@@ -792,8 +792,9 @@ export class VectorMemory implements Memory {
 
     for (let i = 0; i < messagesToSummarize.length; i++) {
       const msg = messagesToSummarize[i];
-      let preview = msg.content.substring(0, 100);
-      if (msg.content.length > 100) {
+      const msgText = String(msg.content);
+      let preview = msgText.substring(0, 100);
+      if (msgText.length > 100) {
         preview += '...';
       }
       summaryParts.push(`${i + 1}. [${msg.role}] ${preview}`);

--- a/agenkit-ts/src/techniques/reasoning/graph-of-thought.ts
+++ b/agenkit-ts/src/techniques/reasoning/graph-of-thought.ts
@@ -132,7 +132,7 @@ export class GraphOfThought implements Agent {
       role: 'user',
       content: prompt,
     });
-    return response.content;
+    return String(response.content);
   }
 
   /**
@@ -488,7 +488,7 @@ Final conclusion:`;
    * ```
    */
   async process(message: Message): Promise<Message> {
-    const problem = message.content;
+    const problem = String(message.content);
 
     // Step 1: Build reasoning graph
     const graph = await this.buildGraph(problem);

--- a/agenkit-ts/src/techniques/reasoning/least-to-most.ts
+++ b/agenkit-ts/src/techniques/reasoning/least-to-most.ts
@@ -62,6 +62,14 @@ export interface Subproblem {
 }
 
 /**
+ * Custom function to decompose a problem into ordered subproblem strings
+ * (simplest to hardest). May be sync or async.
+ */
+export type DecomposerFunction = (
+  problem: string,
+) => string[] | Promise<string[]>;
+
+/**
  * Configuration options for Least-to-Most agent.
  */
 export interface LeastToMostConfig {
@@ -72,7 +80,7 @@ export interface LeastToMostConfig {
    * @param problem The problem to decompose
    * @returns Array of subproblem strings (ordered from simplest to hardest)
    */
-  decomposer?: (problem: string) => string[] | Promise<string[]>;
+  decomposer?: DecomposerFunction;
 
   /**
    * Maximum number of subproblems to generate.

--- a/agenkit-ts/src/transports/grpc-transport.ts
+++ b/agenkit-ts/src/transports/grpc-transport.ts
@@ -160,7 +160,7 @@ export class GRPCTransport extends Transport {
       oneofs: true,
     });
 
-    this.proto = grpc.loadPackageDefinition(packageDefinition).agenkit as GrpcProtoPackage;
+    this.proto = grpc.loadPackageDefinition(packageDefinition).agenkit as unknown as GrpcProtoPackage;
   }
 
   async connect(): Promise<void> {

--- a/agenkit-ts/src/transports/grpc.ts
+++ b/agenkit-ts/src/transports/grpc.ts
@@ -149,7 +149,7 @@ export class GrpcAgent implements Agent {
     });
 
     // Load gRPC package
-    this.proto = grpc.loadPackageDefinition(this.packageDefinition).agenkit as GrpcProtoPackage;
+    this.proto = grpc.loadPackageDefinition(this.packageDefinition).agenkit as unknown as GrpcProtoPackage;
   }
 
   get name(): string {
@@ -231,6 +231,16 @@ export class GrpcAgent implements Agent {
             return;
           }
 
+          if (!response.message) {
+            reject(
+              new GrpcTransportError(
+                'Response missing message payload',
+                grpc.status.UNKNOWN,
+              ),
+            );
+            return;
+          }
+
           resolve(this.protoToMessage(response.message));
         },
       );
@@ -306,7 +316,7 @@ export class GrpcAgent implements Agent {
       }
 
       if (queue.length > 0) {
-        yield queue.shift();
+        yield queue.shift()!;
       } else {
         // Wait a bit before checking again
         await new Promise((resolve) => setTimeout(resolve, 10));
@@ -377,7 +387,7 @@ export class GrpcServer {
     });
 
     // Load gRPC package
-    this.proto = grpc.loadPackageDefinition(this.packageDefinition).agenkit as GrpcProtoPackage;
+    this.proto = grpc.loadPackageDefinition(this.packageDefinition).agenkit as unknown as GrpcProtoPackage;
 
     // Create server
     this.server = new grpc.Server();


### PR DESCRIPTION
## Summary

`agenkit-ts` did not typecheck on `main` (33 `tsc` errors, surfaced during the vuln-triage work). This fixes them all — `npm run build` now succeeds with **0 errors**.

## Root causes & fixes
- **infrastructure/ API drift** (the real one): `load-balancer`, `retry-enhanced`, `health` implemented `name()`/`capabilities()` as **methods**, but the `Agent` interface defines them as **properties**. This was hidden by a broken `import … from '../core'` (no barrel; should be `'../core/interfaces'`). Converted to getters + fixed the import. Fixing the import is what surfaced the drift.
- **llm/openai-compatible**: `...options` spread defeated `stream` literal-narrowing → asserted `ChatCompletion` / `AsyncIterable<ChatCompletionChunk>`.
- **memory/* + graph-of-thought**: `Message.content` is `unknown` (intentional); added `String(...)` coercion where text ops / string params are required.
- **evaluation/index**: `SuiteResult` exported from two modules → aliased one `PatternSuiteResult`.
- **least-to-most**: exported the `DecomposerFunction` type that `index.ts` re-exports.
- **transports/grpc**: `as unknown as` for the package cast; guard undefined message payload; non-null `shift()` under a length guard.
- **chaos test agents**: `capabilities ?? []`.

## Validation
- `npm run build` (tsc): **0 errors** (was 33)
- core + chaos test suites pass (73 tests); full suite via CI

## Note
The infra method→property drift means these modules were written against an older `Agent` interface and never updated — the broken import masked it. No behavior change intended; purely type-correctness + the import path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)