### PR TITLE
feat(cpp): Agent Skills — AgentSkill, SkillRegistry, SkillEnabledAgent (#629)

### DIFF
--- a/agenkit-cpp/CMakeLists.txt
+++ b/agenkit-cpp/CMakeLists.txt
@@ -183,6 +183,8 @@ add_library(agenkit
     src/middleware/caching.cpp
     src/middleware/batching.cpp
     src/protocols/mcp.cpp
+    src/skills/skill.cpp
+    src/skills/skill_enabled_agent.cpp
 )
 
 # Add observability sources if enabled

--- a/agenkit-cpp/include/agenkit/skills/skill.hpp
+++ b/agenkit-cpp/include/agenkit/skills/skill.hpp
@@ -1,0 +1,155 @@
+/**
+ * @file skill.hpp
+ * @brief Agent Skill loader and registry
+ *
+ * Implements the Agent Skills specification: each skill is a directory
+ * containing a SKILL.md file with YAML frontmatter (name, description, optional
+ * license and metadata) followed by Markdown instructions.
+ *
+ * Mirrors the Python reference implementation (agenkit/skills/loader.py).
+ */
+
+#ifndef AGENKIT_SKILLS_SKILL_HPP
+#define AGENKIT_SKILLS_SKILL_HPP
+
+#include <filesystem>
+#include <map>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace agenkit {
+namespace skills {
+
+/**
+ * @brief Represents a single agent skill loaded from a directory.
+ *
+ * A skill directory must contain a SKILL.md file structured as:
+ * @code
+ *     ---
+ *     name: skill-name
+ *     description: What this skill does.
+ *     license: Apache-2.0  # optional
+ *     metadata:            # optional
+ *       key: value
+ *     ---
+ *     # Skill Title
+ *     Markdown instructions here.
+ * @endcode
+ */
+struct AgentSkill {
+    /** Skill name (required). */
+    std::string name;
+
+    /** Human-readable description (required). */
+    std::string description;
+
+    /** Markdown instructions (body after frontmatter). */
+    std::string instructions;
+
+    /** Optional SPDX license identifier. */
+    std::optional<std::string> license;
+
+    /** Optional metadata key/value pairs. */
+    std::map<std::string, std::string> metadata;
+
+    /** Directory the skill was loaded from (if loaded from disk). */
+    std::optional<std::filesystem::path> skill_dir;
+
+    /**
+     * @brief Load a skill from a directory containing a SKILL.md file.
+     *
+     * @param skill_dir Path to the skill directory.
+     * @return AgentSkill instance.
+     *
+     * @throws std::invalid_argument If the directory lacks SKILL.md, has invalid
+     *         frontmatter, or is missing required fields (name, description).
+     *         The message contains one of:
+     *         "No SKILL.md found", "missing frontmatter delimiters",
+     *         "Missing required field 'name'",
+     *         "Missing required field 'description'".
+     */
+    static AgentSkill from_directory(const std::filesystem::path& skill_dir);
+
+    /**
+     * @brief Render the skill as a prompt block for injection into messages.
+     *
+     * Format:
+     * @code
+     * # Skill: {name}
+     *
+     * ## Description
+     * {description}
+     *
+     * ## Instructions
+     * {instructions}
+     * @endcode
+     *
+     * @return Formatted prompt string.
+     */
+    std::string to_prompt() const;
+};
+
+/**
+ * @brief Discovers and searches agent skills across filesystem paths.
+ *
+ * Skills are discovered by walking search paths and loading any subdirectory
+ * that contains a SKILL.md file. Invalid skill directories are skipped with a
+ * warning logged to stderr.
+ */
+class SkillRegistry {
+public:
+    /**
+     * @brief Construct a registry over the given search paths.
+     * @param search_paths Directories to scan for skill subdirectories.
+     */
+    explicit SkillRegistry(std::vector<std::filesystem::path> search_paths);
+
+    /**
+     * @brief Walk each search path and load all valid skill directories.
+     *
+     * Skill directories without a SKILL.md or with invalid format are skipped
+     * and logged as warnings.
+     */
+    void discover_skills();
+
+    /**
+     * @brief Return skills most relevant to the given query string.
+     *
+     * Scoring:
+     *   +10 if query (lowercased) appears in skill name (lowercased)
+     *   +5  if query (lowercased) appears in skill description (lowercased)
+     *   +N  for each unique word in query that also appears in description
+     *
+     * Only skills with score > 0 are returned, sorted descending, capped at
+     * max_results.
+     *
+     * @param query Natural-language query to match against skills.
+     * @param max_results Maximum number of skills to return (default 5).
+     * @return Ordered list of matching skills (best match first).
+     */
+    std::vector<AgentSkill> find_relevant_skills(const std::string& query,
+                                                 std::size_t max_results = 5) const;
+
+    /**
+     * @brief Return the skill with the given name, or nullopt if not found.
+     * @param name Skill name to look up.
+     * @return Optional containing a copy of the skill if present.
+     */
+    std::optional<AgentSkill> get_skill(const std::string& name) const;
+
+    /**
+     * @brief Read-only copy of loaded skills keyed by name.
+     * @return Map of skill name to skill.
+     */
+    std::map<std::string, AgentSkill> skills() const;
+
+private:
+    std::vector<std::filesystem::path> search_paths_;
+    std::map<std::string, AgentSkill> skills_;
+};
+
+} // namespace skills
+} // namespace agenkit
+
+#endif // AGENKIT_SKILLS_SKILL_HPP

