### PR TITLE
fix(ts): resolve the 18 real eslint errors (no-unused-vars deferred)

### DIFF
--- a/agenkit-ts/src/__tests__/adapters/llm/local.test.ts
+++ b/agenkit-ts/src/__tests__/adapters/llm/local.test.ts
@@ -243,6 +243,8 @@ describe('LocalAgent: Error Handling', () => {
     const agent = new LocalAgent({
       name: 'error-agent',
       process: async (msg) => createMessage('assistant', 'Response'),
+      // Intentionally throws before yielding to simulate a failing stream.
+      // eslint-disable-next-line require-yield
       processStream: async function* () {
         throw new Error('Streaming failed');
       },

--- a/agenkit-ts/src/__tests__/chaos/slow_responses.test.ts
+++ b/agenkit-ts/src/__tests__/chaos/slow_responses.test.ts
@@ -309,7 +309,7 @@ describe('Adaptive Timeout Behavior', () => {
     const message: Message = { role: 'user', content: 'Test' };
 
     // Start with conservative timeout
-    let timeout = 500;
+    const timeout = 500;
     const measurements: number[] = [];
 
     // Measure actual response times

--- a/agenkit-ts/src/__tests__/patterns/react.test.ts
+++ b/agenkit-ts/src/__tests__/patterns/react.test.ts
@@ -61,7 +61,6 @@ function createFinalAnswerAgent(answer: string) {
 /** Agent that returns an action then a final answer */
 function createToolUseAgent(toolName: string, toolInput: string, finalAnswer: string) {
   let callCount = 0;
-  const { ExtendedMockAgent } = require('./test-helpers');
   return {
     name: 'llm',
     capabilities: ['mock'],

--- a/agenkit-ts/src/__tests__/safety/permissions.test.ts
+++ b/agenkit-ts/src/__tests__/safety/permissions.test.ts
@@ -447,7 +447,7 @@ describe('Safety: Sandbox Extended', () => {
       allowedCommands: new Set(['echo', 'date', 'whoami']),
     });
 
-    let [isAllowed, _] = sandbox.isCommandAllowed('echo hello');
+    const [isAllowed, _] = sandbox.isCommandAllowed('echo hello');
     expect(isAllowed).toBe(true);
 
     const [isAllowed2, error] = sandbox.isCommandAllowed('curl example.com');
@@ -460,7 +460,7 @@ describe('Safety: Sandbox Extended', () => {
       allowedSqlOperations: new Set(['SELECT', 'EXPLAIN', 'DESCRIBE']),
     });
 
-    let [isAllowed, _] = sandbox.isSqlOperationAllowed('DESCRIBE users');
+    const [isAllowed, _] = sandbox.isSqlOperationAllowed('DESCRIBE users');
     expect(isAllowed).toBe(true);
 
     const [isAllowed2, error] = sandbox.isSqlOperationAllowed('INSERT INTO users VALUES (1)');
@@ -489,7 +489,7 @@ describe('Safety: Sandbox Extended', () => {
       allowedDomains: new Set(['example.com', 'api.example.com']),
     });
 
-    let [isAllowed, _] = sandbox.isDomainAllowed('api.example.com');
+    const [isAllowed, _] = sandbox.isDomainAllowed('api.example.com');
     expect(isAllowed).toBe(true);
 
     // Subdomain not explicitly allowed

--- a/agenkit-ts/src/checkpointing/checkpoint.ts
+++ b/agenkit-ts/src/checkpointing/checkpoint.ts
@@ -88,9 +88,6 @@ export function checkpointFromDict(data: Record<string, unknown>): Checkpoint {
   const deserializedMessages: Message[] = [];
   for (const msg of (dataCopy.messages as Record<string, unknown>[]) || []) {
     const msgCopy = { ...msg };
-    if (msgCopy.timestamp && typeof msgCopy.timestamp === 'string') {
-      msgCopy.timestamp = msgCopy.timestamp;
-    }
     deserializedMessages.push(
       createMessage({
         role: msgCopy.role as 'user' | 'assistant' | 'system',

--- a/agenkit-ts/src/evaluation/index.ts
+++ b/agenkit-ts/src/evaluation/index.ts
@@ -113,6 +113,10 @@ export {
   createErrorRecord,
 } from './metrics';
 
+// Local bindings for the metric-factory helpers below (re-export above does
+// not bring these into local scope).
+import { MetricType, createMetricMeasurement } from './metrics';
+
 // Quality metrics
 export {
   type Metric as QualityMetric,
@@ -258,7 +262,6 @@ export function createQualityMetric(
   maxScore: number = 1.0,
   metadata?: Record<string, unknown>
 ): import('./metrics').MetricMeasurement {
-  const { createMetricMeasurement, MetricType } = require('./metrics');
   return createMetricMeasurement(
     name,
     score / maxScore,
@@ -280,7 +283,6 @@ export function createCostMetric(
   currency: string = 'USD',
   metadata?: Record<string, unknown>
 ): import('./metrics').MetricMeasurement {
-  const { createMetricMeasurement, MetricType } = require('./metrics');
   return createMetricMeasurement('total_cost', cost, MetricType.Cost, {
     currency,
     ...metadata,
@@ -298,7 +300,6 @@ export function createDurationMetric(
   durationSeconds: number,
   metadata?: Record<string, unknown>
 ): import('./metrics').MetricMeasurement {
-  const { createMetricMeasurement, MetricType } = require('./metrics');
   return createMetricMeasurement(
     'duration',
     durationSeconds,
@@ -318,7 +319,6 @@ export function createSuccessMetric(
   success: boolean,
   metadata?: Record<string, unknown>
 ): import('./metrics').MetricMeasurement {
-  const { createMetricMeasurement, MetricType } = require('./metrics');
   return createMetricMeasurement(
     'success',
     success ? 1.0 : 0.0,

--- a/agenkit-ts/src/evaluation/prompt-optimizer.ts
+++ b/agenkit-ts/src/evaluation/prompt-optimizer.ts
@@ -189,11 +189,12 @@ export class PromptOptimizer {
       case 'grid':
         result = await this.optimizeGrid(testCases);
         break;
-      case 'random':
+      case 'random': {
         const nSamples = (options?.nSamples as number) || 20;
         result = await this.optimizeRandom(testCases, nSamples);
         break;
-      case 'genetic':
+      }
+      case 'genetic': {
         const geneticConfig: GeneticConfig = {
           populationSize: (options?.populationSize as number) || 10,
           nGenerations: (options?.nGenerations as number) || 10,
@@ -201,6 +202,7 @@ export class PromptOptimizer {
         };
         result = await this.optimizeGenetic(testCases, geneticConfig);
         break;
+      }
       default:
         throw new Error(`Unknown strategy: ${strategy}`);
     }

--- a/agenkit-ts/src/evaluation/recorder.ts
+++ b/agenkit-ts/src/evaluation/recorder.ts
@@ -382,18 +382,17 @@ export class SessionRecorder {
    * @returns Wrapped agent that records all interactions
    */
   wrap(agent: Agent, sessionId?: string): Agent {
-    const recorder = this;
-
+    // Arrow function closes over `this` (the recorder), avoiding a this-alias.
     const wrapped: RecordingAgent = {
       name: agent.name || 'recording_wrapper',
       capabilities: agent.capabilities || [],
 
-      async process(message: Message): Promise<Message> {
+      process: async (message: Message): Promise<Message> => {
         const sid = sessionId || 'default';
 
         // Start session if not already started
-        if (!recorder.activeSessions.has(sid)) {
-          await recorder.startSession(sid, wrapped.name);
+        if (!this.activeSessions.has(sid)) {
+          await this.startSession(sid, wrapped.name);
         }
 
         // Process with timing
@@ -402,7 +401,7 @@ export class SessionRecorder {
         const latency = performance.now() - startTime;
 
         // Record interaction
-        await recorder.recordInteraction(sid, message, output, latency);
+        await this.recordInteraction(sid, message, output, latency);
 
         return output;
       },

--- a/agenkit-ts/src/infrastructure/load-balancer.ts
+++ b/agenkit-ts/src/infrastructure/load-balancer.ts
@@ -300,7 +300,7 @@ export class LoadBalancer implements Agent {
 
     const attempted = new Set<string>();
 
-    while (true) {
+    for (;;) {
       const backend = this.selectBackend();
       if (!backend) {
         throw new Error('All backends unhealthy');

--- a/agenkit-ts/src/patterns/agents-as-tools.ts
+++ b/agenkit-ts/src/patterns/agents-as-tools.ts
@@ -183,7 +183,7 @@ export class AgentTool implements Tool {
       case OutputFormat.STRING:
         return String(response.content);
 
-      case OutputFormat.DICT:
+      case OutputFormat.DICT: {
         const result: Record<string, unknown> = {
           content: response.content,
         };
@@ -191,6 +191,7 @@ export class AgentTool implements Tool {
           result.metadata = response.metadata;
         }
         return result;
+      }
 
       case OutputFormat.MESSAGE:
         return response;

--- a/agenkit-ts/src/techniques/reasoning/least-to-most.test.ts
+++ b/agenkit-ts/src/techniques/reasoning/least-to-most.test.ts
@@ -193,7 +193,7 @@ describe('LeastToMost', () => {
     });
 
     it('should compose solutions when enabled (default)', async () => {
-      let capturedPrompts: string[] = [];
+      const capturedPrompts: string[] = [];
       const capturingAgent: Agent = {
         name: 'capturing',
         capabilities: [],
@@ -221,7 +221,7 @@ describe('LeastToMost', () => {
     });
 
     it('should not compose solutions when disabled', async () => {
-      let capturedPrompts: string[] = [];
+      const capturedPrompts: string[] = [];
       const capturingAgent: Agent = {
         name: 'capturing',
         capabilities: [],

--- a/agenkit-ts/src/techniques/reasoning/plan-and-solve.ts
+++ b/agenkit-ts/src/techniques/reasoning/plan-and-solve.ts
@@ -88,7 +88,7 @@ Solution Plan:`;
       const line = lines[i].trim();
       if (!line) continue;
 
-      const cleaned = line.replace(/^\d+[\.\)]\s*/, '');
+      const cleaned = line.replace(/^\d+[.)]\s*/, '');
       if (cleaned) {
         steps.push({
           description: cleaned,

--- a/agenkit-ts/src/transports/transport.ts
+++ b/agenkit-ts/src/transports/transport.ts
@@ -159,6 +159,10 @@ export abstract class Transport {
  * @returns Transport instance
  * @throws Error if endpoint format is unsupported
  */
+/* eslint-disable @typescript-eslint/no-require-imports --
+   Transports are loaded lazily via require() so that selecting one endpoint
+   type does not eagerly pull in the others' heavy deps (e.g. gRPC). A static
+   import here would load every transport unconditionally. */
 export function parseEndpoint(endpoint: string): Transport {
   if (endpoint.startsWith('tcp://')) {
     const { TCPTransport } = require('./tcp');
@@ -192,3 +196,4 @@ export function parseEndpoint(endpoint: string): Transport {
 
   throw new Error(`Unsupported endpoint format: ${endpoint}`);
 }
+/* eslint-enable @typescript-eslint/no-require-imports */


### PR DESCRIPTION
## Summary

Addresses the genuine eslint **errors** in agenkit-ts. `tsc` remains **0 errors** throughout.

Investigation reframed task #29: the "~113" estimate was actually **274 errors** (247 mechanical `no-unused-vars` + 18 real) + 291 `no-explicit-any` **warnings**. Per scope decision, this PR fixes **the 18 real errors**; the mechanical `no-unused-vars` and `any`-warnings are left (eslint is not a CI gate; folds into the ruff migration #20).

## The 18 fixes
- **no-case-declarations** → brace-wrap case blocks (`prompt-optimizer`, `agents-as-tools`)
- **no-useless-escape** → `[.)]` in a `plan-and-solve` regex
- **no-self-assign** → removed a dead `msgCopy.timestamp = msgCopy.timestamp` (`checkpoint`)
- **no-constant-condition** → `while (true)` → `for (;;)` (`load-balancer`)
- **no-this-alias** → `recorder.wrap` uses an arrow fn closing over `this`
- **require-yield** → `eslint-disable` on an intentional throw-before-yield test fixture
- **no-require-imports** (9):
  - `transport.ts` → documented `eslint-disable` (the lazy `require()` is intentional — avoids eagerly loading every transport's heavy deps like gRPC)
  - `evaluation/index.ts` → the 4 `require('./metrics')` were **load-bearing** (the `./metrics` line is a re-`export`, which creates no local binding). Added a real `import` + removed the requires. *(Caught + fixed a tsc regression here mid-change.)*
  - `react.test.ts` → removed a dead `require` (the binding was unused)
- **prefer-const** (9) → auto-fixed via `eslint --fix` (3 test files, `let`→`const`)

## Validation
- `tsc --noEmit`: **0 errors**
- eslint errors now exclusively `no-unused-vars` (down from 18 mixed real errors)
- touched-area tests pass; full suite via CI Smoke Test

🤖 Generated with [Claude Code](https://claude.com/claude-code)