### PR TITLE
feat(scala): real HTTP-backed Anthropic + OpenAI adapters (closes #632)

### DIFF
--- a/agenkit-scala/src/main/scala/io/agenkit/adapters/AnthropicAdapter.scala
+++ b/agenkit-scala/src/main/scala/io/agenkit/adapters/AnthropicAdapter.scala
@@ -1,17 +1,47 @@
 package io.agenkit.adapters
 
 import io.agenkit.core.Message
-import org.slf4j.LoggerFactory
 import scala.concurrent.{ExecutionContext, Future}
 
-/** Anthropic adapter stub.  Extend with an HTTP client for production use. */
+/** Anthropic Messages API adapter.
+  *
+  * Calls `POST {baseUrl}/v1/messages` with `x-api-key` + `anthropic-version`
+  * headers. The Anthropic API takes the system prompt as a top-level field
+  * (not a message role), so any `system` messages are concatenated and sent
+  * separately; the rest go in `messages`. The reply text is read from
+  * `content[0].text`.
+  */
 class AnthropicAdapter(
   apiKey: String,
   model: String = "claude-opus-4-6",
-  baseUrl: String = "https://api.anthropic.com"
+  baseUrl: String = "https://api.anthropic.com",
+  maxTokens: Int = 4096,
+  anthropicVersion: String = "2023-06-01"
 ) extends LlmClient:
-  private val logger = LoggerFactory.getLogger(getClass)
 
   def complete(messages: List[Message])(using ExecutionContext): Future[Message] =
-    logger.warn("AnthropicAdapter.complete: HTTP not implemented; use MockAdapter for tests")
-    Future.failed(new UnsupportedOperationException("Anthropic HTTP not implemented in core"))
+    val (systemMsgs, convoMsgs) = messages.partition(_.role == "system")
+    val systemPrompt = systemMsgs.map(_.contentString).filter(_.nonEmpty).mkString("\n")
+
+    val payload = ujson.Obj(
+      "model" -> model,
+      "max_tokens" -> maxTokens,
+      "messages" -> ujson.Arr.from(
+        convoMsgs.map(m => ujson.Obj("role" -> m.role, "content" -> m.contentString))
+      )
+    )
+    if systemPrompt.nonEmpty then payload("system") = systemPrompt
+
+    HttpLlm
+      .postJson(
+        s"$baseUrl/v1/messages",
+        ujson.write(payload),
+        Map("x-api-key" -> apiKey, "anthropic-version" -> anthropicVersion)
+      )
+      .map { body =>
+        val json = ujson.read(body)
+        val content = json("content").arr
+        if content.isEmpty then throw new RuntimeException("Anthropic response contained no content")
+        val text = content(0)("text").str
+        Message.of("assistant", text)
+      }

--- a/agenkit-scala/src/main/scala/io/agenkit/adapters/HttpLlm.scala
+++ b/agenkit-scala/src/main/scala/io/agenkit/adapters/HttpLlm.scala
@@ -1,0 +1,49 @@
+package io.agenkit.adapters
+
+import java.net.URI
+import java.net.http.{HttpClient, HttpRequest, HttpResponse}
+import java.time.Duration
+import scala.concurrent.{ExecutionContext, Future}
+import scala.jdk.FutureConverters.*
+
+/** Shared HTTP plumbing for the real LLM adapters.
+  *
+  * Uses the JDK's built-in `java.net.http.HttpClient` (JDK 11+) so the core
+  * library needs no third-party HTTP dependency. JSON is handled by upickle,
+  * which the project already depends on.
+  */
+private[adapters] object HttpLlm:
+  /** A lazily-created, shared async client. */
+  private lazy val client: HttpClient =
+    HttpClient
+      .newBuilder()
+      .connectTimeout(Duration.ofSeconds(30))
+      .build()
+
+  /** POST a JSON body to `url` with the given headers and return the response
+    * body as a string, failing the Future on any non-2xx status.
+    */
+  def postJson(
+    url: String,
+    body: String,
+    headers: Map[String, String],
+    timeout: Duration = Duration.ofSeconds(60)
+  )(using ExecutionContext): Future[String] =
+    var builder = HttpRequest
+      .newBuilder()
+      .uri(URI.create(url))
+      .timeout(timeout)
+      .header("content-type", "application/json")
+      .POST(HttpRequest.BodyPublishers.ofString(body))
+    headers.foreach { case (k, v) => builder = builder.header(k, v) }
+
+    client
+      .sendAsync(builder.build(), HttpResponse.BodyHandlers.ofString())
+      .asScala
+      .map { resp =>
+        if resp.statusCode() >= 200 && resp.statusCode() < 300 then resp.body()
+        else
+          throw new RuntimeException(
+            s"LLM HTTP request to $url failed: ${resp.statusCode()} ${resp.body()}"
+          )
+      }

--- a/agenkit-scala/src/main/scala/io/agenkit/adapters/OpenAiAdapter.scala
+++ b/agenkit-scala/src/main/scala/io/agenkit/adapters/OpenAiAdapter.scala
@@ -1,17 +1,38 @@
 package io.agenkit.adapters
 
 import io.agenkit.core.Message
-import org.slf4j.LoggerFactory
 import scala.concurrent.{ExecutionContext, Future}
 
-/** OpenAI adapter stub.  Extend with an HTTP client for production use. */
+/** OpenAI Chat Completions adapter.
+  *
+  * Calls `POST {baseUrl}/chat/completions` with bearer auth and maps the first
+  * choice's message back into an agenkit [[Message]]. Works against OpenAI and
+  * any OpenAI-compatible endpoint (vLLM, llama.cpp, SGLang, …) via `baseUrl`.
+  */
 class OpenAiAdapter(
   apiKey: String,
   model: String = "gpt-4o",
   baseUrl: String = "https://api.openai.com/v1"
 ) extends LlmClient:
-  private val logger = LoggerFactory.getLogger(getClass)
 
   def complete(messages: List[Message])(using ExecutionContext): Future[Message] =
-    logger.warn("OpenAiAdapter.complete: HTTP not implemented; use MockAdapter for tests")
-    Future.failed(new UnsupportedOperationException("OpenAI HTTP not implemented in core"))
+    val payload = ujson.Obj(
+      "model" -> model,
+      "messages" -> ujson.Arr.from(
+        messages.map(m => ujson.Obj("role" -> m.role, "content" -> m.contentString))
+      )
+    )
+
+    HttpLlm
+      .postJson(
+        s"$baseUrl/chat/completions",
+        ujson.write(payload),
+        Map("authorization" -> s"Bearer $apiKey")
+      )
+      .map { body =>
+        val json = ujson.read(body)
+        val choices = json("choices").arr
+        if choices.isEmpty then throw new RuntimeException("OpenAI response contained no choices")
+        val content = choices(0)("message")("content").str
+        Message.of("assistant", content)
+      }

--- a/agenkit-scala/src/test/scala/io/agenkit/adapters/HttpAdaptersSpec.scala
+++ b/agenkit-scala/src/test/scala/io/agenkit/adapters/HttpAdaptersSpec.scala
@@ -1,0 +1,88 @@
+package io.agenkit.adapters
+
+import com.sun.net.httpserver.{HttpExchange, HttpServer}
+import io.agenkit.core.Message
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import java.net.InetSocketAddress
+import scala.concurrent.Await
+import scala.concurrent.duration.*
+import scala.concurrent.ExecutionContext.Implicits.global
+
+/** Hermetic tests for the real HTTP adapters. A local JDK HttpServer stands in
+  * for the provider API on an ephemeral port — no network, no API keys — so we
+  * exercise the actual request building + response parsing.
+  */
+class HttpAdaptersSpec extends AnyFunSuite with Matchers:
+
+  /** Start a one-shot stub server that captures the request body and returns
+    * `responseJson`. Returns (baseUrl, capturedBody-thunk, stop-thunk).
+    */
+  private def withStub(path: String, responseJson: String)(
+    body: (String, () => String) => Unit
+  ): Unit =
+    val server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0)
+    @volatile var captured: String = ""
+    server.createContext(
+      path,
+      (ex: HttpExchange) =>
+        captured = new String(ex.getRequestBody.readAllBytes(), "UTF-8")
+        val bytes = responseJson.getBytes("UTF-8")
+        ex.sendResponseHeaders(200, bytes.length.toLong)
+        ex.getResponseBody.write(bytes)
+        ex.getResponseBody.close()
+    )
+    server.start()
+    try
+      val baseUrl = s"http://127.0.0.1:${server.getAddress.getPort}"
+      body(baseUrl, () => captured)
+    finally server.stop(0)
+
+  test("OpenAiAdapter sends chat/completions and parses the first choice"):
+    val resp =
+      """{"choices":[{"message":{"role":"assistant","content":"hi from openai"}}]}"""
+    withStub("/chat/completions", resp): (baseUrl, captured) =>
+      val adapter = OpenAiAdapter(apiKey = "test-key", model = "gpt-4o", baseUrl = baseUrl)
+      val out =
+        Await.result(adapter.complete(List(Message.user("hello"))), 10.seconds)
+      out.role shouldBe "assistant"
+      out.contentString shouldBe "hi from openai"
+      // Request shape
+      val sent = ujson.read(captured())
+      sent("model").str shouldBe "gpt-4o"
+      sent("messages").arr should have size 1
+      sent("messages")(0)("role").str shouldBe "user"
+      sent("messages")(0)("content").str shouldBe "hello"
+
+  test("AnthropicAdapter sends v1/messages, lifts system prompt, parses content"):
+    val resp = """{"content":[{"type":"text","text":"hi from claude"}]}"""
+    withStub("/v1/messages", resp): (baseUrl, captured) =>
+      val adapter =
+        AnthropicAdapter(apiKey = "test-key", model = "claude-opus-4-6", baseUrl = baseUrl)
+      val msgs = List(Message.system("be terse"), Message.user("hello"))
+      val out  = Await.result(adapter.complete(msgs), 10.seconds)
+      out.contentString shouldBe "hi from claude"
+      val sent = ujson.read(captured())
+      sent("system").str shouldBe "be terse" // system lifted out of messages
+      sent("messages").arr should have size 1 // only the user message remains
+      sent("messages")(0)("role").str shouldBe "user"
+      sent("max_tokens").num shouldBe 4096
+
+  test("OpenAiAdapter fails the Future on a non-2xx response"):
+    val server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0)
+    server.createContext(
+      "/chat/completions",
+      (ex: HttpExchange) =>
+        val bytes = """{"error":"bad request"}""".getBytes("UTF-8")
+        ex.sendResponseHeaders(400, bytes.length.toLong)
+        ex.getResponseBody.write(bytes)
+        ex.getResponseBody.close()
+    )
+    server.start()
+    try
+      val baseUrl = s"http://127.0.0.1:${server.getAddress.getPort}"
+      val adapter = OpenAiAdapter(apiKey = "k", baseUrl = baseUrl)
+      val ex = Await.result(adapter.complete(List(Message.user("hi"))).failed, 10.seconds)
+      ex shouldBe a[RuntimeException]
+      ex.getMessage should include("400")
+    finally server.stop(0)