--- a/agenkit-cpp/include/agenkit/skills/skill_enabled_agent.hpp
+++ b/agenkit-cpp/include/agenkit/skills/skill_enabled_agent.hpp
@@ -1,0 +1,81 @@
+/**
+ * @file skill_enabled_agent.hpp
+ * @brief SkillEnabledAgent — wraps an Agent and injects relevant skill instructions.
+ *
+ * Mirrors the Python reference implementation (agenkit/skills/agent.py).
+ */
+
+#ifndef AGENKIT_SKILLS_SKILL_ENABLED_AGENT_HPP
+#define AGENKIT_SKILLS_SKILL_ENABLED_AGENT_HPP
+
+#include "agenkit/core/agent.hpp"
+#include "agenkit/core/message.hpp"
+#include "agenkit/core/result.hpp"
+#include "agenkit/skills/skill.hpp"
+
+#include <cstddef>
+#include <future>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace agenkit {
+namespace skills {
+
+/**
+ * @brief Agent wrapper that automatically injects relevant skill instructions.
+ *
+ * Before delegating to the wrapped agent, this wrapper queries the registry for
+ * skills relevant to the incoming message and prepends their instructions
+ * inside an `<available_skills>` block. The response's metadata will contain
+ * `active_skills` listing the skill names that were injected.
+ */
+class SkillEnabledAgent : public core::Agent {
+public:
+    /**
+     * @brief Construct a skill-enabled agent.
+     *
+     * @param agent Base agent to delegate processing to.
+     * @param registry SkillRegistry used to look up relevant skills.
+     * @param max_active_skills Maximum number of skills to inject (default 3).
+     * @param auto_discover Whether to call registry.discover_skills() at
+     *        construction time (default true).
+     */
+    SkillEnabledAgent(std::shared_ptr<core::Agent> agent,
+                      std::shared_ptr<SkillRegistry> registry,
+                      std::size_t max_active_skills = 3,
+                      bool auto_discover = true);
+
+    /**
+     * @brief Delegate to the wrapped agent's name.
+     */
+    std::string name() const override;
+
+    /**
+     * @brief Wrapped agent capabilities plus "skill_injection".
+     */
+    std::vector<std::string> capabilities() const override;
+
+    /**
+     * @brief Process a message, injecting relevant skill instructions first.
+     *
+     * Finds skills relevant to the message content, builds an
+     * `<available_skills>` block, prepends it to the message content, and sets
+     * `active_skills` metadata before delegating to the wrapped agent.
+     *
+     * @param message Input message.
+     * @return Future with the wrapped agent's response.
+     */
+    std::future<core::Result<core::Message, core::AgentError>>
+    process(core::Message message) override;
+
+private:
+    std::shared_ptr<core::Agent> agent_;
+    std::shared_ptr<SkillRegistry> registry_;
+    std::size_t max_active_skills_;
+};
+
+} // namespace skills
+} // namespace agenkit
+
+#endif // AGENKIT_SKILLS_SKILL_ENABLED_AGENT_HPP

