### PR TITLE
fix(ci): make parity PR comment truly non-fatal on read-only tokens

### DIFF
--- a/.github/workflows/parity-validation.yml
+++ b/.github/workflows/parity-validation.yml
@@ -100,12 +100,21 @@ jobs:
             📋 See [FEATURE_MATRIX.md](../blob/${process.env.GITHUB_SHA}/docs/parity/FEATURE_MATRIX.md) for details
             `;
 
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: comment
-            });
+            // Dependabot / forked PRs run with a read-only token, so the
+            // create-comment call rejects. Await inside try/catch so the
+            // rejection is handled here and never escapes as an unhandled
+            // promise rejection (which crashes Node and defeats
+            // continue-on-error).
+            try {
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: comment
+              });
+            } catch (error) {
+              core.warning(`Could not post parity comment (read-only token?): ${error.message}`);
+            }
 
   # Optional: Block PR if parity regresses
   parity-gate:


### PR DESCRIPTION
## Problem
Every Dependabot PR red-fails on **Feature Parity Validation** with `HttpError: Resource not accessible by integration` — even though parity validation itself passes (all languages ✅). The "Comment PR with parity summary" step already had `continue-on-error: true`, yet the job still failed.

## Root cause
`github.rest.issues.createComment(...)` was called **without `await`** (line 103). In an async `actions/github-script` body the promise rejects *after* the script returns → **unhandled promise rejection** → Node process crash. `continue-on-error` only traps the step's exit code, not a post-completion process crash, so it was defeated. Dependabot/forked PRs always reject the call (read-only `GITHUB_TOKEN`), so the job always failed.

## Fix
`await` the call inside `try/catch`, downgrading any failure to `core.warning`. A missing comment can now never red the run.

## Impact
Unblocks the 5 stalled Dependabot Python PRs (#557–#562), which were failing on this spurious check alone.