### PR TITLE
ci: provision Go 1.25.11 for CodeQL go autobuild

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -59,6 +59,15 @@ jobs:
             build-mode: autobuild
     steps:
       - uses: actions/checkout@v4
+      # Go autobuild compiles agenkit-go, whose go.mod requires Go 1.25.11.
+      # Provision that toolchain (and put it first on PATH) so autobuild on the
+      # self-hosted runner doesn't fall back to an older system Go.
+      - name: Set up Go (for go autobuild)
+        if: matrix.language == 'go'
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.25.11"
+          cache: false
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:


### PR DESCRIPTION
After #612 bumped agenkit-go's go.mod directive to 1.25.11, CodeQL's **go autobuild** failed on the janus run — the CodeQL job had no setup-go step, so autobuild used the runner's older default Go, which can't build a `go 1.25.11` module.

Fix: add a conditional `setup-go@v5` (go 1.25.11, cache:false) before Initialize CodeQL, only for the `go` matrix entry. Other languages unaffected.

This is the last piece of the govulncheck/#30 chain — with it, the full janus security run should be green (govulncheck already passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)