--- a/agenkit-cpp/src/skills/skill.cpp
+++ b/agenkit-cpp/src/skills/skill.cpp
@@ -1,0 +1,330 @@
+/**
+ * @file skill.cpp
+ * @brief Agent Skill loader and registry implementation.
+ */
+
+#include "agenkit/skills/skill.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <fstream>
+#include <iostream>
+#include <set>
+#include <sstream>
+#include <stdexcept>
+#include <utility>
+
+namespace agenkit {
+namespace skills {
+
+namespace {
+
+/** Lowercase a copy of the given string (ASCII). */
+std::string to_lower(const std::string& s) {
+    std::string out = s;
+    std::transform(out.begin(), out.end(), out.begin(), [](unsigned char c) {
+        return static_cast<char>(std::tolower(c));
+    });
+    return out;
+}
+
+/** Trim leading and trailing whitespace (matches Python str.strip semantics). */
+std::string trim(const std::string& s) {
+    auto is_space = [](unsigned char c) { return std::isspace(c) != 0; };
+    std::size_t start = 0;
+    while (start < s.size() && is_space(static_cast<unsigned char>(s[start]))) {
+        ++start;
+    }
+    std::size_t end = s.size();
+    while (end > start && is_space(static_cast<unsigned char>(s[end - 1]))) {
+        --end;
+    }
+    return s.substr(start, end - start);
+}
+
+/**
+ * @brief Strip matching surrounding single or double quotes from a scalar.
+ *
+ * Mirrors enough of YAML scalar handling for the frontmatter we support
+ * (e.g. version: '1.0' -> 1.0).
+ */
+std::string unquote(const std::string& s) {
+    if (s.size() >= 2) {
+        char first = s.front();
+        char last = s.back();
+        if ((first == '\'' && last == '\'') || (first == '"' && last == '"')) {
+            return s.substr(1, s.size() - 2);
+        }
+    }
+    return s;
+}
+
+/** Read an entire file into a string. */
+std::string read_file(const std::filesystem::path& path) {
+    std::ifstream in(path, std::ios::binary);
+    std::ostringstream ss;
+    ss << in.rdbuf();
+    return ss.str();
+}
+
+/**
+ * @brief Split a string on the first `max_splits` occurrences of `delim`.
+ *
+ * Replicates Python's str.split(delim, maxsplit) behaviour, which is what the
+ * reference loader relies on: raw.split("---", 2).
+ */
+std::vector<std::string> split_n(const std::string& s, const std::string& delim,
+                                 std::size_t max_splits) {
+    std::vector<std::string> parts;
+    std::size_t pos = 0;
+    std::size_t splits = 0;
+    while (splits < max_splits) {
+        std::size_t next = s.find(delim, pos);
+        if (next == std::string::npos) {
+            break;
+        }
+        parts.push_back(s.substr(pos, next - pos));
+        pos = next + delim.size();
+        ++splits;
+    }
+    parts.push_back(s.substr(pos));
+    return parts;
+}
+
+/**
+ * @brief Minimal YAML frontmatter parser for skill SKILL.md files.
+ *
+ * Supports the subset used by skills:
+ *   - top-level scalar entries: `key: value`
+ *   - a `metadata:` mapping block with indented `key: value` entries
+ *
+ * Populates name/description/license/metadata on the skill. Returns false only
+ * if the frontmatter is not a mapping (no key/value lines at all and not empty
+ * — empty maps to an empty mapping, matching yaml.safe_load("") -> None being
+ * rejected; here we treat any non-mapping content as invalid).
+ */
+struct Frontmatter {
+    std::string name;
+    std::string description;
+    std::optional<std::string> license;
+    std::map<std::string, std::string> metadata;
+    bool has_name = false;
+    bool has_description = false;
+};
+
+Frontmatter parse_frontmatter(const std::string& text) {
+    Frontmatter fm;
+    std::istringstream stream(text);
+    std::string line;
+    bool in_metadata = false;
+
+    while (std::getline(stream, line)) {
+        // Strip a trailing carriage return for CRLF files.
+        if (!line.empty() && line.back() == '\r') {
+            line.pop_back();
+        }
+
+        const std::string trimmed = trim(line);
+        if (trimmed.empty() || trimmed[0] == '#') {
+            continue;
+        }
+
+        // Determine indentation to detect nested metadata entries.
+        const std::size_t indent = line.find_first_not_of(" \t");
+        const bool indented = (indent != std::string::npos && indent > 0);
+
+        const std::size_t colon = trimmed.find(':');
+        if (colon == std::string::npos) {
+            // Not a key/value line; ignore (lenient).
+            continue;
+        }
+
+        const std::string key = trim(trimmed.substr(0, colon));
+        const std::string value = trim(trimmed.substr(colon + 1));
+
+        if (in_metadata && indented) {
+            if (!key.empty()) {
+                fm.metadata[key] = unquote(value);
+            }
+            continue;
+        }
+
+        // A non-indented line ends any metadata block.
+        in_metadata = false;
+
+        if (key == "metadata" && value.empty()) {
+            in_metadata = true;
+            continue;
+        }
+
+        if (key == "name") {
+            fm.name = unquote(value);
+            fm.has_name = !fm.name.empty();
+        } else if (key == "description") {
+            fm.description = unquote(value);
+            fm.has_description = !fm.description.empty();
+        } else if (key == "license") {
+            std::string lic = unquote(value);
+            if (!lic.empty()) {
+                fm.license = lic;
+            }
+        }
+        // Unknown top-level keys are ignored.
+    }
+
+    return fm;
+}
+
+} // namespace
+
+AgentSkill AgentSkill::from_directory(const std::filesystem::path& skill_dir) {
+    const std::filesystem::path skill_file = skill_dir / "SKILL.md";
+    if (!std::filesystem::exists(skill_file)) {
+        throw std::invalid_argument("No SKILL.md found in " + skill_dir.string());
+    }
+
+    const std::string raw = read_file(skill_file);
+
+    // Split on "---" delimiters (first two occurrences). File must start with
+    // "---" so that parts[0] is empty and parts[1] is the frontmatter.
+    const std::vector<std::string> parts = split_n(raw, "---", 2);
+    if (parts.size() < 3) {
+        throw std::invalid_argument("Invalid SKILL.md in " + skill_dir.string() +
+                                    ": missing frontmatter delimiters");
+    }
+
+    const std::string frontmatter_text = trim(parts[1]);
+    const std::string instructions = trim(parts[2]);
+
+    const Frontmatter fm = parse_frontmatter(frontmatter_text);
+
+    if (!fm.has_name) {
+        throw std::invalid_argument("Missing required field 'name' in " +
+                                    skill_dir.string() + "/SKILL.md");
+    }
+    if (!fm.has_description) {
+        throw std::invalid_argument("Missing required field 'description' in " +
+                                    skill_dir.string() + "/SKILL.md");
+    }
+
+    AgentSkill skill;
+    skill.name = fm.name;
+    skill.description = fm.description;
+    skill.instructions = instructions;
+    skill.license = fm.license;
+    skill.metadata = fm.metadata;
+    skill.skill_dir = skill_dir;
+    return skill;
+}
+
+std::string AgentSkill::to_prompt() const {
+    return "# Skill: " + name + "\n\n" +
+           "## Description\n" + description + "\n\n" +
+           "## Instructions\n" + instructions + "\n";
+}
+
+SkillRegistry::SkillRegistry(std::vector<std::filesystem::path> search_paths)
+    : search_paths_(std::move(search_paths)) {}
+
+void SkillRegistry::discover_skills() {
+    for (const auto& search_path : search_paths_) {
+        std::error_code ec;
+        if (!std::filesystem::is_directory(search_path, ec) || ec) {
+            continue;
+        }
+        for (const auto& entry : std::filesystem::directory_iterator(search_path, ec)) {
+            if (ec) {
+                break;
+            }
+            if (!entry.is_directory(ec) || ec) {
+                continue;
+            }
+            const std::filesystem::path skill_md = entry.path() / "SKILL.md";
+            if (!std::filesystem::exists(skill_md)) {
+                continue;
+            }
+            try {
+                AgentSkill skill = AgentSkill::from_directory(entry.path());
+                skills_[skill.name] = std::move(skill);
+            } catch (const std::invalid_argument& exc) {
+                std::cerr << "skipping skill directory " << entry.path().string()
+                          << ": " << exc.what() << std::endl;
+            }
+        }
+    }
+}
+
+std::vector<AgentSkill> SkillRegistry::find_relevant_skills(const std::string& query,
+                                                            std::size_t max_results) const {
+    const std::string query_lower = to_lower(query);
+
+    // Unique query words.
+    std::set<std::string> query_words;
+    {
+        std::istringstream qs(query_lower);
+        std::string word;
+        while (qs >> word) {
+            query_words.insert(word);
+        }
+    }
+
+    std::vector<std::pair<int, const AgentSkill*>> scored;
+    for (const auto& [name, skill] : skills_) {
+        int score = 0;
+        const std::string name_lower = to_lower(skill.name);
+        const std::string desc_lower = to_lower(skill.description);
+
+        if (!query_lower.empty() && name_lower.find(query_lower) != std::string::npos) {
+            score += 10;
+        }
+        if (!query_lower.empty() && desc_lower.find(query_lower) != std::string::npos) {
+            score += 5;
+        }
+
+        // Count unique query words that appear as whitespace-delimited words in
+        // the description.
+        std::set<std::string> desc_words;
+        {
+            std::istringstream ds(desc_lower);
+            std::string word;
+            while (ds >> word) {
+                desc_words.insert(word);
+            }
+        }
+        for (const auto& qw : query_words) {
+            if (desc_words.count(qw) > 0) {
+                score += 1;
+            }
+        }
+
+        if (score > 0) {
+            scored.emplace_back(score, &skill);
+        }
+    }
+
+    // Stable sort by score descending so equal-scored skills keep a
+    // deterministic (name-ordered) order from the map iteration above.
+    std::stable_sort(scored.begin(), scored.end(),
+                     [](const auto& a, const auto& b) { return a.first > b.first; });
+
+    std::vector<AgentSkill> result;
+    for (std::size_t i = 0; i < scored.size() && i < max_results; ++i) {
+        result.push_back(*scored[i].second);
+    }
+    return result;
+}
+
+std::optional<AgentSkill> SkillRegistry::get_skill(const std::string& name) const {
+    auto it = skills_.find(name);
+    if (it == skills_.end()) {
+        return std::nullopt;
+    }
+    return it->second;
+}
+
+std::map<std::string, AgentSkill> SkillRegistry::skills() const {
+    return skills_;
+}
+
+} // namespace skills
+} // namespace agenkit

