### PR TITLE
fix(ts): repair build broken by npm-group bump (closes #626)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,17 +108,12 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '22'
-      # TS build is currently RED on main (a tsc + @types/node bump via the npm
-      # group broke moduleResolution + tightened Buffer/string[] types). Kept
-      # non-blocking until the dedicated TS-build-fix issue lands; flip to
-      # blocking once green.
       - name: TypeScript install
         if: matrix.lang == 'typescript'
         working-directory: agenkit-ts
         run: npm ci
-      - name: TypeScript build (non-blocking)
+      - name: TypeScript build (blocking)
         if: matrix.lang == 'typescript'
-        continue-on-error: true
         working-directory: agenkit-ts
         run: npm run build
       # Hard 5-min cap: some TS tests connect to Redis and retry until the job

--- a/agenkit-ts/src/memory/redisMemory.ts
+++ b/agenkit-ts/src/memory/redisMemory.ts
@@ -333,14 +333,19 @@ export class RedisMemory implements Memory {
     const pattern = `${this.keyPrefix}:*:messages`;
     const sessions: string[] = [];
 
-    // Use SCAN to iterate over keys
-    for await (const key of client.scanIterator({ MATCH: pattern })) {
-      // Extract session_id from key
-      // Format: "agenkit:memory:{session_id}:messages"
-      const parts = key.split(':');
-      if (parts.length >= 3) {
-        const sessionId = parts[parts.length - 2]; // Second to last part
-        sessions.push(sessionId);
+    // Use SCAN to iterate over keys. redis v6's scanIterator yields a batch
+    // of keys (string[]) per iteration rather than one key at a time, so
+    // normalize to an array before processing.
+    for await (const batch of client.scanIterator({ MATCH: pattern })) {
+      const keys = Array.isArray(batch) ? batch : [batch];
+      for (const key of keys) {
+        // Extract session_id from key
+        // Format: "agenkit:memory:{session_id}:messages"
+        const parts = key.split(':');
+        if (parts.length >= 3) {
+          const sessionId = parts[parts.length - 2]; // Second to last part
+          sessions.push(sessionId);
+        }
       }
     }
 

--- a/agenkit-ts/src/transports/tcp.ts
+++ b/agenkit-ts/src/transports/tcp.ts
@@ -54,9 +54,11 @@ export class TCPTransport extends Transport {
           this.socket = null;
         });
 
-        // Setup data handler for buffering
-        this.socket.on('data', (data) => {
-          this.receiveBuffer = Buffer.concat([this.receiveBuffer, data]);
+        // Setup data handler for buffering. The 'data' event payload is typed
+        // string | Buffer; normalize to Buffer before concatenating.
+        this.socket.on('data', (data: Buffer | string) => {
+          const chunk = typeof data === 'string' ? Buffer.from(data) : data;
+          this.receiveBuffer = Buffer.concat([this.receiveBuffer, chunk]);
         });
 
         this.socket.connect(this.port, this.host);

--- a/agenkit-ts/tsconfig.json
+++ b/agenkit-ts/tsconfig.json
@@ -14,6 +14,7 @@
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "moduleResolution": "node",
+    "ignoreDeprecations": "6.0",
     "allowSyntheticDefaultImports": true
   },
   "include": ["src/**/*"],


### PR DESCRIPTION
Closes #626.

The npm group bump (#603) broke the agenkit-ts build three ways — invisible until the new lang-smoke CI started building TS:

1. **tsc deprecation** — `moduleResolution=node10` is now a hard error. Added `ignoreDeprecations: "6.0"` (keeps CommonJS emit unchanged; no consumer impact).
2. **redis v6 scanIterator** — now yields a *batch* (`string[]`) per iteration instead of one key. `getAllSessions` normalizes to an array.
3. **@types/node 25** — types the socket `'data'` payload as `string | Buffer`; coerce to `Buffer` before `Buffer.concat` (tcp.ts).

Also flips the TS build CI step from non-blocking → **blocking** (acceptance criterion).

## Verified
- `npx tsc --noEmit` clean
- `npm run build` clean