### PR TITLE
fix(ci): smoke test Go step survives setup-go@v6 on self-hosted runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,17 @@ jobs:
 
       - name: Run Go smoke tests
         working-directory: agenkit-go
+        # The self-hosted runner has an older system `go` (1.22) earlier on PATH
+        # than setup-go's 1.25.11. setup-go@v6 no longer guarantees its Go wins
+        # PATH (v5 did), so the shadowing system go ran and — with the job-level
+        # GOTOOLCHAIN=local — could not satisfy go.mod's `go >= 1.25.11`.
+        # GOTOOLCHAIN=auto here lets whichever go runs fetch the required
+        # toolchain; the tests still execute against 1.25.11. Mirrors the
+        # govulncheck step's fix in security.yml.
+        env:
+          GOTOOLCHAIN: auto
         run: |
+          go version
           # Quick tests without race detector for speed
           go test -short $(go list ./... | grep -v /examples/) -failfast
 


### PR DESCRIPTION
## Problem
After #575 (actions group bump, `setup-go@v5 → v6`), the **CI Smoke Test** push job on the self-hosted janus runner fails:
```
go: go.mod requires go >= 1.25.11 (running go 1.22.0; GOTOOLCHAIN=local)
```
Under v6, setup-go no longer guarantees its Go is first on PATH (v5 did), so the runner's older system go (1.22) shadows it. With the job-level `GOTOOLCHAIN=local`, go.mod's `go >= 1.25.11` can't be satisfied. **PRs run on hosted runners (no old system go), which masked this** — it only fails on push-to-main.

## Fix
Set `GOTOOLCHAIN: auto` for the Go smoke step so whichever `go` runs can fetch the required toolchain; tests still execute against 1.25.11. Identical to the fix already applied to the govulncheck step in `security.yml` (#575).

## Note
This PR's own checks run on hosted runners and don't reproduce the failure — verification is the **push-to-main run on the self-hosted runner** after merge.