--- a/agenkit-cpp/src/skills/skill_enabled_agent.cpp
+++ b/agenkit-cpp/src/skills/skill_enabled_agent.cpp
@@ -1,0 +1,82 @@
+/**
+ * @file skill_enabled_agent.cpp
+ * @brief SkillEnabledAgent implementation.
+ */
+
+#include "agenkit/skills/skill_enabled_agent.hpp"
+
+#include <algorithm>
+#include <utility>
+
+namespace agenkit {
+namespace skills {
+
+SkillEnabledAgent::SkillEnabledAgent(std::shared_ptr<core::Agent> agent,
+                                     std::shared_ptr<SkillRegistry> registry,
+                                     std::size_t max_active_skills,
+                                     bool auto_discover)
+    : agent_(std::move(agent)),
+      registry_(std::move(registry)),
+      max_active_skills_(max_active_skills) {
+    if (auto_discover && registry_) {
+        registry_->discover_skills();
+    }
+}
+
+std::string SkillEnabledAgent::name() const {
+    return agent_->name();
+}
+
+std::vector<std::string> SkillEnabledAgent::capabilities() const {
+    std::vector<std::string> caps = agent_->capabilities();
+    if (std::find(caps.begin(), caps.end(), "skill_injection") == caps.end()) {
+        caps.push_back("skill_injection");
+    }
+    return caps;
+}
+
+std::future<core::Result<core::Message, core::AgentError>>
+SkillEnabledAgent::process(core::Message message) {
+    const std::string query = message.content_as_str();
+
+    std::vector<AgentSkill> relevant;
+    if (registry_) {
+        relevant = registry_->find_relevant_skills(query, max_active_skills_);
+    }
+
+    if (relevant.empty()) {
+        return agent_->process(std::move(message));
+    }
+
+    // Build the <available_skills> block from the relevant skills.
+    std::string skill_blocks;
+    for (std::size_t i = 0; i < relevant.size(); ++i) {
+        if (i > 0) {
+            skill_blocks += "\n\n";
+        }
+        skill_blocks += relevant[i].to_prompt();
+    }
+
+    const std::string augmented_content =
+        "<available_skills>\n" + skill_blocks + "\n</available_skills>\n\n" + query;
+
+    // Preserve existing metadata, then record the active skill names.
+    nlohmann::json metadata = message.metadata();
+    nlohmann::json active = nlohmann::json::array();
+    for (const auto& skill : relevant) {
+        active.push_back(skill.name);
+    }
+
+    core::Message enhanced(message.role(), nlohmann::json(augmented_content));
+    if (metadata.is_object()) {
+        for (auto it = metadata.begin(); it != metadata.end(); ++it) {
+            enhanced.with_metadata(it.key(), it.value());
+        }
+    }
+    enhanced.with_metadata("active_skills", active);
+
+    return agent_->process(std::move(enhanced));
+}
+
+} // namespace skills
+} // namespace agenkit