--- a/agenkit-scala/src/test/scala/io/agenkit/adapters/MockAdapterSpec.scala
+++ b/agenkit-scala/src/test/scala/io/agenkit/adapters/MockAdapterSpec.scala
@@ -18,15 +18,3 @@ class MockAdapterSpec extends AnyFunSuite with Matchers:
     val adapter  = MockAdapter()
     val response = Await.result(adapter.complete(List.empty), 5.seconds)
     response.contentString shouldBe "mock adapter response"
-
-  test("OpenAiAdapter fails with UnsupportedOperationException"):
-    val adapter = OpenAiAdapter("key")
-    val result  = adapter.complete(List(Message.user("hi"))).failed
-    val ex      = Await.result(result, 5.seconds)
-    ex shouldBe a[UnsupportedOperationException]
-
-  test("AnthropicAdapter fails with UnsupportedOperationException"):
-    val adapter = AnthropicAdapter("key")
-    val result  = adapter.complete(List(Message.user("hi"))).failed
-    val ex      = Await.result(result, 5.seconds)
-    ex shouldBe a[UnsupportedOperationException]


### PR DESCRIPTION
Closes #632.

The Scala `AnthropicAdapter`/`OpenAiAdapter` threw `UnsupportedOperationException` — `MockAdapter` was the only working `LlmClient`, so Scala was effectively test-only for real LLM use.

## Implementation
Uses the JDK's built-in `java.net.http.HttpClient` (**no new dependency**) + upickle (already a dep):
- **`HttpLlm`** — shared async `postJson` helper (30s connect / 60s request timeout; fails the Future on non-2xx with status + body).
- **`OpenAiAdapter`** — `POST {baseUrl}/chat/completions`, bearer auth, maps first choice. Works with any OpenAI-compatible endpoint (vLLM/llama.cpp/SGLang) via `baseUrl`.
- **`AnthropicAdapter`** — `POST {baseUrl}/v1/messages`, `x-api-key` + `anthropic-version` headers, lifts `system` messages to the top-level field, reads `content[0].text`; `maxTokens` configurable.

## Tests
New `HttpAdaptersSpec` drives both adapters against a **local JDK HttpServer stub on an ephemeral port** — fully hermetic (no network, no API keys). Verifies request shape (model, messages, lifted system prompt, max_tokens) and response parsing, plus non-2xx → failed Future. Removed the two now-obsolete `UnsupportedOperationException` assertions from `MockAdapterSpec`.

**Full Scala suite: 339 passed, 0 failed.**