### PR TITLE
chore: migrate Python formatter black -> ruff format

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   # Basic formatting checks only - detailed linting runs locally
   format-check:
-    name: Format Check (Python Black + Go fmt)
+    name: Format Check (Python ruff format + Go fmt)
     # push/schedule -> self-hosted Linux (janus, fast); PRs (incl. forks) ->
     # GitHub-hosted, so untrusted PR code never runs on the LAN runner.
     runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || fromJSON('["self-hosted","Linux"]') }}
@@ -33,13 +33,10 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v4
 
-      # Use the repo's locked black (via uv) so CI and local `make format`
-      # never disagree on formatting — pinning avoids version skew where a
-      # newer black reformats files the locked version leaves alone.
-      # --extra dev installs black (a dev dependency); without it uv can't
-      # find black to run.
-      - name: Check Python formatting (Black)
-        run: uv run --extra dev black --check agenkit/ tests/ || (echo "❌ Python code not formatted. Run 'make format' to fix" && exit 1)
+      # Use the repo's locked ruff (via uv --extra dev) so CI and local
+      # `make format` agree — pinning avoids formatter version skew.
+      - name: Check Python formatting (ruff format)
+        run: uv run --extra dev ruff format --check agenkit/ tests/ || (echo "❌ Python code not formatted. Run 'make format' to fix" && exit 1)
 
       - name: Check Go formatting (gofmt)
         working-directory: agenkit-go

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -200,7 +200,7 @@ make test-lint
 - [ ] All operations use `uv run` prefix
 - [ ] Regex patterns use raw strings (`r"..."`)
 - [ ] Type hints present on function signatures
-- [ ] Code passes ruff, black, mypy without warnings
+- [ ] Code passes ruff (check + format), mypy without warnings
 - [ ] Exception handlers include noqa comments explaining why
 
 ### All Languages

--- a/Makefile
+++ b/Makefile
@@ -54,18 +54,18 @@ install: ## Install development dependencies
 	@echo ""
 	@echo "Go dependencies are managed by go.mod"
 
-format: ## Format code (Python: black, Go: gofmt)
+format: ## Format code (Python: ruff format, Go: gofmt)
 	@echo "Formatting Python code..."
-	@black agenkit/ tests/ examples/
+	@ruff format agenkit/ tests/ examples/
 	@echo "Formatting Go code..."
 	@cd agenkit-go && gofmt -s -w .
 	@echo "✓ Code formatted"
 
 lint: ## Run linters only (no tests)
-	@echo "Running Ruff..."
+	@echo "Running Ruff check..."
 	@ruff check agenkit/ tests/
-	@echo "Running Black check..."
-	@black --check agenkit/ tests/
+	@echo "Running Ruff format check..."
+	@ruff format --check agenkit/ tests/
 	@echo "Running go fmt check..."
 	@cd agenkit-go && gofmt -s -l . | grep -v "^examples/" || echo "✓ Go code formatted"
 	@echo "Running go vet..."

--- a/agenkit/adapters/llm/bedrock.py
+++ b/agenkit/adapters/llm/bedrock.py
@@ -19,8 +19,7 @@ try:
     from botocore.exceptions import ClientError
 except ImportError as e:
     raise ImportError(
-        "The boto3 package is required to use BedrockLLM. "
-        "Install it with: pip install agenkit[aws]"
+        "The boto3 package is required to use BedrockLLM. Install it with: pip install agenkit[aws]"
     ) from e
 
 