--- a/agenkit-cpp/tests/CMakeLists.txt
+++ b/agenkit-cpp/tests/CMakeLists.txt
@@ -347,6 +347,11 @@ add_executable(test_reasoning_graph techniques/reasoning/test_reasoning_graph.cp
 target_link_libraries(test_reasoning_graph agenkit gtest_main)
 add_test(NAME reasoning_graph_tests COMMAND test_reasoning_graph)
 
+# Skills tests - AgentSkill, SkillRegistry, SkillEnabledAgent
+add_executable(test_skills skills/test_skills.cpp)
+target_link_libraries(test_skills agenkit gtest_main)
+add_test(NAME skills_tests COMMAND test_skills)
+
 # MCP protocol tests
 add_executable(test_mcp test_mcp.cpp)
 target_link_libraries(test_mcp agenkit GTest::gtest_main)

--- a/agenkit-cpp/tests/skills/test_skills.cpp
+++ b/agenkit-cpp/tests/skills/test_skills.cpp
@@ -1,0 +1,386 @@
+/**
+ * @file test_skills.cpp
+ * @brief Tests for AgentSkill, SkillRegistry, and SkillEnabledAgent.
+ *
+ * Ported from the Python reference suites:
+ *   tests/skills/test_skill_loader.py
+ *   tests/skills/test_skill_agent.py
+ */
+
+#include <gtest/gtest.h>
+
+#include "agenkit/core/agent.hpp"
+#include "agenkit/core/message.hpp"
+#include "agenkit/core/result.hpp"
+#include "agenkit/skills/skill.hpp"
+#include "agenkit/skills/skill_enabled_agent.hpp"
+
+#include <algorithm>
+#include <filesystem>
+#include <fstream>
+#include <future>
+#include <memory>
+#include <random>
+#include <string>
+#include <vector>
+
+using agenkit::core::Agent;
+using agenkit::core::AgentError;
+using agenkit::core::Message;
+using agenkit::core::Result;
+using agenkit::skills::AgentSkill;
+using agenkit::skills::SkillEnabledAgent;
+using agenkit::skills::SkillRegistry;
+
+namespace fs = std::filesystem;
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+/** Create a unique temporary directory for a test and clean it up after. */
+class TempDir {
+public:
+    TempDir() {
+        std::random_device rd;
+        std::mt19937_64 gen(rd());
+        path_ = fs::temp_directory_path() /
+                ("agenkit_skills_" + std::to_string(gen()));
+        fs::create_directories(path_);
+    }
+
+    ~TempDir() {
+        std::error_code ec;
+        fs::remove_all(path_, ec);
+    }
+
+    const fs::path& path() const { return path_; }
+
+private:
+    fs::path path_;
+};
+
+/** Create a minimal valid skill directory inside base. */
+static fs::path make_skill_dir(const fs::path& base, const std::string& name,
+                               const std::string& description,
+                               const std::string& body = "Instructions here.") {
+    const fs::path skill_dir = base / name;
+    fs::create_directories(skill_dir);
+    const std::string content =
+        "---\nname: " + name + "\ndescription: " + description + "\n---\n" + body;
+    std::ofstream out(skill_dir / "SKILL.md", std::ios::binary);
+    out << content;
+    return skill_dir;
+}
+
+/** Agent that echoes its input content back. */
+class EchoAgent : public Agent {
+public:
+    std::string name() const override { return "echo"; }
+
+    std::future<Result<Message, AgentError>> process(Message message) override {
+        // EchoAgent uses role "agent" in the Python reference; mirror that and
+        // echo content + metadata back unchanged.
+        Message echoed("agent", message.content());
+        const auto& metadata = message.metadata();
+        if (metadata.is_object()) {
+            for (auto it = metadata.begin(); it != metadata.end(); ++it) {
+                echoed.with_metadata(it.key(), it.value());
+            }
+        }
+        return agenkit::core::make_ready_future(
+            Result<Message, AgentError>::ok(std::move(echoed)));
+    }
+};
+
+// ---------------------------------------------------------------------------
+// AgentSkill::from_directory
+// ---------------------------------------------------------------------------
+
+TEST(SkillLoaderTest, LoadSkillValid) {
+    TempDir tmp;
+    const fs::path dir =
+        make_skill_dir(tmp.path(), "pdf-processing", "Extract text from PDFs.",
+                       "# PDF\nDo stuff.");
+    const AgentSkill skill = AgentSkill::from_directory(dir);
+
+    EXPECT_EQ(skill.name, "pdf-processing");
+    EXPECT_EQ(skill.description, "Extract text from PDFs.");
+    EXPECT_NE(skill.instructions.find("Do stuff."), std::string::npos);
+    ASSERT_TRUE(skill.skill_dir.has_value());
+    EXPECT_EQ(*skill.skill_dir, dir);
+}
+
+TEST(SkillLoaderTest, LoadSkillWithLicenseAndMetadata) {
+    TempDir tmp;
+    const fs::path dir = tmp.path() / "advanced";
+    fs::create_directories(dir);
+    const std::string content =
+        "---\n"
+        "name: advanced\n"
+        "description: Advanced skill.\n"
+        "license: Apache-2.0\n"
+        "metadata:\n"
+        "  version: '1.0'\n"
+        "---\n"
+        "Advanced instructions.";
+    {
+        std::ofstream out(dir / "SKILL.md", std::ios::binary);
+        out << content;
+    }
+
+    const AgentSkill skill = AgentSkill::from_directory(dir);
+    ASSERT_TRUE(skill.license.has_value());
+    EXPECT_EQ(*skill.license, "Apache-2.0");
+    ASSERT_EQ(skill.metadata.size(), 1u);
+    EXPECT_EQ(skill.metadata.at("version"), "1.0");
+}
+
+TEST(SkillLoaderTest, LoadSkillMissingSkillMd) {
+    TempDir tmp;
+    const fs::path empty_dir = tmp.path() / "empty";
+    fs::create_directories(empty_dir);
+
+    try {
+        AgentSkill::from_directory(empty_dir);
+        FAIL() << "expected std::invalid_argument";
+    } catch (const std::invalid_argument& e) {
+        EXPECT_NE(std::string(e.what()).find("No SKILL.md found"),
+                  std::string::npos);
+    }
+}
+
+TEST(SkillLoaderTest, LoadSkillInvalidFrontmatter) {
+    TempDir tmp;
+    const fs::path dir = tmp.path() / "bad";
+    fs::create_directories(dir);
+    {
+        // Missing second "---" delimiter.
+        std::ofstream out(dir / "SKILL.md", std::ios::binary);
+        out << "name: foo\ndescription: bar\n";
+    }
+
+    try {
+        AgentSkill::from_directory(dir);
+        FAIL() << "expected std::invalid_argument";
+    } catch (const std::invalid_argument& e) {
+        EXPECT_NE(std::string(e.what()).find("missing frontmatter delimiters"),
+                  std::string::npos);
+    }
+}
+
+TEST(SkillLoaderTest, LoadSkillMissingName) {
+    TempDir tmp;
+    const fs::path dir = tmp.path() / "noname";
+    fs::create_directories(dir);
+    {
+        std::ofstream out(dir / "SKILL.md", std::ios::binary);
+        out << "---\ndescription: A skill without a name.\n---\nInstructions.";
+    }
+
+    try {
+        AgentSkill::from_directory(dir);
+        FAIL() << "expected std::invalid_argument";
+    } catch (const std::invalid_argument& e) {
+        EXPECT_NE(std::string(e.what()).find("Missing required field 'name'"),
+                  std::string::npos);
+    }
+}
+
+TEST(SkillLoaderTest, LoadSkillMissingDescription) {
+    TempDir tmp;
+    const fs::path dir = tmp.path() / "nodesc";
+    fs::create_directories(dir);
+    {
+        std::ofstream out(dir / "SKILL.md", std::ios::binary);
+        out << "---\nname: nodesc\n---\nInstructions.";
+    }
+
+    try {
+        AgentSkill::from_directory(dir);
+        FAIL() << "expected std::invalid_argument";
+    } catch (const std::invalid_argument& e) {
+        EXPECT_NE(
+            std::string(e.what()).find("Missing required field 'description'"),
+            std::string::npos);
+    }
+}
+
+TEST(SkillLoaderTest, SkillToPrompt) {
+    TempDir tmp;
+    const fs::path dir = make_skill_dir(tmp.path(), "csv-tools",
+                                        "Handle CSV files.", "Parse and write CSV.");
+    const AgentSkill skill = AgentSkill::from_directory(dir);
+    const std::string prompt = skill.to_prompt();
+
+    EXPECT_NE(prompt.find("# Skill: csv-tools"), std::string::npos);
+    EXPECT_NE(prompt.find("## Description"), std::string::npos);
+    EXPECT_NE(prompt.find("Handle CSV files."), std::string::npos);
+    EXPECT_NE(prompt.find("## Instructions"), std::string::npos);
+    EXPECT_NE(prompt.find("Parse and write CSV."), std::string::npos);
+}
+
+// ---------------------------------------------------------------------------
+// SkillRegistry
+// ---------------------------------------------------------------------------
+
+TEST(SkillRegistryTest, DiscoverSkipsNonDirs) {
+    TempDir tmp;
+    {
+        std::ofstream out(tmp.path() / "not_a_dir.md", std::ios::binary);
+        out << "ignored";
+    }
+    SkillRegistry registry({tmp.path()});
+    registry.discover_skills();
+    EXPECT_EQ(registry.skills().size(), 0u);
+}
+
+TEST(SkillRegistryTest, DiscoversValidSkills) {
+    TempDir tmp;
+    make_skill_dir(tmp.path(), "skill-a", "Skill A description.");
+    make_skill_dir(tmp.path(), "skill-b", "Skill B description.");
+    SkillRegistry registry({tmp.path()});
+    registry.discover_skills();
+
+    const auto skills = registry.skills();
+    EXPECT_TRUE(skills.count("skill-a") > 0);
+    EXPECT_TRUE(skills.count("skill-b") > 0);
+}
+
+TEST(SkillRegistryTest, DiscoverSkipsInvalidSkill) {
+    TempDir tmp;
+    make_skill_dir(tmp.path(), "good", "A good skill.");
+    // An invalid skill directory (SKILL.md present but missing required name).
+    const fs::path bad = tmp.path() / "bad";
+    fs::create_directories(bad);
+    {
+        std::ofstream out(bad / "SKILL.md", std::ios::binary);
+        out << "---\ndescription: no name here.\n---\nbody";
+    }
+
+    SkillRegistry registry({tmp.path()});
+    registry.discover_skills();
+
+    const auto skills = registry.skills();
+    EXPECT_TRUE(skills.count("good") > 0);
+    EXPECT_EQ(skills.size(), 1u);
+}
+
+TEST(SkillRegistryTest, FindRelevantNameMatch) {
+    TempDir tmp;
+    make_skill_dir(tmp.path(), "pdf-processing", "Work with PDF documents.");
+    make_skill_dir(tmp.path(), "csv-tools", "Handle CSV spreadsheets.");
+    SkillRegistry registry({tmp.path()});
+    registry.discover_skills();
+
+    const auto results = registry.find_relevant_skills("pdf");
+    ASSERT_GE(results.size(), 1u);
+    EXPECT_EQ(results[0].name, "pdf-processing");
+}
+
+TEST(SkillRegistryTest, FindRelevantMaxResults) {
+    TempDir tmp;
+    for (int i = 0; i < 6; ++i) {
+        make_skill_dir(tmp.path(), "skill-" + std::to_string(i),
+                       "A skill about document processing number " +
+                           std::to_string(i) + ".");
+    }
+    SkillRegistry registry({tmp.path()});
+    registry.discover_skills();
+
+    const auto results = registry.find_relevant_skills("document", 3);
+    EXPECT_LE(results.size(), 3u);
+}
+
+TEST(SkillRegistryTest, GetSkill) {
+    TempDir tmp;
+    make_skill_dir(tmp.path(), "email-compose", "Compose professional emails.");
+    SkillRegistry registry({tmp.path()});
+    registry.discover_skills();
+
+    const auto skill = registry.get_skill("email-compose");
+    ASSERT_TRUE(skill.has_value());
+    EXPECT_EQ(skill->name, "email-compose");
+
+    const auto missing = registry.get_skill("nonexistent");
+    EXPECT_FALSE(missing.has_value());
+}
+
+// ---------------------------------------------------------------------------
+// SkillEnabledAgent
+// ---------------------------------------------------------------------------
+
+TEST(SkillEnabledAgentTest, AugmentsMessage) {
+    TempDir tmp;
+    make_skill_dir(tmp.path(), "pdf-processing", "Extract text from PDF documents.");
+    auto registry = std::make_shared<SkillRegistry>(
+        std::vector<fs::path>{tmp.path()});
+    SkillEnabledAgent agent(std::make_shared<EchoAgent>(), registry, 3, true);
+
+    Message msg = Message::with_text("user", "How do I parse pdf files?");
+    auto result = agent.process(std::move(msg)).get();
+    ASSERT_TRUE(result.is_ok());
+
+    const std::string content = result.unwrap().content_as_str();
+    EXPECT_NE(content.find("<available_skills>"), std::string::npos);
+    EXPECT_NE(content.find("pdf-processing"), std::string::npos);
+}
+
+TEST(SkillEnabledAgentTest, NoSkillsPassthrough) {
+    TempDir tmp;
+    make_skill_dir(tmp.path(), "email-compose", "Compose professional emails.");
+    auto registry = std::make_shared<SkillRegistry>(
+        std::vector<fs::path>{tmp.path()});
+    SkillEnabledAgent agent(std::make_shared<EchoAgent>(), registry, 3, true);
+
+    Message msg = Message::with_text("user", "tell me a joke");
+    auto result = agent.process(std::move(msg)).get();
+    ASSERT_TRUE(result.is_ok());
+
+    const std::string content = result.unwrap().content_as_str();
+    EXPECT_EQ(content.find("<available_skills>"), std::string::npos);
+    EXPECT_EQ(content, "tell me a joke");
+}
+
+TEST(SkillEnabledAgentTest, ActiveSkillsMetadata) {
+    TempDir tmp;
+    make_skill_dir(tmp.path(), "csv-tools",
+                   "Handle and transform CSV spreadsheets.");
+    auto registry = std::make_shared<SkillRegistry>(
+        std::vector<fs::path>{tmp.path()});
+    SkillEnabledAgent agent(std::make_shared<EchoAgent>(), registry, 3, true);
+
+    Message msg = Message::with_text("user", "parse this csv spreadsheet data");
+    auto result = agent.process(std::move(msg)).get();
+    ASSERT_TRUE(result.is_ok());
+
+    const auto& metadata = result.unwrap().metadata();
+    ASSERT_TRUE(metadata.contains("active_skills"));
+    const auto active = metadata["active_skills"];
+    ASSERT_TRUE(active.is_array());
+    bool found = false;
+    for (const auto& name : active) {
+        if (name.get<std::string>() == "csv-tools") {
+            found = true;
+        }
+    }
+    EXPECT_TRUE(found);
+}
+
+TEST(SkillEnabledAgentTest, Capabilities) {
+    TempDir tmp;
+    auto registry = std::make_shared<SkillRegistry>(
+        std::vector<fs::path>{tmp.path()});
+    SkillEnabledAgent agent(std::make_shared<EchoAgent>(), registry, 3, false);
+
+    const auto caps = agent.capabilities();
+    EXPECT_NE(std::find(caps.begin(), caps.end(), "skill_injection"), caps.end());
+}
+
+TEST(SkillEnabledAgentTest, NameDelegates) {
+    TempDir tmp;
+    auto registry = std::make_shared<SkillRegistry>(
+        std::vector<fs::path>{tmp.path()});
+    SkillEnabledAgent agent(std::make_shared<EchoAgent>(), registry, 3, false);
+    EXPECT_EQ(agent.name(), "echo");
+}


### PR DESCRIPTION
Part of #629 (Agent Skills cross-language parity). Ports the spec to C++17, mirroring the Python/Go reference.

## Added
- `include/agenkit/skills/skill.hpp` + `src/skills/skill.cpp` — `AgentSkill` (`from_directory` parses SKILL.md frontmatter+markdown; `to_prompt`) and `SkillRegistry` (`discover_skills`, `find_relevant_skills` with the +10/+5/+1-per-word scoring, `get_skill`, `skills`). Minimal hand-written YAML frontmatter parser — no new dependency.
- `include/agenkit/skills/skill_enabled_agent.hpp` + `.cpp` — wraps `core::Agent`, prepends `<available_skills>`, sets `active_skills` metadata, adds `skill_injection` capability.
- `tests/skills/test_skills.cpp` — 18 GTest cases ported from the Python suite (`std::filesystem` temp-dir fixtures).
- CMakeLists: sources added to the `agenkit` lib + a `test_skills` target.

## Verified
- `cmake --build --target test_skills` clean under `-Wall -Wextra -Wpedantic -Werror`
- **18/18 tests pass**

Companion PRs for the other languages (TS/C#/Java/Scala/Zig) land separately under #629.