### PR TITLE
fix(deps): clear LOW vuln alerts in example projects

### DIFF
--- a/examples/agui_simple/code-assistant/backend/requirements.txt
+++ b/examples/agui_simple/code-assistant/backend/requirements.txt
@@ -1,4 +1,4 @@
 fastapi==0.115.0
 uvicorn[standard]==0.32.1
-python-multipart==0.0.18
+python-multipart>=0.0.31
 websockets==14.1

--- a/examples/agui_simple/collaborative-editor/backend/requirements.txt
+++ b/examples/agui_simple/collaborative-editor/backend/requirements.txt
@@ -1,7 +1,7 @@
 # FastAPI and server
 fastapi==0.115.0
 uvicorn[standard]==0.32.1
-python-multipart==0.0.18
+python-multipart>=0.0.31
 websockets==14.1
 
 # Agenkit (local development - use published version in production)

--- a/examples/agui_simple/hitl-approval/backend/requirements.txt
+++ b/examples/agui_simple/hitl-approval/backend/requirements.txt
@@ -1,7 +1,7 @@
 # FastAPI and server
 fastapi==0.115.0
 uvicorn[standard]==0.32.1
-python-multipart==0.0.18
+python-multipart>=0.0.31
 websockets==14.1
 
 # Agenkit (local development - use published version in production)

--- a/examples/agui_simple/multi-agent/backend/requirements.txt
+++ b/examples/agui_simple/multi-agent/backend/requirements.txt
@@ -1,7 +1,7 @@
 # FastAPI and server
 fastapi==0.115.0
 uvicorn[standard]==0.32.1
-python-multipart==0.0.18
+python-multipart>=0.0.31
 websockets==14.1
 
 # Agenkit (local development - use published version in production)

--- a/examples/agui_simple/multimodal-agent/backend/requirements.txt
+++ b/examples/agui_simple/multimodal-agent/backend/requirements.txt
@@ -1,7 +1,7 @@
 # FastAPI and server
 fastapi==0.115.0
 uvicorn[standard]==0.32.1
-python-multipart==0.0.18
+python-multipart>=0.0.31
 websockets==14.1
 
 # Agenkit (local development - use published version in production)

--- a/examples/agui_simple/streaming-chat/backend/requirements.txt
+++ b/examples/agui_simple/streaming-chat/backend/requirements.txt
@@ -1,7 +1,7 @@
 # FastAPI and server
 fastapi==0.115.0
 uvicorn[standard]==0.32.1
-python-multipart==0.0.18
+python-multipart>=0.0.31
 websockets==14.1
 
 # Agenkit (local development - use published version in production)

--- a/examples/agui_simple/support-bot/backend/requirements.txt
+++ b/examples/agui_simple/support-bot/backend/requirements.txt
@@ -1,7 +1,7 @@
 # FastAPI and server
 fastapi==0.115.0
 uvicorn[standard]==0.32.1
-python-multipart==0.0.18
+python-multipart>=0.0.31
 websockets==14.1
 
 # Agenkit (local development - use published version in production)

--- a/examples/agui_simple/tool-dashboard/backend/requirements.txt
+++ b/examples/agui_simple/tool-dashboard/backend/requirements.txt
@@ -1,7 +1,7 @@
 # FastAPI and server
 fastapi==0.115.0
 uvicorn[standard]==0.32.1
-python-multipart==0.0.18
+python-multipart>=0.0.31
 websockets==14.1
 
 # Agenkit (local development - use published version in production)

--- a/examples/browser/astro-example/package.json
+++ b/examples/browser/astro-example/package.json
@@ -9,7 +9,7 @@
     "preview": "astro preview"
   },
   "dependencies": {
-    "astro": "^4.0.0"
+    "astro": "^5.18.1"
   },
   "devDependencies": {
     "typescript": "^5.5.0"

--- a/examples/deployment/vercel-edge/package.json
+++ b/examples/deployment/vercel-edge/package.json
@@ -12,7 +12,7 @@
     "test": "echo \"Tests not yet implemented\" && exit 0"
   },
   "dependencies": {
-    "next": "^14.1.0",
+    "next": "^15.5.16",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "@vercel/kv": "^1.0.1"

--- a/examples/integrations/custom-frontends/astro/package.json
+++ b/examples/integrations/custom-frontends/astro/package.json
@@ -9,6 +9,6 @@
     "preview": "astro preview"
   },
   "dependencies": {
-    "astro": "^4.5.0"
+    "astro": "^5.18.1"
   }
 }


### PR DESCRIPTION
Low-severity Dependabot fixes in example projects (version-pin bumps; these examples aren't built in CI):

- **agui_simple backends** (8× `requirements.txt`): `python-multipart` ==0.0.18 → >=0.0.31
- **astro examples** (2 dirs): `astro` ^4 → ^5.18.1
- **vercel-edge**: `next` ^14 → ^15.5.16

🤖 Generated with [Claude Code](https://claude.com/claude-code)