### PR TITLE
fix(deps): clear HIGH vuln alerts in example frontends (vite, esbuild, astro)

### DIFF
--- a/examples/browser/astro-example/package.json
+++ b/examples/browser/astro-example/package.json
@@ -9,7 +9,7 @@
     "preview": "astro preview"
   },
   "dependencies": {
-    "astro": "^5.18.1"
+    "astro": "^6.4.6"
   },
   "devDependencies": {
     "typescript": "^5.5.0"

--- a/examples/browser/react-example/package.json
+++ b/examples/browser/react-example/package.json
@@ -17,6 +17,6 @@
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.0",
     "typescript": "^5.5.0",
-    "vite": "^5.4.0"
+    "vite": "^6.4.3"
   }
 }

--- a/examples/browser/svelte-example/package.json
+++ b/examples/browser/svelte-example/package.json
@@ -12,6 +12,6 @@
     "@sveltejs/vite-plugin-svelte": "^3.0.0",
     "svelte": "^4.2.0",
     "typescript": "^5.5.0",
-    "vite": "^5.4.0"
+    "vite": "^6.4.3"
   }
 }

--- a/examples/browser/vue-example/package.json
+++ b/examples/browser/vue-example/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.0.0",
     "typescript": "^5.5.0",
-    "vite": "^5.4.0",
+    "vite": "^6.4.3",
     "vue-tsc": "^2.0.0"
   }
 }

--- a/examples/deployment/cloudflare-workers/package.json
+++ b/examples/deployment/cloudflare-workers/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20241127.0",
     "@types/node": "^20.10.6",
-    "esbuild": "^0.19.11",
+    "esbuild": "^0.28.1",
     "eslint": "^8.56.0",
     "@typescript-eslint/eslint-plugin": "^6.17.0",
     "@typescript-eslint/parser": "^6.17.0",

--- a/examples/integrations/copilotkit/frontend/package.json
+++ b/examples/integrations/copilotkit/frontend/package.json
@@ -26,6 +26,6 @@
     "eslint-plugin-react-hooks": "^4.6.2",
     "eslint-plugin-react-refresh": "^0.4.7",
     "typescript": "^5.2.2",
-    "vite": "^5.3.1"
+    "vite": "^6.4.3"
   }
 }

--- a/examples/integrations/custom-frontends/astro/package.json
+++ b/examples/integrations/custom-frontends/astro/package.json
@@ -9,6 +9,6 @@
     "preview": "astro preview"
   },
   "dependencies": {
-    "astro": "^5.18.1"
+    "astro": "^6.4.6"
   }
 }

--- a/examples/integrations/custom-frontends/react/package.json
+++ b/examples/integrations/custom-frontends/react/package.json
@@ -14,6 +14,6 @@
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.3.1",
-    "vite": "^5.3.1"
+    "vite": "^6.4.3"
   }
 }

--- a/examples/integrations/custom-frontends/svelte/package.json
+++ b/examples/integrations/custom-frontends/svelte/package.json
@@ -11,6 +11,6 @@
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^3.0.2",
     "svelte": "^4.2.12",
-    "vite": "^5.3.1"
+    "vite": "^6.4.3"
   }
 }

--- a/examples/integrations/custom-frontends/vue/package.json
+++ b/examples/integrations/custom-frontends/vue/package.json
@@ -13,6 +13,6 @@
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.0.4",
-    "vite": "^5.3.1"
+    "vite": "^6.4.3"
   }
 }


### PR DESCRIPTION
Clears the 12 high-severity Dependabot alerts in example/demo frontend projects (version-pin bumps; examples aren't built in CI):

- **vite** ^5.x → ^6.4.3 — 7 frontends (vue/svelte/react browser + custom-frontends + copilotkit)
- **esbuild** ^0.19 → ^0.28.1 — cloudflare-workers
- **astro** ^5.18 → ^6.4.6 — 2 dirs (the HIGH fix requires astro 6.x)

**Shipped-code Dependabot alerts remain at 0 across all severities.** Remaining example alerts are medium/low in demo frontends — left to Dependabot's auto-PRs per scope decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)