--- a/agenkit/evaluation/ab_testing.py
+++ b/agenkit/evaluation/ab_testing.py
@@ -352,7 +352,8 @@ class ABTest:
 
         for _ in range(n_iterations):
             control_resample = [
-                random.choice(control_samples) for _ in range(len(control_samples))  # noqa: S311
+                random.choice(control_samples)
+                for _ in range(len(control_samples))  # noqa: S311
             ]
             treatment_resample = [
                 random.choice(treatment_samples)  # noqa: S311

--- a/agenkit/middleware/caching.py
+++ b/agenkit/middleware/caching.py
@@ -55,9 +55,7 @@ class AsyncRWLock:
                         self._readers -= 1
                     if self._readers == 0:
                         self._write_ok.notify()
-            except (
-                Exception
-            ):  # noqa: BLE001 — last-ditch cleanup during CancelledError, all exceptions must be suppressed
+            except Exception:  # noqa: BLE001 — last-ditch cleanup during CancelledError, all exceptions must be suppressed
                 pass
             raise
 
@@ -88,9 +86,7 @@ class AsyncRWLock:
                     self._writer = False
                     self._read_ok.notify_all()
                     self._write_ok.notify()
-            except (
-                Exception
-            ):  # noqa: BLE001 — last-ditch cleanup during CancelledError, all exceptions must be suppressed
+            except Exception:  # noqa: BLE001 — last-ditch cleanup during CancelledError, all exceptions must be suppressed
                 pass
             raise
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,6 @@ dev = [
     "pytest-xdist>=3.5.0",
     "mypy>=1.5.0",
     "ruff>=0.1.0",
-    "black>=23.0.0",
     "bandit>=1.7.5",
     "pylint>=3.0.0",
     "hypothesis>=6.0.0",
@@ -340,10 +339,6 @@ ignore = [
 
 [tool.ruff.lint.isort]
 known-first-party = ["agenkit"]
-
-[tool.black]
-line-length = 100
-target-version = ["py312", "py313", "py314"]
 
 [tool.coverage.run]
 source = ["agenkit"]

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -31,7 +31,7 @@ make test
 make test          # Run all tests (fast, ~15-30s)
 make test-quick    # Run quick tests only (~10s, skip integration)
 make test-lint     # Run tests with linting (slower, CI-equivalent)
-make format        # Format code (Python: black, Go: gofmt)
+make format        # Format code (Python: ruff format, Go: gofmt)
 make lint          # Run linters only (no tests)
 make pre-commit    # Format + test (recommended before commit)
 make coverage      # Generate coverage reports
@@ -78,7 +78,7 @@ make test-lint     # Slower but thorough, matches CI
 
 CI now runs minimal smoke tests only:
 - **test.yml**: Quick unit tests (Python + Go, no integration)
-- **lint.yml**: Basic formatting check (Black + gofmt)
+- **lint.yml**: Basic formatting check (ruff format + gofmt)
 
 Purpose: Catch obvious regressions, not primary validation.
 

--- a/scripts/test-local.sh
+++ b/scripts/test-local.sh
@@ -87,8 +87,8 @@ if [ "$LINT" = true ]; then
     run_step "Ruff (Python linter)" \
         ruff check agenkit/ tests/
 
-    run_step "Black (Python formatter)" \
-        black --check agenkit/ tests/
+    run_step "ruff format (Python formatter)" \
+        ruff format --check agenkit/ tests/
 
     cd "$REPO_ROOT/agenkit-go"
     run_step "go fmt check" \

--- a/tests/chaos/test_partial_failures.py
+++ b/tests/chaos/test_partial_failures.py
@@ -149,17 +149,17 @@ async def test_partial_failure_with_retry():
                     await asyncio.sleep(0.01)
 
     # Retry should significantly improve success rate
-    assert (
-        successes_with_retry > successes_no_retry
-    ), f"Retry ({successes_with_retry}) should improve success rate over no retry ({successes_no_retry})"
+    assert successes_with_retry > successes_no_retry, (
+        f"Retry ({successes_with_retry}) should improve success rate over no retry ({successes_no_retry})"
+    )
 
     # With 70% failure rate and 5 retries:
     # - Theoretical success rate: 1 - 0.7^5 = 83.2%
     # - Expected successes: 16.64 out of 20
     # - Allow variance: accept >= 15 successes (75%)
-    assert (
-        successes_with_retry >= 15
-    ), f"Expected >=15 successes with retry (75% success rate), got {successes_with_retry}"
+    assert successes_with_retry >= 15, (
+        f"Expected >=15 successes with retry (75% success rate), got {successes_with_retry}"
+    )
 
 
 # ============================================

--- a/tests/chaos/test_slow_responses.py
+++ b/tests/chaos/test_slow_responses.py
@@ -119,9 +119,9 @@ async def test_gradual_performance_degradation():
 
     assert elapsed5 >= 0.06, f"6th request should take >=60ms, took {elapsed5:.3f}s"
     # Later requests should be significantly slower (use 2x multiplier to handle timing variance)
-    assert (
-        elapsed5 > elapsed1 * 2
-    ), f"6th request ({elapsed5:.3f}s) should be > 2x first request ({elapsed1:.3f}s)"
+    assert elapsed5 > elapsed1 * 2, (
+        f"6th request ({elapsed5:.3f}s) should be > 2x first request ({elapsed1:.3f}s)"
+    )
 
 
 @pytest.mark.asyncio
@@ -176,9 +176,9 @@ async def test_tail_latency_spikes():
 
     # Also check that max latency shows spikes exist
     max_latency = latencies[-1]
-    assert (
-        max_latency > 0.15
-    ), f"Max latency ({max_latency * 1000:.1f}ms) should show spikes (>150ms)"
+    assert max_latency > 0.15, (
+        f"Max latency ({max_latency * 1000:.1f}ms) should show spikes (>150ms)"
+    )
 
 
 # ============================================
@@ -346,14 +346,14 @@ async def test_performance_under_sustained_load():
     # Concurrent should be significantly faster (at least 3x faster)
     # Sequential: ~0.50s, Concurrent: ~0.05s
     # Use conservative 2x threshold to handle timing variance
-    assert (
-        concurrent_time * 2 < sequential_time
-    ), f"Concurrent ({concurrent_time:.2f}s) should be <50% of sequential ({sequential_time:.2f}s)"
+    assert concurrent_time * 2 < sequential_time, (
+        f"Concurrent ({concurrent_time:.2f}s) should be <50% of sequential ({sequential_time:.2f}s)"
+    )
 
     # Verify concurrent execution actually happened
-    assert (
-        agent._max_concurrent >= 5
-    ), f"Should have seen significant concurrency, got max={agent._max_concurrent}"
+    assert agent._max_concurrent >= 5, (
+        f"Should have seen significant concurrency, got max={agent._max_concurrent}"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/cross_language/harness_manager.py
+++ b/tests/cross_language/harness_manager.py
@@ -225,16 +225,14 @@ class HarnessManager:
         request_json = json.dumps(request)
 
         # Execute harness
-        result = (
-            subprocess.run(  # noqa: S603 - Test harness executable paths are controlled and trusted
-                [str(executable)],
-                input=request_json,
-                capture_output=True,
-                text=True,
-                timeout=timeout,
-                env=env,
-                check=False,  # Don't raise on non-zero exit
-            )
+        result = subprocess.run(  # noqa: S603 - Test harness executable paths are controlled and trusted
+            [str(executable)],
+            input=request_json,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            env=env,
+            check=False,  # Don't raise on non-zero exit
         )
 
         # Check for errors

--- a/tests/cross_language/harness_python.py
+++ b/tests/cross_language/harness_python.py
@@ -726,7 +726,7 @@ def execute_test(  # noqa: PLR0911, PLR0915 - Test harness dispatcher handles al
                 spec_result = {
                     "checkpoints_created": checkpoints_created,
                     "checkpoint_locations": [
-                        f"checkpoint_{i*checkpoint_interval}" for i in range(checkpoints_created)
+                        f"checkpoint_{i * checkpoint_interval}" for i in range(checkpoints_created)
                     ],
                 }
             elif config.get("stop_condition"):
@@ -1212,7 +1212,7 @@ def execute_test(  # noqa: PLR0911, PLR0915 - Test harness dispatcher handles al
                     agents_value = transformed_metadata.get("collaboration_agents", [])
                     if isinstance(agents_value, int):
                         agents_count = agents_value
-                        agents_list = [f"agent{i+1}" for i in range(agents_count)]
+                        agents_list = [f"agent{i + 1}" for i in range(agents_count)]
                     else:
                         agents_list = agents_value
                         agents_count = len(agents_list)

--- a/tests/cross_language/test_api_consistency.py
+++ b/tests/cross_language/test_api_consistency.py
@@ -74,9 +74,9 @@ class TestParameterNaming:
         assert "max_attempts" not in param_names, "Deprecated max_attempts should be removed"
         assert "initial_backoff" not in param_names, "Deprecated initial_backoff should be removed"
         assert "max_backoff" not in param_names, "Deprecated max_backoff should be removed"
-        assert (
-            "backoff_multiplier" not in param_names
-        ), "Deprecated backoff_multiplier should be removed"
+        assert "backoff_multiplier" not in param_names, (
+            "Deprecated backoff_multiplier should be removed"
+        )
 
     def test_timeout_parameter_names(self):
         """Verify TimeoutMiddleware parameter names clearly indicate units."""
@@ -128,9 +128,9 @@ class TestDefaultValues:
         else:
             pytest.fail("TimeoutConfig has no recognizable timeout attribute")
 
-        assert (
-            actual_ms == expected_ms
-        ), f"TimeoutConfig default should be {expected_ms}ms (30 seconds), got {actual_ms}ms"
+        assert actual_ms == expected_ms, (
+            f"TimeoutConfig default should be {expected_ms}ms (30 seconds), got {actual_ms}ms"
+        )
 
     def test_retry_defaults(self):
         """Verify RetryMiddleware default configuration values."""
@@ -145,9 +145,9 @@ class TestDefaultValues:
 
         # Check max_retries
         expected_max_retries = defaults["max_retries"]["value"]
-        assert (
-            config.max_retries == expected_max_retries
-        ), f"max_retries default should be {expected_max_retries}"
+        assert config.max_retries == expected_max_retries, (
+            f"max_retries default should be {expected_max_retries}"
+        )
 
         # Check initial_delay (convert to ms)
         expected_initial_delay_ms = defaults["initial_delay"]["value_ms"]
@@ -158,9 +158,9 @@ class TestDefaultValues:
         else:
             pytest.fail("RetryConfig has no recognizable initial_delay attribute")
 
-        assert (
-            actual_delay_ms == expected_initial_delay_ms
-        ), f"initial_delay default should be {expected_initial_delay_ms}ms"
+        assert actual_delay_ms == expected_initial_delay_ms, (
+            f"initial_delay default should be {expected_initial_delay_ms}ms"
+        )
 
         # Check max_delay (convert to ms)
         expected_max_delay_ms = defaults["max_delay"]["value_ms"]
@@ -171,15 +171,15 @@ class TestDefaultValues:
         else:
             pytest.fail("RetryConfig has no recognizable max_delay attribute")
 
-        assert (
-            actual_max_delay_ms == expected_max_delay_ms
-        ), f"max_delay default should be {expected_max_delay_ms}ms"
+        assert actual_max_delay_ms == expected_max_delay_ms, (
+            f"max_delay default should be {expected_max_delay_ms}ms"
+        )
 
         # Check multiplier
         expected_multiplier = defaults["multiplier"]["value"]
-        assert (
-            config.multiplier == expected_multiplier
-        ), f"multiplier default should be {expected_multiplier}"
+        assert config.multiplier == expected_multiplier, (
+            f"multiplier default should be {expected_multiplier}"
+        )
 
     def test_retry_using_new_parameter_names(self):
         """Verify RetryConfig works correctly when using new parameter names."""
@@ -208,15 +208,15 @@ class TestDefaultValues:
 
         # Check rate
         expected_rate = defaults["rate"]["value"]
-        assert (
-            config.rate == expected_rate
-        ), f"rate default should be {expected_rate} requests/second"
+        assert config.rate == expected_rate, (
+            f"rate default should be {expected_rate} requests/second"
+        )
 
         # Check capacity
         expected_capacity = defaults["capacity"]["value"]
-        assert (
-            config.capacity == expected_capacity
-        ), f"capacity default should be {expected_capacity}"
+        assert config.capacity == expected_capacity, (
+            f"capacity default should be {expected_capacity}"
+        )
 
     def test_circuit_breaker_defaults(self):
         """Verify CircuitBreakerMiddleware default configuration values."""
@@ -231,15 +231,15 @@ class TestDefaultValues:
 
         # Check failure_threshold
         expected_failure_threshold = defaults["failure_threshold"]["value"]
-        assert (
-            config.failure_threshold == expected_failure_threshold
-        ), f"failure_threshold default should be {expected_failure_threshold}"
+        assert config.failure_threshold == expected_failure_threshold, (
+            f"failure_threshold default should be {expected_failure_threshold}"
+        )
 
         # Check success_threshold
         expected_success_threshold = defaults["success_threshold"]["value"]
-        assert (
-            config.success_threshold == expected_success_threshold
-        ), f"success_threshold default should be {expected_success_threshold}"
+        assert config.success_threshold == expected_success_threshold, (
+            f"success_threshold default should be {expected_success_threshold}"
+        )
 
         # Check timeout (convert to ms)
         expected_timeout_ms = defaults["timeout"]["value_ms"]
@@ -250,9 +250,9 @@ class TestDefaultValues:
         else:
             pytest.fail("CircuitBreakerConfig has no recognizable timeout attribute")
 
-        assert (
-            actual_timeout_ms == expected_timeout_ms
-        ), f"timeout default should be {expected_timeout_ms}ms"
+        assert actual_timeout_ms == expected_timeout_ms, (
+            f"timeout default should be {expected_timeout_ms}ms"
+        )
 
         # Check recovery_timeout (convert to ms)
         expected_recovery_ms = defaults["recovery_timeout"]["value_ms"]
@@ -263,9 +263,9 @@ class TestDefaultValues:
         else:
             pytest.fail("CircuitBreakerConfig has no recognizable recovery_timeout attribute")
 
-        assert (
-            actual_recovery_ms == expected_recovery_ms
-        ), f"recovery_timeout default should be {expected_recovery_ms}ms"
+        assert actual_recovery_ms == expected_recovery_ms, (
+            f"recovery_timeout default should be {expected_recovery_ms}ms"
+        )
 
 
 class TestInterfaceSignatures:
@@ -281,17 +281,17 @@ class TestInterfaceSignatures:
 
         # Python should have: self, params (dict[str, Any])
         assert "self" in params
-        assert (
-            "params" in params or "kwargs" in params
-        ), "Tool.execute should accept params or **kwargs"
+        assert "params" in params or "kwargs" in params, (
+            "Tool.execute should accept params or **kwargs"
+        )
 
         # Check return type annotation if available
         if sig.return_annotation != inspect.Signature.empty:
             # Should return ToolResult (or awaitable ToolResult for async)
             return_type_str = str(sig.return_annotation)
-            assert (
-                "ToolResult" in return_type_str
-            ), f"Tool.execute should return ToolResult, got {return_type_str}"
+            assert "ToolResult" in return_type_str, (
+                f"Tool.execute should return ToolResult, got {return_type_str}"
+            )
 
     def test_agent_process_signature(self):
         """Verify Agent.process() method signature matches specification."""
@@ -308,9 +308,9 @@ class TestInterfaceSignatures:
         # Check return type annotation if available
         if sig.return_annotation != inspect.Signature.empty:
             return_type_str = str(sig.return_annotation)
-            assert (
-                "Message" in return_type_str
-            ), f"Agent.process should return Message, got {return_type_str}"
+            assert "Message" in return_type_str, (
+                f"Agent.process should return Message, got {return_type_str}"
+            )
 
 
 class TestErrorTypes:

--- a/tests/cross_language/test_retry_behavior.py
+++ b/tests/cross_language/test_retry_behavior.py
@@ -115,9 +115,9 @@ class TestRetryBehavior:
         # Verify delay is within expected range
         min_delay = expected.get("min_total_delay_ms", 0)
         max_delay = expected.get("max_total_delay_ms", float("inf"))
-        assert (
-            min_delay <= elapsed_ms <= max_delay * 1.5
-        ), f"Delay {elapsed_ms}ms not in range [{min_delay}, {max_delay}]"
+        assert min_delay <= elapsed_ms <= max_delay * 1.5, (
+            f"Delay {elapsed_ms}ms not in range [{min_delay}, {max_delay}]"
+        )
 
     @pytest.mark.asyncio
     async def test_retries_exhausted(self):
@@ -176,9 +176,9 @@ class TestRetryBehavior:
         # Expected: 100ms + 200ms + 400ms = 700ms
         min_delay = expected.get("min_total_delay_ms", 0)
         max_delay = expected.get("max_total_delay_ms", float("inf"))
-        assert (
-            min_delay <= elapsed_ms <= max_delay * 1.5
-        ), f"Delay {elapsed_ms}ms not in range [{min_delay}, {max_delay}]"
+        assert min_delay <= elapsed_ms <= max_delay * 1.5, (
+            f"Delay {elapsed_ms}ms not in range [{min_delay}, {max_delay}]"
+        )
 
     @pytest.mark.asyncio
     async def test_max_backoff_cap(self):
@@ -212,9 +212,9 @@ class TestRetryBehavior:
         # Verify capped backoff: 100ms + 200ms (capped) + 200ms (capped) + 200ms (capped) = 700ms
         min_delay = expected.get("min_total_delay_ms", 0)
         max_delay = expected.get("max_total_delay_ms", float("inf"))
-        assert (
-            min_delay <= elapsed_ms <= max_delay * 1.5
-        ), f"Delay {elapsed_ms}ms not in range [{min_delay}, {max_delay}]"
+        assert min_delay <= elapsed_ms <= max_delay * 1.5, (
+            f"Delay {elapsed_ms}ms not in range [{min_delay}, {max_delay}]"
+        )
 
     @pytest.mark.asyncio
     async def test_non_retryable_error(self):

--- a/tests/middleware/test_circuit_breaker.py
+++ b/tests/middleware/test_circuit_breaker.py
@@ -75,9 +75,9 @@ async def test_circuit_breaker_closed():
 
     metrics = cb.metrics
     assert metrics.total_requests == 3, f"Expected 3 total requests, got {metrics.total_requests}"
-    assert (
-        metrics.successful_requests == 3
-    ), f"Expected 3 successful requests, got {metrics.successful_requests}"
+    assert metrics.successful_requests == 3, (
+        f"Expected 3 successful requests, got {metrics.successful_requests}"
+    )
 
 
 @pytest.mark.asyncio
@@ -106,9 +106,9 @@ async def test_circuit_breaker_opens():
     assert cb.state == CircuitState.OPEN, f"Expected OPEN state, got {cb.state.value}"
 
     metrics = cb.metrics
-    assert (
-        metrics.failed_requests == 3
-    ), f"Expected 3 failed requests, got {metrics.failed_requests}"
+    assert metrics.failed_requests == 3, (
+        f"Expected 3 failed requests, got {metrics.failed_requests}"
+    )
 
 
 @pytest.mark.asyncio
@@ -144,9 +144,9 @@ async def test_circuit_breaker_rejects_when_open():
     assert "OPEN" in str(exc_info.value), "Expected CircuitBreakerError with OPEN message"
 
     metrics = cb.metrics
-    assert (
-        metrics.rejected_requests == 1
-    ), f"Expected 1 rejected request, got {metrics.rejected_requests}"
+    assert metrics.rejected_requests == 1, (
+        f"Expected 1 rejected request, got {metrics.rejected_requests}"
+    )
 
 
 @pytest.mark.asyncio
@@ -219,18 +219,18 @@ async def test_circuit_breaker_recovery():
         assert response.content == "success", f"Attempt {i + 1}: Expected 'success'"
 
     # Circuit should be closed
-    assert (
-        cb.state == CircuitState.CLOSED
-    ), f"Expected CLOSED state after recovery, got {cb.state.value}"
+    assert cb.state == CircuitState.CLOSED, (
+        f"Expected CLOSED state after recovery, got {cb.state.value}"
+    )
 
     metrics = cb.metrics
     assert metrics.state_changes.get("closed->open", 0) == 1, "Expected 1 closed->open transition"
-    assert (
-        metrics.state_changes.get("open->half_open", 0) == 1
-    ), "Expected 1 open->half_open transition"
-    assert (
-        metrics.state_changes.get("half_open->closed", 0) == 1
-    ), "Expected 1 half_open->closed transition"
+    assert metrics.state_changes.get("open->half_open", 0) == 1, (
+        "Expected 1 open->half_open transition"
+    )
+    assert metrics.state_changes.get("half_open->closed", 0) == 1, (
+        "Expected 1 half_open->closed transition"
+    )
 
 
 @pytest.mark.asyncio
@@ -269,14 +269,14 @@ async def test_circuit_breaker_reopens_from_half_open():
     with pytest.raises(Exception):
         await cb.process(msg)
 
-    assert (
-        cb.state == CircuitState.OPEN
-    ), f"Expected OPEN state after failure in half-open, got {cb.state.value}"
+    assert cb.state == CircuitState.OPEN, (
+        f"Expected OPEN state after failure in half-open, got {cb.state.value}"
+    )
 
     metrics = cb.metrics
-    assert (
-        metrics.state_changes.get("half_open->open", 0) == 1
-    ), "Expected 1 half_open->open transition"
+    assert metrics.state_changes.get("half_open->open", 0) == 1, (
+        "Expected 1 half_open->open transition"
+    )
 
 
 @pytest.mark.asyncio
@@ -302,14 +302,14 @@ async def test_circuit_breaker_timeout():
             await cb.process(msg)
 
     # Circuit should be open due to timeouts
-    assert (
-        cb.state == CircuitState.OPEN
-    ), f"Expected OPEN state after timeouts, got {cb.state.value}"
+    assert cb.state == CircuitState.OPEN, (
+        f"Expected OPEN state after timeouts, got {cb.state.value}"
+    )
 
     metrics = cb.metrics
-    assert (
-        metrics.failed_requests == 2
-    ), f"Expected 2 failed requests, got {metrics.failed_requests}"
+    assert metrics.failed_requests == 2, (
+        f"Expected 2 failed requests, got {metrics.failed_requests}"
+    )
 
 
 @pytest.mark.asyncio
@@ -339,13 +339,13 @@ async def test_circuit_breaker_metrics():
     metrics = cb.metrics
 
     assert metrics.total_requests == 5, f"Expected 5 total requests, got {metrics.total_requests}"
-    assert (
-        metrics.successful_requests == 2
-    ), f"Expected 2 successful requests, got {metrics.successful_requests}"
-    assert (
-        metrics.failed_requests == 3
-    ), f"Expected 3 failed requests, got {metrics.failed_requests}"
-    assert (
-        metrics.current_state == CircuitState.OPEN
-    ), f"Expected OPEN state, got {metrics.current_state.value}"
+    assert metrics.successful_requests == 2, (
+        f"Expected 2 successful requests, got {metrics.successful_requests}"
+    )
+    assert metrics.failed_requests == 3, (
+        f"Expected 3 failed requests, got {metrics.failed_requests}"
+    )
+    assert metrics.current_state == CircuitState.OPEN, (
+        f"Expected OPEN state, got {metrics.current_state.value}"
+    )
     assert metrics.last_state_change is not None, "Expected last_state_change to be set"

--- a/tests/middleware/test_rate_limiter.py
+++ b/tests/middleware/test_rate_limiter.py
@@ -50,9 +50,9 @@ async def test_rate_limiter_basic():
 
     metrics = rl.metrics
     assert metrics.total_requests == 10, f"Expected 10 total requests, got {metrics.total_requests}"
-    assert (
-        metrics.allowed_requests == 10
-    ), f"Expected 10 allowed requests, got {metrics.allowed_requests}"
+    assert metrics.allowed_requests == 10, (
+        f"Expected 10 allowed requests, got {metrics.allowed_requests}"
+    )
 
 
 @pytest.mark.asyncio
@@ -85,9 +85,9 @@ async def test_rate_limiter_refill():
             break  # Stop on first error
 
     # Should have successfully made around 5 requests (allowing for timing variance)
-    assert (
-        success_count >= 4
-    ), f"Expected at least 4 successful requests after refill, got {success_count}"
+    assert success_count >= 4, (
+        f"Expected at least 4 successful requests after refill, got {success_count}"
+    )
 
 
 @pytest.mark.asyncio
@@ -116,9 +116,9 @@ async def test_rate_limiter_wait():
 
     # Should have waited approximately 200ms (1 token / 5 tokens per second)
     expected_wait = 0.2
-    assert (
-        elapsed >= expected_wait / 2
-    ), f"Expected to wait at least {expected_wait / 2}s, but only waited {elapsed}s"
+    assert elapsed >= expected_wait / 2, (
+        f"Expected to wait at least {expected_wait / 2}s, but only waited {elapsed}s"
+    )
 
     metrics = rl.metrics
     assert metrics.total_wait_time > 0, "Expected non-zero total wait time"
@@ -213,17 +213,17 @@ async def test_rate_limiter_metrics():
     metrics = rl.metrics
 
     assert metrics.total_requests == 5, f"Expected 5 total requests, got {metrics.total_requests}"
-    assert (
-        metrics.allowed_requests == 5
-    ), f"Expected 5 allowed requests, got {metrics.allowed_requests}"
-    assert (
-        metrics.rejected_requests == 0
-    ), f"Expected 0 rejected requests, got {metrics.rejected_requests}"
+    assert metrics.allowed_requests == 5, (
+        f"Expected 5 allowed requests, got {metrics.allowed_requests}"
+    )
+    assert metrics.rejected_requests == 0, (
+        f"Expected 0 rejected requests, got {metrics.rejected_requests}"
+    )
 
     # Current tokens should be near 0
-    assert (
-        metrics.current_tokens <= 1.0
-    ), f"Expected current tokens near 0, got {metrics.current_tokens}"
+    assert metrics.current_tokens <= 1.0, (
+        f"Expected current tokens near 0, got {metrics.current_tokens}"
+    )
 
 
 @pytest.mark.asyncio
@@ -253,6 +253,6 @@ async def test_rate_limiter_high_throughput():
     assert agent.call_count == 100, f"Expected 100 calls, got {agent.call_count}"
 
     metrics = rl.metrics
-    assert (
-        metrics.allowed_requests == 100
-    ), f"Expected 100 allowed requests, got {metrics.allowed_requests}"
+    assert metrics.allowed_requests == 100, (
+        f"Expected 100 allowed requests, got {metrics.allowed_requests}"
+    )

--- a/tests/parity/test_feature_detection.py
+++ b/tests/parity/test_feature_detection.py
@@ -307,9 +307,9 @@ class TestFeatureManifest:
             for category, items in features.items():
                 if isinstance(items, list):
                     # Check for duplicates
-                    assert len(items) == len(
-                        set(items)
-                    ), f"Duplicates found in {lang}.{category}: {items}"
+                    assert len(items) == len(set(items)), (
+                        f"Duplicates found in {lang}.{category}: {items}"
+                    )
 
 
 @pytest.mark.parametrize(
@@ -329,6 +329,6 @@ def test_scanner_min_feature_count(scanner, expected_count):
         for cat in ["patterns", "middleware", "llm_adapters", "memory", "techniques"]
     )
 
-    assert (
-        total_features >= expected_count
-    ), f"{scanner.__name__} found {total_features} features, expected >= {expected_count}"
+    assert total_features >= expected_count, (
+        f"{scanner.__name__} found {total_features} features, expected >= {expected_count}"
+    )

--- a/tests/parity/test_matrix_generation.py
+++ b/tests/parity/test_matrix_generation.py
@@ -222,9 +222,9 @@ class TestDataIntegrity:
 
             manifest_total = feature_manifest["summary"]["total"].get(lang, 0)
 
-            assert (
-                total == manifest_total
-            ), f"{lang}: matrix shows {total} but manifest has {manifest_total}"
+            assert total == manifest_total, (
+                f"{lang}: matrix shows {total} but manifest has {manifest_total}"
+            )
 
     def test_parity_percentages_calculated_correctly(self, feature_manifest, test_report):
         """Verify parity percentages are calculated correctly."""
@@ -237,6 +237,6 @@ class TestDataIntegrity:
         for stat in matrix_data["summary_stats"]:
             if python_total > 0:
                 expected_parity = round(stat["total_features"] / python_total * 100, 1)
-                assert (
-                    abs(stat["parity_percent"] - expected_parity) < 0.1
-                ), f"{stat['language']}: parity mismatch"
+                assert abs(stat["parity_percent"] - expected_parity) < 0.1, (
+                    f"{stat['language']}: parity mismatch"
+                )

--- a/tests/patterns/test_planning.py
+++ b/tests/patterns/test_planning.py
@@ -11,11 +11,14 @@ from agenkit.patterns import Plan, PlanningAgent, PlanStep, StepStatus
 # Mock Planning Agent
 class MockPlanningAgent:
     def __init__(self, plan_text=None):
-        self.plan_text = plan_text or """Goal: Test goal
+        self.plan_text = (
+            plan_text
+            or """Goal: Test goal
 Steps:
 1. First step
 2. Second step
 3. Third step"""
+        )
         self.call_count = 0
         self.last_message = None
         self.name = "MockPlanningAgent"
@@ -207,13 +210,15 @@ async def test_planning_agent_executes_steps():
 @pytest.mark.asyncio
 async def test_planning_agent_max_steps():
     """Test max_steps limit."""
-    mock_planner = MockPlanningAgent(plan_text="""Goal: Test
+    mock_planner = MockPlanningAgent(
+        plan_text="""Goal: Test
 Steps:
 1. Step 1
 2. Step 2
 3. Step 3
 4. Step 4
-5. Step 5""")
+5. Step 5"""
+    )
 
     agent = PlanningAgent(planner=mock_planner, max_steps=3)
 

--- a/tests/property/test_cache_properties.py
+++ b/tests/property/test_cache_properties.py
@@ -133,9 +133,9 @@ def test_cache_size_never_exceeds_max(max_size, num_requests):
         cache.put(key, value)
 
         # Property: size never exceeds max
-        assert (
-            cache.get_cache_size() <= max_size
-        ), f"Cache size {cache.get_cache_size()} exceeds max {max_size}"
+        assert cache.get_cache_size() <= max_size, (
+            f"Cache size {cache.get_cache_size()} exceeds max {max_size}"
+        )
 
 
 # ============================================
@@ -305,9 +305,9 @@ def test_cache_statistics_consistency(max_size, operations):
 
     # Property: hits + misses = total get requests
     stats = cache.get_stats()
-    assert (
-        stats["hits"] + stats["misses"] == total_gets
-    ), f"hits ({stats['hits']}) + misses ({stats['misses']}) != total gets ({total_gets})"
+    assert stats["hits"] + stats["misses"] == total_gets, (
+        f"hits ({stats['hits']}) + misses ({stats['misses']}) != total gets ({total_gets})"
+    )
 
 
 # ============================================
@@ -332,9 +332,9 @@ def test_cache_size_bounds_after_eviction(max_size, num_entries):
         cache.put(f"key_{i}", Message(role="user", content=f"Value {i}"))
 
     # Property: Cache should be exactly at max_size
-    assert (
-        cache.get_cache_size() == max_size
-    ), f"Cache size {cache.get_cache_size()} should equal max_size {max_size} after eviction"
+    assert cache.get_cache_size() == max_size, (
+        f"Cache size {cache.get_cache_size()} should equal max_size {max_size} after eviction"
+    )
 
 
 # ============================================

--- a/tests/property/test_circuit_breaker_properties.py
+++ b/tests/property/test_circuit_breaker_properties.py
@@ -147,9 +147,9 @@ def test_state_transitions_are_valid(failure_threshold, success_threshold):
         next_state = history[i + 1]
 
         # Property: Transition must be valid
-        assert next_state in valid_transitions.get(
-            current, set()
-        ), f"Invalid transition from {current} to {next_state}"
+        assert next_state in valid_transitions.get(current, set()), (
+            f"Invalid transition from {current} to {next_state}"
+        )
 
 
 # ============================================
@@ -172,17 +172,17 @@ def test_opens_after_exact_threshold(failure_threshold):
     for i in range(failure_threshold - 1):
         cb.record_failure()
         # Should still be CLOSED
-        assert (
-            cb.get_state() == CircuitBreakerState.CLOSED
-        ), f"Should be CLOSED after {i + 1} failures (threshold={failure_threshold})"
+        assert cb.get_state() == CircuitBreakerState.CLOSED, (
+            f"Should be CLOSED after {i + 1} failures (threshold={failure_threshold})"
+        )
 
     # One more failure should open circuit
     cb.record_failure()
 
     # Property: Circuit should be OPEN after exactly failure_threshold failures
-    assert (
-        cb.get_state() == CircuitBreakerState.OPEN
-    ), f"Should be OPEN after {failure_threshold} failures"
+    assert cb.get_state() == CircuitBreakerState.OPEN, (
+        f"Should be OPEN after {failure_threshold} failures"
+    )
     assert cb.get_failure_count() == failure_threshold
 
 
@@ -220,9 +220,9 @@ async def test_transitions_to_half_open_after_timeout(failure_threshold, recover
     # After timeout: should allow request and transition to HALF_OPEN
     # Property: is_request_allowed() returns True and transitions to HALF_OPEN
     assert cb.is_request_allowed(), "Should allow request after recovery timeout"
-    assert (
-        cb.get_state() == CircuitBreakerState.HALF_OPEN
-    ), "Should transition to HALF_OPEN after recovery timeout"
+    assert cb.get_state() == CircuitBreakerState.HALF_OPEN, (
+        "Should transition to HALF_OPEN after recovery timeout"
+    )
 
 
 # ============================================
@@ -259,17 +259,17 @@ async def test_closes_after_success_threshold(failure_threshold, success_thresho
     for i in range(success_threshold - 1):
         cb.record_success()
         # Should still be HALF_OPEN
-        assert (
-            cb.get_state() == CircuitBreakerState.HALF_OPEN
-        ), f"Should be HALF_OPEN after {i + 1} successes (threshold={success_threshold})"
+        assert cb.get_state() == CircuitBreakerState.HALF_OPEN, (
+            f"Should be HALF_OPEN after {i + 1} successes (threshold={success_threshold})"
+        )
 
     # One more success should close circuit
     cb.record_success()
 
     # Property: Circuit should be CLOSED after exactly success_threshold successes
-    assert (
-        cb.get_state() == CircuitBreakerState.CLOSED
-    ), f"Should be CLOSED after {success_threshold} successes"
+    assert cb.get_state() == CircuitBreakerState.CLOSED, (
+        f"Should be CLOSED after {success_threshold} successes"
+    )
 
 
 # ============================================
@@ -344,9 +344,9 @@ def test_open_circuit_blocks_requests(failure_threshold, num_attempts):
         if not cb.is_request_allowed():
             blocked_count += 1
 
-    assert (
-        blocked_count == num_attempts
-    ), f"All {num_attempts} requests should be blocked in OPEN state"
+    assert blocked_count == num_attempts, (
+        f"All {num_attempts} requests should be blocked in OPEN state"
+    )
 
 
 # ============================================
@@ -410,9 +410,9 @@ async def test_half_open_failure_immediately_opens(failure_threshold):
     cb.record_failure()
 
     # Property: Should immediately transition back to OPEN
-    assert (
-        cb.get_state() == CircuitBreakerState.OPEN
-    ), "Failure in HALF_OPEN should immediately transition to OPEN"
+    assert cb.get_state() == CircuitBreakerState.OPEN, (
+        "Failure in HALF_OPEN should immediately transition to OPEN"
+    )
 
 
 if __name__ == "__main__":

--- a/tests/property/test_message_properties.py
+++ b/tests/property/test_message_properties.py
@@ -141,9 +141,9 @@ def test_metadata_type_preservation(metadata):
         elif isinstance(original_value, int):
             assert isinstance(deserialized_value, int), f"Int type for {key} should be preserved"
         elif isinstance(original_value, float):
-            assert isinstance(
-                deserialized_value, float
-            ), f"Float type for {key} should be preserved"
+            assert isinstance(deserialized_value, float), (
+                f"Float type for {key} should be preserved"
+            )
         elif isinstance(original_value, str):
             assert isinstance(deserialized_value, str), f"String type for {key} should be preserved"
 
@@ -168,9 +168,9 @@ def test_serialized_size_is_reasonable(message):
 
     actual_size = len(serialized)
 
-    assert (
-        actual_size <= expected_max_size
-    ), f"Serialized size {actual_size} too large (expected <={expected_max_size})"
+    assert actual_size <= expected_max_size, (
+        f"Serialized size {actual_size} too large (expected <={expected_max_size})"
+    )
 
 
 # ============================================
@@ -215,9 +215,9 @@ def test_unicode_content_preservation(unicode_content):
     deserialized = deserialize_message(serialized)
 
     # Property: Unicode characters should be preserved exactly
-    assert (
-        deserialized.content == unicode_content
-    ), f"Unicode content not preserved: expected {unicode_content!r}, got {deserialized.content!r}"
+    assert deserialized.content == unicode_content, (
+        f"Unicode content not preserved: expected {unicode_content!r}, got {deserialized.content!r}"
+    )
 
 
 # ============================================
@@ -267,9 +267,9 @@ def test_large_metadata_handling(num_keys):
     deserialized = deserialize_message(serialized)
 
     # Property: All metadata keys should be preserved
-    assert (
-        len(deserialized.metadata) == num_keys
-    ), f"Expected {num_keys} keys, got {len(deserialized.metadata)}"
+    assert len(deserialized.metadata) == num_keys, (
+        f"Expected {num_keys} keys, got {len(deserialized.metadata)}"
+    )
 
     for i in range(num_keys):
         key = f"key_{i}"

--- a/tests/property/test_retry_properties.py
+++ b/tests/property/test_retry_properties.py
@@ -115,14 +115,14 @@ async def test_retry_count_never_exceeds_max(max_retries):
         await policy.execute(always_fails)
 
     # Property: Total attempts = 1 (initial) + max_retries
-    assert (
-        policy.get_attempt_count() == 1 + max_retries
-    ), f"Expected {1 + max_retries} attempts, got {policy.get_attempt_count()}"
+    assert policy.get_attempt_count() == 1 + max_retries, (
+        f"Expected {1 + max_retries} attempts, got {policy.get_attempt_count()}"
+    )
 
     # Property: Retry count = max_retries
-    assert (
-        policy.get_retry_count() == max_retries
-    ), f"Expected {max_retries} retries, got {policy.get_retry_count()}"
+    assert policy.get_retry_count() == max_retries, (
+        f"Expected {max_retries} retries, got {policy.get_retry_count()}"
+    )
 
 
 # ============================================
@@ -160,9 +160,9 @@ async def test_backoff_delays_are_monotonic(max_retries, initial_delay, multipli
 
     # Property: Each delay should be >= previous delay
     for i in range(1, len(delays)):
-        assert (
-            delays[i] >= delays[i - 1]
-        ), f"Delay {i} ({delays[i]}) should be >= delay {i - 1} ({delays[i - 1]})"
+        assert delays[i] >= delays[i - 1], (
+            f"Delay {i} ({delays[i]}) should be >= delay {i - 1} ({delays[i - 1]})"
+        )
 
 
 # ============================================
@@ -198,9 +198,9 @@ async def test_success_propagates_immediately(success_on_attempt, max_retries):
     result = await policy.execute(succeeds_on_nth_attempt)
 
     # Property: Should stop immediately on success
-    assert (
-        policy.get_attempt_count() == success_on_attempt
-    ), f"Should stop on attempt {success_on_attempt}, got {policy.get_attempt_count()}"
+    assert policy.get_attempt_count() == success_on_attempt, (
+        f"Should stop on attempt {success_on_attempt}, got {policy.get_attempt_count()}"
+    )
 
     assert result == "Success"
 
@@ -264,9 +264,9 @@ async def test_total_attempts_equals_one_plus_retries(max_retries):
         await policy.execute(always_fails)
 
     # Property: attempts = 1 + retries
-    assert (
-        policy.get_attempt_count() == 1 + policy.get_retry_count()
-    ), f"Attempts ({policy.get_attempt_count()}) != 1 + retries ({policy.get_retry_count()})"
+    assert policy.get_attempt_count() == 1 + policy.get_retry_count(), (
+        f"Attempts ({policy.get_attempt_count()}) != 1 + retries ({policy.get_retry_count()})"
+    )
 
 
 # ============================================
@@ -296,9 +296,9 @@ async def test_only_retries_on_configured_exceptions(max_retries):
         await policy.execute(raises_value_error)
 
     # Property: Should not retry (0 retries for non-retryable exception)
-    assert (
-        policy.get_retry_count() == 0
-    ), f"Should not retry non-retryable exception, got {policy.get_retry_count()} retries"
+    assert policy.get_retry_count() == 0, (
+        f"Should not retry non-retryable exception, got {policy.get_retry_count()} retries"
+    )
     assert policy.get_attempt_count() == 1, "Should only attempt once for non-retryable exception"
 
 
@@ -338,9 +338,9 @@ async def test_exponential_growth_formula(max_retries, initial_delay, multiplier
         expected_delay = initial_delay * (multiplier**i)
 
         # Allow small floating point error
-        assert (
-            abs(delay - expected_delay) < 0.001
-        ), f"Delay {i} ({delay}) doesn't match formula ({expected_delay})"
+        assert abs(delay - expected_delay) < 0.001, (
+            f"Delay {i} ({delay}) doesn't match formula ({expected_delay})"
+        )
 
 
 # ============================================
@@ -392,9 +392,9 @@ async def test_delays_length_equals_retry_count(max_retries):
     delays = policy.get_delays()
 
     # Property: len(delays) == retry_count
-    assert (
-        len(delays) == policy.get_retry_count()
-    ), f"Delays length ({len(delays)}) != retry count ({policy.get_retry_count()})"
+    assert len(delays) == policy.get_retry_count(), (
+        f"Delays length ({len(delays)}) != retry count ({policy.get_retry_count()})"
+    )
 
 
 # ============================================
@@ -423,9 +423,9 @@ async def test_first_delay_is_base_delay(initial_delay):
 
     # Property: First delay should be initial delay
     assert len(delays) > 0, "Should have at least one delay"
-    assert (
-        abs(delays[0] - initial_delay) < 0.001
-    ), f"First delay ({delays[0]}) should equal initial_delay ({initial_delay})"
+    assert abs(delays[0] - initial_delay) < 0.001, (
+        f"First delay ({delays[0]}) should equal initial_delay ({initial_delay})"
+    )
 
 
 if __name__ == "__main__":

--- a/tests/skills/test_skill_agent.py
+++ b/tests/skills/test_skill_agent.py
@@ -18,7 +18,7 @@ def make_skill_dir(
 ) -> Path:
     skill_dir = tmp_path / name
     skill_dir.mkdir()
-    content = "---\n" f"name: {name}\n" f"description: {description}\n" "---\n" f"{body}"
+    content = f"---\nname: {name}\ndescription: {description}\n---\n{body}"
     (skill_dir / "SKILL.md").write_text(content, encoding="utf-8")
     return skill_dir
 

--- a/tests/skills/test_skill_loader.py
+++ b/tests/skills/test_skill_loader.py
@@ -17,7 +17,7 @@ def make_skill_dir(
     """Create a minimal valid skill directory inside tmp_path."""
     skill_dir = tmp_path / name
     skill_dir.mkdir()
-    content = "---\n" f"name: {name}\n" f"description: {description}\n" "---\n" f"{body}"
+    content = f"---\nname: {name}\ndescription: {description}\n---\n{body}"
     (skill_dir / "SKILL.md").write_text(content, encoding="utf-8")
     return skill_dir
 

--- a/tests/test_parity_validation.py
+++ b/tests/test_parity_validation.py
@@ -361,9 +361,9 @@ def test_cpp_test_counting_fixed(parity_report: dict[str, Any]) -> None:
 
     # Check the note was updated
     cpp_note = parity_report["languages"]["cpp"].get("note", "")
-    assert (
-        "individual TEST()" in cpp_note or "TEST() macros" in cpp_note
-    ), f"C++ note should mention individual tests: {cpp_note}"
+    assert "individual TEST()" in cpp_note or "TEST() macros" in cpp_note, (
+        f"C++ note should mention individual tests: {cpp_note}"
+    )
 
 
 @pytest.mark.slow
@@ -421,7 +421,7 @@ def test_all_languages_positive_counts(parity_report: dict[str, Any]) -> None:
 
         total = lang_data.get("total", 0)
         assert total > 0, (
-            f"{lang_name.upper()} has zero tests. " "This suggests a counting or build issue."
+            f"{lang_name.upper()} has zero tests. This suggests a counting or build issue."
         )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -62,7 +62,6 @@ benchmarks = [
 ]
 dev = [
     { name = "bandit" },
-    { name = "black" },
     { name = "grpcio-tools" },
     { name = "hypothesis" },
     { name = "jinja2" },
@@ -131,7 +130,6 @@ requires-dist = [
     { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.40.0" },
     { name = "anthropic", marker = "extra == 'llm'", specifier = ">=0.40.0" },
     { name = "bandit", marker = "extra == 'dev'", specifier = ">=1.7.5" },
-    { name = "black", marker = "extra == 'dev'", specifier = ">=23.0.0" },
     { name = "boto3", marker = "extra == 'all'", specifier = ">=1.34.0" },
     { name = "boto3", marker = "extra == 'all-providers'", specifier = ">=1.34.0" },
     { name = "boto3", marker = "extra == 'aws'", specifier = ">=1.34.0" },
@@ -451,38 +449,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/fb/b5/7eb834e213d6f73aace21938e5e90425c92e5f42abafaf8a6d5d21beed51/bandit-1.8.6.tar.gz", hash = "sha256:dbfe9c25fc6961c2078593de55fd19f2559f9e45b99f1272341f5b95dea4e56b", size = 4240271, upload-time = "2025-07-06T03:10:50.9Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/48/ca/ba5f909b40ea12ec542d5d7bdd13ee31c4d65f3beed20211ef81c18fa1f3/bandit-1.8.6-py3-none-any.whl", hash = "sha256:3348e934d736fcdb68b6aa4030487097e23a501adf3e7827b63658df464dddd0", size = 133808, upload-time = "2025-07-06T03:10:49.134Z" },
-]
-
-[[package]]
-name = "black"
-version = "26.5.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "mypy-extensions" },
-    { name = "packaging" },
-    { name = "pathspec" },
-    { name = "platformdirs" },
-    { name = "pytokens" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c0/37/5628dd55bf2b34257fc7603f0fe97c40e3aaf24265f416a9c85c95ca1436/black-26.5.1.tar.gz", hash = "sha256:dd321f668053961824bcc1be1cc1df748b2d7e4fa28086b08331e577b0100a73", size = 679439, upload-time = "2026-05-18T16:53:36.107Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/24/99/7744b906703228264ef73bdd534df88ec1ef3de45c4e78f6d31b9e32d0c9/black-26.5.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:4ad6fa01f941920f54f2bbb35f3df7673428a0ef98a0b0840c2eaef3b110efa8", size = 2012518, upload-time = "2026-05-18T17:05:20.108Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/c0/c5a3b1636dfd09c42534f2b3cf33506814f6d3e066fb0879ffa16c1ae860/black-26.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3915f256e75a2d7cf88d8953d37f780455dc586cc72dee059c528fe77f581217", size = 1816016, upload-time = "2026-05-18T17:05:21.84Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/0e/36044316b65ca471d3bb6d3703fd06fb50c6b727c3562f6a5a3153634f88/black-26.5.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d98d4137277c75dfb898ec8d846c4fd68ba1e9cf77f95e2865c203dc18f4c3d", size = 1884150, upload-time = "2026-05-18T17:05:23.546Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/33/dafc5808c2af43672912111d7c3354af1615f7e2be3bed7a878461abbe4d/black-26.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:a1dca32d9f1784af512a13410ec204c6f7f0aa9797a111c42e1c03449821c264", size = 1486825, upload-time = "2026-05-18T17:05:25.004Z" },
-    { url = "https://files.pythonhosted.org/packages/82/14/b965ee6ad2a311f28bdbf692def3ee9848d2ae289dab28b27657fcee3e78/black-26.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:1037d5ac7b7b310b2632ad867ec8d0e4c4819dcdb0b820f63135da746a24e418", size = 1288646, upload-time = "2026-05-18T17:05:26.477Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/5c/c384363980e11e25ca6b93205949bb331fbf35f4e0dbec376dfa6326cec8/black-26.5.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:2b36cf2ddf5566e205f6535f782a62194a184d33e175b64ae8c40b1737522be3", size = 2009020, upload-time = "2026-05-18T17:05:28.132Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/df/9f31c5e0babbfed77d505fc5d120beb98b21b33feaeded3924ea941fe360/black-26.5.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1f7ea64ebfa01b50f693508fc39f875e264446d3b097088f84f203b9d09618a0", size = 1813335, upload-time = "2026-05-18T17:05:31.266Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/24/8e7b9a2fa61b0afd82209efe937557d180a1fa055bd7f6161eb9defc3719/black-26.5.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ecb3e624844c798144e9bd986954e0adc81d8911a1f30f375e1252fe26e8c294", size = 1881614, upload-time = "2026-05-18T17:05:32.718Z" },
-    { url = "https://files.pythonhosted.org/packages/49/ad/b4e0d9365ba8ac34f6bbab62a4b1b2dd5d618fac3fa1b8db968c844201b5/black-26.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:e1a26503279b6b310669fb0b219c39e4820b77e8189fe80f522bb511f247db0a", size = 1488925, upload-time = "2026-05-18T17:05:34.259Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/4b/652b859bf5df88a751c30451b09338f7fd26a77d1271c666992f836b7711/black-26.5.1-cp313-cp313-win_arm64.whl", hash = "sha256:5c34b25da232ead53a6f335b76dbea124f4d152ad568b9080d6f944bc2b34b52", size = 1289883, upload-time = "2026-05-18T17:05:36.019Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/16/a8da8eb208c51c7f4ce74609a45d0dcc6d8a2141e45e81ee5289d1bb0d59/black-26.5.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:e88976690a64b0af98312ca958415849cb42423423c5f2ee74af4b49a97a2168", size = 2004800, upload-time = "2026-05-18T17:05:38.182Z" },
-    { url = "https://files.pythonhosted.org/packages/11/8a/a479296a19e383b70a725882a6cf3d786540601ff03cabbaaf1cce864c5a/black-26.5.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:32d5ea7f6c8bdfa6e648326ebca1f02b0764e2a029edc6f8dce2627e19d468c3", size = 1815576, upload-time = "2026-05-18T17:05:40.309Z" },
-    { url = "https://files.pythonhosted.org/packages/81/6b/cfaf3d39f25132c156a068f6b805576c9103a84086019507c70e1911ee7d/black-26.5.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ea8d16dc41655aa113cd64665e7219446cd7e4ff2248d7178eaa905190c86b18", size = 1877927, upload-time = "2026-05-18T17:05:42.463Z" },
-    { url = "https://files.pythonhosted.org/packages/66/76/302e313964bcff7e28df329d39f84f5270095730d85ff0acc260610a0d82/black-26.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:577f21094ea469ef92ec1adaf2c9441a226d2144d01a5be2fa823cecf6543e50", size = 1511860, upload-time = "2026-05-18T17:05:43.943Z" },
-    { url = "https://files.pythonhosted.org/packages/27/4e/a3827e35e0e567f9f9ee59e2a0ab979267dca98718f25547ca8c6733afd4/black-26.5.1-cp314-cp314-win_arm64.whl", hash = "sha256:ed1a20af114c301a0269bf01163d51dbef72737fd65f850001e7cbe7f3c7abae", size = 1316632, upload-time = "2026-05-18T17:05:45.521Z" },
-    { url = "https://files.pythonhosted.org/packages/94/51/f975cae76d44274cc2868dc9040ac5d58d464784610234455b4e7b19c6ef/black-26.5.1-py3-none-any.whl", hash = "sha256:4ed7f7da04046d2e488437170797d3b4a4ad83906683bcb7dfc68b673bbce5e2", size = 213693, upload-time = "2026-05-18T16:53:33.964Z" },
 ]
 
 [[package]]
@@ -2368,35 +2334,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
-]
-
-[[package]]
-name = "pytokens"
-version = "0.4.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b6/34/b4e015b99031667a7b960f888889c5bd34ef585c85e1cb56a594b92836ac/pytokens-0.4.1.tar.gz", hash = "sha256:292052fe80923aae2260c073f822ceba21f3872ced9a68bb7953b348e561179a", size = 23015, upload-time = "2026-01-30T01:03:45.924Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/41/5d/e44573011401fb82e9d51e97f1290ceb377800fb4eed650b96f4753b499c/pytokens-0.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:140709331e846b728475786df8aeb27d24f48cbcf7bcd449f8de75cae7a45083", size = 160663, upload-time = "2026-01-30T01:03:06.473Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/e6/5bbc3019f8e6f21d09c41f8b8654536117e5e211a85d89212d59cbdab381/pytokens-0.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d6c4268598f762bc8e91f5dbf2ab2f61f7b95bdc07953b602db879b3c8c18e1", size = 255626, upload-time = "2026-01-30T01:03:08.177Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/3c/2d5297d82286f6f3d92770289fd439956b201c0a4fc7e72efb9b2293758e/pytokens-0.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:24afde1f53d95348b5a0eb19488661147285ca4dd7ed752bbc3e1c6242a304d1", size = 269779, upload-time = "2026-01-30T01:03:09.756Z" },
-    { url = "https://files.pythonhosted.org/packages/20/01/7436e9ad693cebda0551203e0bf28f7669976c60ad07d6402098208476de/pytokens-0.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5ad948d085ed6c16413eb5fec6b3e02fa00dc29a2534f088d3302c47eb59adf9", size = 268076, upload-time = "2026-01-30T01:03:10.957Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/df/533c82a3c752ba13ae7ef238b7f8cdd272cf1475f03c63ac6cf3fcfb00b6/pytokens-0.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:3f901fe783e06e48e8cbdc82d631fca8f118333798193e026a50ce1b3757ea68", size = 103552, upload-time = "2026-01-30T01:03:12.066Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/dc/08b1a080372afda3cceb4f3c0a7ba2bde9d6a5241f1edb02a22a019ee147/pytokens-0.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8bdb9d0ce90cbf99c525e75a2fa415144fd570a1ba987380190e8b786bc6ef9b", size = 160720, upload-time = "2026-01-30T01:03:13.843Z" },
-    { url = "https://files.pythonhosted.org/packages/64/0c/41ea22205da480837a700e395507e6a24425151dfb7ead73343d6e2d7ffe/pytokens-0.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5502408cab1cb18e128570f8d598981c68a50d0cbd7c61312a90507cd3a1276f", size = 254204, upload-time = "2026-01-30T01:03:14.886Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/d2/afe5c7f8607018beb99971489dbb846508f1b8f351fcefc225fcf4b2adc0/pytokens-0.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29d1d8fb1030af4d231789959f21821ab6325e463f0503a61d204343c9b355d1", size = 268423, upload-time = "2026-01-30T01:03:15.936Z" },
-    { url = "https://files.pythonhosted.org/packages/68/d4/00ffdbd370410c04e9591da9220a68dc1693ef7499173eb3e30d06e05ed1/pytokens-0.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:970b08dd6b86058b6dc07efe9e98414f5102974716232d10f32ff39701e841c4", size = 266859, upload-time = "2026-01-30T01:03:17.458Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/c9/c3161313b4ca0c601eeefabd3d3b576edaa9afdefd32da97210700e47652/pytokens-0.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:9bd7d7f544d362576be74f9d5901a22f317efc20046efe2034dced238cbbfe78", size = 103520, upload-time = "2026-01-30T01:03:18.652Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/a7/b470f672e6fc5fee0a01d9e75005a0e617e162381974213a945fcd274843/pytokens-0.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:4a14d5f5fc78ce85e426aa159489e2d5961acf0e47575e08f35584009178e321", size = 160821, upload-time = "2026-01-30T01:03:19.684Z" },
-    { url = "https://files.pythonhosted.org/packages/80/98/e83a36fe8d170c911f864bfded690d2542bfcfacb9c649d11a9e6eb9dc41/pytokens-0.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97f50fd18543be72da51dd505e2ed20d2228c74e0464e4262e4899797803d7fa", size = 254263, upload-time = "2026-01-30T01:03:20.834Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/95/70d7041273890f9f97a24234c00b746e8da86df462620194cef1d411ddeb/pytokens-0.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dc74c035f9bfca0255c1af77ddd2d6ae8419012805453e4b0e7513e17904545d", size = 268071, upload-time = "2026-01-30T01:03:21.888Z" },
-    { url = "https://files.pythonhosted.org/packages/da/79/76e6d09ae19c99404656d7db9c35dfd20f2086f3eb6ecb496b5b31163bad/pytokens-0.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f66a6bbe741bd431f6d741e617e0f39ec7257ca1f89089593479347cc4d13324", size = 271716, upload-time = "2026-01-30T01:03:23.633Z" },
-    { url = "https://files.pythonhosted.org/packages/79/37/482e55fa1602e0a7ff012661d8c946bafdc05e480ea5a32f4f7e336d4aa9/pytokens-0.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:b35d7e5ad269804f6697727702da3c517bb8a5228afa450ab0fa787732055fc9", size = 104539, upload-time = "2026-01-30T01:03:24.788Z" },
-    { url = "https://files.pythonhosted.org/packages/30/e8/20e7db907c23f3d63b0be3b8a4fd1927f6da2395f5bcc7f72242bb963dfe/pytokens-0.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8fcb9ba3709ff77e77f1c7022ff11d13553f3c30299a9fe246a166903e9091eb", size = 168474, upload-time = "2026-01-30T01:03:26.428Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/81/88a95ee9fafdd8f5f3452107748fd04c24930d500b9aba9738f3ade642cc/pytokens-0.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:79fc6b8699564e1f9b521582c35435f1bd32dd06822322ec44afdeba666d8cb3", size = 290473, upload-time = "2026-01-30T01:03:27.415Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/35/3aa899645e29b6375b4aed9f8d21df219e7c958c4c186b465e42ee0a06bf/pytokens-0.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d31b97b3de0f61571a124a00ffe9a81fb9939146c122c11060725bd5aea79975", size = 303485, upload-time = "2026-01-30T01:03:28.558Z" },
-    { url = "https://files.pythonhosted.org/packages/52/a0/07907b6ff512674d9b201859f7d212298c44933633c946703a20c25e9d81/pytokens-0.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:967cf6e3fd4adf7de8fc73cd3043754ae79c36475c1c11d514fc72cf5490094a", size = 306698, upload-time = "2026-01-30T01:03:29.653Z" },
-    { url = "https://files.pythonhosted.org/packages/39/2a/cbbf9250020a4a8dd53ba83a46c097b69e5eb49dd14e708f496f548c6612/pytokens-0.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:584c80c24b078eec1e227079d56dc22ff755e0ba8654d8383b2c549107528918", size = 116287, upload-time = "2026-01-30T01:03:30.912Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/78/397db326746f0a342855b81216ae1f0a32965deccfd7c830a2dbc66d2483/pytokens-0.4.1-py3-none-any.whl", hash = "sha256:26cef14744a8385f35d0e095dc8b3a7583f6c953c2e3d269c7f82484bf5ad2de", size = 13729, upload-time = "2026-01-30T01:03:45.029Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #20. Consolidates Python tooling on **ruff** for both lint (`ruff check`, already configured) and formatting (`ruff format`), dropping `black`.

## Changes
- **pyproject.toml**: remove `black` dep + `[tool.black]` (ruff already had matching `line-length=100`)
- **Makefile / lint.yml / test-local.sh**: `black` → `ruff format` (`--check` in CI)
- **CLAUDE.md / scripts/README.md**: doc updates
- applied `ruff format` — 21 files reformatted (black↔ruff-format edge-case differences)
- **uv.lock**: `black` + `pytokens` removed

## Validation
- `ruff format --check` clean (350 files)
- CI Format Check job now runs ruff (renamed accordingly)

## Note
`ruff check` (the lint *rules*, separate from formatting) has ~370 pre-existing findings — **not introduced here and not a CI gate** (only `ruff format --check` gates). This is the Python analogue of the eslint mechanical debt; tracked separately. This PR is scoped to the formatter swap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)