### PR TITLE
refactor(go): MCP client cleanup + SkillRegistry.All()

### DIFF
--- a/agenkit-go/protocols/mcp/client.go
+++ b/agenkit-go/protocols/mcp/client.go
@@ -12,6 +12,23 @@ import (
 	"sync/atomic"
 )
 
+const (
+	mcpProtocolVersion = "2024-11-05"
+	mcpClientVersion   = "0.82.0"
+)
+
+// mcpInitParams returns the serialised params for the MCP initialize request.
+func mcpInitParams() (json.RawMessage, error) {
+	return json.Marshal(map[string]interface{}{
+		"protocolVersion": mcpProtocolVersion,
+		"capabilities":    map[string]interface{}{},
+		"clientInfo": map[string]interface{}{
+			"name":    "agenkit",
+			"version": mcpClientVersion,
+		},
+	})
+}
+
 // StdioConfig holds configuration for StdioClient.
 type StdioConfig struct {
 	// Command is the executable to spawn (e.g. "npx", "python").
@@ -76,14 +93,7 @@ func NewStdioClient(ctx context.Context, cfg StdioConfig) (*StdioClient, error) 
 
 // Initialize sends the MCP initialize request and stores server info.
 func (c *StdioClient) Initialize(ctx context.Context) error {
-	params, err := json.Marshal(map[string]interface{}{
-		"protocolVersion": "2024-11-05",
-		"capabilities":    map[string]interface{}{},
-		"clientInfo": map[string]string{
-			"name":    "agenkit",
-			"version": "0.82.0",
-		},
-	})
+	params, err := mcpInitParams()
 	if err != nil {
 		return fmt.Errorf("mcp: marshal initialize params: %w", err)
 	}
@@ -154,8 +164,17 @@ func (c *StdioClient) Close() error {
 }
 
 // sendRequest encodes a JSON-RPC request and decodes the response.
-// The mutex ensures requests are serialised over the single pipe.
+// The mutex serialises the full write→read cycle so concurrent callers
+// never interleave their request/response pairs on the stdio pipe.
+// Note: stdio I/O is not cancellable mid-operation; ctx is only checked
+// before acquiring the lock.
 func (c *StdioClient) sendRequest(ctx context.Context, method string, params json.RawMessage) (*jsonrpcResponse, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -167,35 +186,17 @@ func (c *StdioClient) sendRequest(ctx context.Context, method string, params jso
 		Params:  params,
 	}
 
-	type result struct {
-		resp *jsonrpcResponse
-		err  error
+	if err := c.encoder.Encode(req); err != nil {
+		return nil, fmt.Errorf("encode request: %w", err)
 	}
-	done := make(chan result, 1)
-
-	go func() {
-		if err := c.encoder.Encode(req); err != nil {
-			done <- result{nil, fmt.Errorf("encode request: %w", err)}
-			return
-		}
-		var resp jsonrpcResponse
-		if err := c.decoder.Decode(&resp); err != nil {
-			done <- result{nil, fmt.Errorf("decode response: %w", err)}
-			return
-		}
-		if resp.Error != nil {
-			done <- result{nil, fmt.Errorf("rpc error %d: %s", resp.Error.Code, resp.Error.Message)}
-			return
-		}
-		done <- result{&resp, nil}
-	}()
-
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	case r := <-done:
-		return r.resp, r.err
+	var resp jsonrpcResponse
+	if err := c.decoder.Decode(&resp); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
 	}
+	if resp.Error != nil {
+		return nil, fmt.Errorf("rpc error %d: %s", resp.Error.Code, resp.Error.Message)
+	}
+	return &resp, nil
 }
 
 // ─── HTTPClient ────────────────────────────────────────────────────────────────
@@ -225,14 +226,7 @@ func NewHTTPClient(ctx context.Context, baseURL string) (*HTTPClient, error) {
 
 // Initialize sends the MCP initialize request to the HTTP server.
 func (c *HTTPClient) Initialize(ctx context.Context) error {
-	params, err := json.Marshal(map[string]interface{}{
-		"protocolVersion": "2024-11-05",
-		"capabilities":    map[string]interface{}{},
-		"clientInfo": map[string]string{
-			"name":    "agenkit",
-			"version": "0.82.0",
-		},
-	})
+	params, err := mcpInitParams()
 	if err != nil {
 		return fmt.Errorf("mcp: marshal initialize params: %w", err)
 	}

--- a/agenkit-go/skills/agent.go
+++ b/agenkit-go/skills/agent.go
@@ -2,7 +2,6 @@ package skills
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"time"
 
@@ -99,7 +98,7 @@ func (s *SkillEnabledAgent) Process(ctx context.Context, message *agenkit.Messag
 	for k, v := range message.Metadata {
 		enhanced.Metadata[k] = v
 	}
-	enhanced.Metadata["active_skills"] = fmt.Sprintf("%s", strings.Join(activeNames, ","))
+	enhanced.Metadata["active_skills"] = strings.Join(activeNames, ",")
 
 	return s.agent.Process(ctx, enhanced)
 }

--- a/agenkit-go/skills/loader.go
+++ b/agenkit-go/skills/loader.go
@@ -199,3 +199,12 @@ func (r *SkillRegistry) GetSkill(name string) (*AgentSkill, bool) {
 	s, ok := r.skills[name]
 	return s, ok
 }
+
+// All returns all loaded skills as an unordered slice.
+func (r *SkillRegistry) All() []*AgentSkill {
+	out := make([]*AgentSkill, 0, len(r.skills))
+	for _, s := range r.skills {
+		out = append(out, s)
+	}
+	return out
+}


### PR DESCRIPTION
## Summary
Commits pre-existing working-tree changes in the Go MCP client and skills packages (present since before recent release work), plus one idiomatic fix surfaced while validating them.

## Changes
- **`protocols/mcp/client.go`**: extract a shared `mcpInitParams()` helper (dedups the identical `initialize` params built by the Stdio and HTTP clients); simplify `sendRequest` from a goroutine+channel pattern to a direct mutex-guarded write→read cycle. stdio I/O isn't cancellable mid-operation, so `ctx` is now checked before acquiring the lock, with documented intent.
- **`skills/loader.go`**: add `SkillRegistry.All()` to enumerate loaded skills.
- **`skills/agent.go`**: drop redundant `fmt.Sprintf("%s", strings.Join(...))` (staticcheck S1025) + now-unused `fmt` import.

## Validation
- `go build ./...`, `go vet ./...`, `go test ./...` all pass
- `golangci-lint run` → 0 issues