### PR TITLE
feat(ts): Agent Skills — AgentSkill, SkillRegistry, SkillEnabledAgent (#629)

### DIFF
--- a/agenkit-ts/src/__tests__/skills.test.ts
+++ b/agenkit-ts/src/__tests__/skills.test.ts
@@ -1,0 +1,285 @@
+/**
+ * Tests for Agent Skills: AgentSkill, SkillRegistry, and SkillEnabledAgent.
+ *
+ * Ported from the Python reference suites:
+ *   tests/skills/test_skill_loader.py
+ *   tests/skills/test_skill_agent.py
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+import { AgentSkill, SkillRegistry } from '../skills/loader';
+import { SkillEnabledAgent } from '../skills/agent';
+import { Agent, Message } from '../core/interfaces';
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+let tmpRoot: string;
+
+beforeEach(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'agenkit-skills-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+function makeSkillDir(
+  root: string,
+  name: string,
+  description: string,
+  body = 'Instructions here.',
+): string {
+  const skillDir = path.join(root, name);
+  fs.mkdirSync(skillDir);
+  const content = `---\nname: ${name}\ndescription: ${description}\n---\n${body}`;
+  fs.writeFileSync(path.join(skillDir, 'SKILL.md'), content, 'utf-8');
+  return skillDir;
+}
+
+// ---------------------------------------------------------------------------
+// AgentSkill.fromDirectory
+// ---------------------------------------------------------------------------
+
+describe('AgentSkill.fromDirectory', () => {
+  it('loads a valid skill', () => {
+    const skillDir = makeSkillDir(
+      tmpRoot,
+      'pdf-processing',
+      'Extract text from PDFs.',
+      '# PDF\nDo stuff.',
+    );
+    const skill = AgentSkill.fromDirectory(skillDir);
+
+    expect(skill.name).toBe('pdf-processing');
+    expect(skill.description).toBe('Extract text from PDFs.');
+    expect(skill.instructions).toContain('Do stuff.');
+    expect(skill.skillDir).toBe(skillDir);
+  });
+
+  it('loads license and metadata', () => {
+    const skillDir = path.join(tmpRoot, 'advanced');
+    fs.mkdirSync(skillDir);
+    const content =
+      '---\n' +
+      'name: advanced\n' +
+      'description: Advanced skill.\n' +
+      'license: Apache-2.0\n' +
+      'metadata:\n' +
+      "  version: '1.0'\n" +
+      '---\n' +
+      'Advanced instructions.';
+    fs.writeFileSync(path.join(skillDir, 'SKILL.md'), content, 'utf-8');
+    const skill = AgentSkill.fromDirectory(skillDir);
+
+    expect(skill.license).toBe('Apache-2.0');
+    expect(skill.metadata).toEqual({ version: '1.0' });
+  });
+
+  it('throws when SKILL.md is missing', () => {
+    const emptyDir = path.join(tmpRoot, 'empty');
+    fs.mkdirSync(emptyDir);
+    expect(() => AgentSkill.fromDirectory(emptyDir)).toThrow(/No SKILL\.md found/);
+  });
+
+  it('throws on missing frontmatter delimiters', () => {
+    const skillDir = path.join(tmpRoot, 'bad');
+    fs.mkdirSync(skillDir);
+    // Missing second "---" delimiter.
+    fs.writeFileSync(
+      path.join(skillDir, 'SKILL.md'),
+      'name: foo\ndescription: bar\n',
+      'utf-8',
+    );
+    expect(() => AgentSkill.fromDirectory(skillDir)).toThrow(
+      /missing frontmatter delimiters/,
+    );
+  });
+
+  it('throws on missing name', () => {
+    const skillDir = path.join(tmpRoot, 'noname');
+    fs.mkdirSync(skillDir);
+    const content = '---\ndescription: A skill without a name.\n---\nInstructions.';
+    fs.writeFileSync(path.join(skillDir, 'SKILL.md'), content, 'utf-8');
+    expect(() => AgentSkill.fromDirectory(skillDir)).toThrow(
+      /Missing required field 'name'/,
+    );
+  });
+
+  it('throws on missing description', () => {
+    const skillDir = path.join(tmpRoot, 'nodesc');
+    fs.mkdirSync(skillDir);
+    const content = '---\nname: nodesc\n---\nInstructions.';
+    fs.writeFileSync(path.join(skillDir, 'SKILL.md'), content, 'utf-8');
+    expect(() => AgentSkill.fromDirectory(skillDir)).toThrow(
+      /Missing required field 'description'/,
+    );
+  });
+
+  it('renders toPrompt', () => {
+    const skillDir = makeSkillDir(
+      tmpRoot,
+      'csv-tools',
+      'Handle CSV files.',
+      'Parse and write CSV.',
+    );
+    const skill = AgentSkill.fromDirectory(skillDir);
+    const prompt = skill.toPrompt();
+
+    expect(prompt).toContain('# Skill: csv-tools');
+    expect(prompt).toContain('## Description');
+    expect(prompt).toContain('Handle CSV files.');
+    expect(prompt).toContain('## Instructions');
+    expect(prompt).toContain('Parse and write CSV.');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SkillRegistry
+// ---------------------------------------------------------------------------
+
+describe('SkillRegistry', () => {
+  it('skips non-directory entries during discovery', () => {
+    fs.writeFileSync(path.join(tmpRoot, 'not_a_dir.md'), 'ignored', 'utf-8');
+    const registry = new SkillRegistry([tmpRoot]);
+    registry.discoverSkills();
+    expect(Object.keys(registry.skills)).toHaveLength(0);
+  });
+
+  it('discovers valid skills', () => {
+    makeSkillDir(tmpRoot, 'skill-a', 'Skill A description.');
+    makeSkillDir(tmpRoot, 'skill-b', 'Skill B description.');
+    const registry = new SkillRegistry([tmpRoot]);
+    registry.discoverSkills();
+
+    expect(registry.skills).toHaveProperty('skill-a');
+    expect(registry.skills).toHaveProperty('skill-b');
+  });
+
+  it('finds relevant skills by name match', () => {
+    makeSkillDir(tmpRoot, 'pdf-processing', 'Work with PDF documents.');
+    makeSkillDir(tmpRoot, 'csv-tools', 'Handle CSV spreadsheets.');
+    const registry = new SkillRegistry([tmpRoot]);
+    registry.discoverSkills();
+
+    const results = registry.findRelevantSkills('pdf');
+    expect(results.length).toBeGreaterThanOrEqual(1);
+    expect(results[0].name).toBe('pdf-processing');
+  });
+
+  it('caps results at maxResults', () => {
+    for (let i = 0; i < 6; i++) {
+      makeSkillDir(
+        tmpRoot,
+        `skill-${i}`,
+        `A skill about document processing number ${i}.`,
+      );
+    }
+    const registry = new SkillRegistry([tmpRoot]);
+    registry.discoverSkills();
+
+    const results = registry.findRelevantSkills('document', 3);
+    expect(results.length).toBeLessThanOrEqual(3);
+  });
+
+  it('getSkill returns the skill or undefined', () => {
+    makeSkillDir(tmpRoot, 'email-compose', 'Compose professional emails.');
+    const registry = new SkillRegistry([tmpRoot]);
+    registry.discoverSkills();
+
+    const skill = registry.getSkill('email-compose');
+    expect(skill).toBeDefined();
+    expect(skill?.name).toBe('email-compose');
+
+    expect(registry.getSkill('nonexistent')).toBeUndefined();
+  });
+
+  it('skips invalid skill directories with a warning', () => {
+    // Valid skill.
+    makeSkillDir(tmpRoot, 'good', 'Good skill.');
+    // Invalid skill: has SKILL.md but missing required fields.
+    const badDir = path.join(tmpRoot, 'bad');
+    fs.mkdirSync(badDir);
+    fs.writeFileSync(path.join(badDir, 'SKILL.md'), '---\nfoo: bar\n---\nbody', 'utf-8');
+
+    const registry = new SkillRegistry([tmpRoot]);
+    registry.discoverSkills();
+
+    expect(registry.skills).toHaveProperty('good');
+    expect(Object.keys(registry.skills)).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SkillEnabledAgent
+// ---------------------------------------------------------------------------
+
+class EchoAgent implements Agent {
+  get name(): string {
+    return 'echo';
+  }
+
+  async process(message: Message): Promise<Message> {
+    return {
+      role: 'agent',
+      content: message.content,
+      metadata: { ...(message.metadata ?? {}) },
+    };
+  }
+}
+
+describe('SkillEnabledAgent', () => {
+  it('augments the message with an available_skills block', async () => {
+    makeSkillDir(tmpRoot, 'pdf-processing', 'Extract text from PDF documents.');
+    const registry = new SkillRegistry([tmpRoot]);
+    const agent = new SkillEnabledAgent(new EchoAgent(), registry, 3, true);
+
+    const msg: Message = { role: 'user', content: 'How do I parse pdf files?' };
+    const response = await agent.process(msg);
+
+    expect(String(response.content)).toContain('<available_skills>');
+    expect(String(response.content)).toContain('pdf-processing');
+  });
+
+  it('passes through when no skills are relevant', async () => {
+    makeSkillDir(tmpRoot, 'email-compose', 'Compose professional emails.');
+    const registry = new SkillRegistry([tmpRoot]);
+    const agent = new SkillEnabledAgent(new EchoAgent(), registry, 3, true);
+
+    const msg: Message = { role: 'user', content: 'tell me a joke' };
+    const response = await agent.process(msg);
+
+    expect(String(response.content)).not.toContain('<available_skills>');
+    expect(String(response.content)).toBe('tell me a joke');
+  });
+
+  it('records active_skills in metadata', async () => {
+    makeSkillDir(tmpRoot, 'csv-tools', 'Handle and transform CSV spreadsheets.');
+    const registry = new SkillRegistry([tmpRoot]);
+    const agent = new SkillEnabledAgent(new EchoAgent(), registry, 3, true);
+
+    const msg: Message = { role: 'user', content: 'parse this csv spreadsheet data' };
+    const response = await agent.process(msg);
+
+    expect(response.metadata).toHaveProperty('active_skills');
+    expect(response.metadata?.active_skills as string[]).toContain('csv-tools');
+  });
+
+  it('exposes skill_injection capability', () => {
+    const registry = new SkillRegistry([tmpRoot]);
+    const agent = new SkillEnabledAgent(new EchoAgent(), registry, 3, false);
+
+    expect(agent.capabilities).toContain('skill_injection');
+  });
+
+  it('delegates name to the wrapped agent', () => {
+    const registry = new SkillRegistry([tmpRoot]);
+    const agent = new SkillEnabledAgent(new EchoAgent(), registry, 3, false);
+    expect(agent.name).toBe('echo');
+  });
+});

--- a/agenkit-ts/src/index.ts
+++ b/agenkit-ts/src/index.ts
@@ -504,3 +504,6 @@ export {
   McpToolAdapter,
   toolsFromClient,
 } from './protocols/mcp/index.js';
+
+// Agent Skills
+export { AgentSkill, SkillRegistry, SkillEnabledAgent } from './skills';

--- a/agenkit-ts/src/skills/agent.ts
+++ b/agenkit-ts/src/skills/agent.ts
@@ -1,0 +1,98 @@
+/**
+ * SkillEnabledAgent — wraps an Agent and injects relevant skill instructions.
+ */
+
+import { Agent, Message } from '../core/interfaces';
+import { IntrospectionResult } from '../core/introspection';
+import { SkillRegistry } from './loader';
+
+/**
+ * Agent wrapper that automatically injects relevant skill instructions.
+ *
+ * Before delegating to the wrapped agent, this wrapper queries the registry
+ * for skills relevant to the incoming message and prepends their instructions
+ * inside an `<available_skills>` block. The response's metadata will contain
+ * `active_skills` listing the skill names that were injected.
+ */
+export class SkillEnabledAgent implements Agent {
+  private readonly agent: Agent;
+  private readonly registry: SkillRegistry;
+  private readonly maxActiveSkills: number;
+
+  /**
+   * @param agent Base agent to delegate processing to.
+   * @param registry SkillRegistry used to look up relevant skills.
+   * @param maxActiveSkills Maximum number of skills to inject (default 3).
+   * @param autoDiscover Whether to call `registry.discoverSkills()` at
+   *   construction time (default true).
+   */
+  constructor(
+    agent: Agent,
+    registry: SkillRegistry,
+    maxActiveSkills = 3,
+    autoDiscover = true,
+  ) {
+    this.agent = agent;
+    this.registry = registry;
+    this.maxActiveSkills = maxActiveSkills;
+    if (autoDiscover) {
+      this.registry.discoverSkills();
+    }
+  }
+
+  get name(): string {
+    return this.agent.name;
+  }
+
+  get capabilities(): string[] {
+    const base = [...(this.agent.capabilities ?? [])];
+    if (!base.includes('skill_injection')) {
+      base.push('skill_injection');
+    }
+    return base;
+  }
+
+  introspect(): IntrospectionResult {
+    if (this.agent.introspect) {
+      return this.agent.introspect();
+    }
+    return {
+      timestamp: new Date().toISOString(),
+      agentName: this.name,
+      capabilities: this.capabilities,
+      internalState: {},
+      metadata: {},
+    };
+  }
+
+  /**
+   * Process a message, injecting relevant skill instructions first.
+   *
+   * Finds skills relevant to the message content, builds an
+   * `<available_skills>` block, and prepends it to the message content before
+   * passing to the wrapped agent. The returned message's metadata will include
+   * `active_skills`.
+   */
+  async process(message: Message): Promise<Message> {
+    const query = message.content != null ? String(message.content) : '';
+    const relevant = this.registry.findRelevantSkills(query, this.maxActiveSkills);
+
+    if (relevant.length > 0) {
+      const skillBlocks = relevant.map((skill) => skill.toPrompt()).join('\n\n');
+      const prefix = `<available_skills>\n${skillBlocks}\n</available_skills>\n\n`;
+      const augmentedContent = prefix + query;
+
+      const newMetadata: Record<string, unknown> = { ...(message.metadata ?? {}) };
+      newMetadata.active_skills = relevant.map((skill) => skill.name);
+
+      const enhanced: Message = {
+        ...message,
+        content: augmentedContent,
+        metadata: newMetadata,
+      };
+      return this.agent.process(enhanced);
+    }
+
+    return this.agent.process(message);
+  }
+}

--- a/agenkit-ts/src/skills/index.ts
+++ b/agenkit-ts/src/skills/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Agent Skills — directory-based, discoverable units of agent capability.
+ *
+ * Each skill is a directory containing a SKILL.md file with YAML frontmatter
+ * (name, description, optional license and metadata) followed by Markdown
+ * instructions.
+ *
+ * Classes:
+ *   AgentSkill: A single skill loaded from a directory.
+ *   SkillRegistry: Discovers and searches skills across filesystem paths.
+ *   SkillEnabledAgent: Wraps an Agent and injects relevant skill instructions.
+ *
+ * Example:
+ *   import { SkillRegistry, SkillEnabledAgent } from 'agenkit';
+ *
+ *   const registry = new SkillRegistry(['./skills']);
+ *   const agent = new SkillEnabledAgent(baseAgent, registry);
+ *   const response = await agent.process({ role: 'user', content: 'parse this pdf' });
+ */
+
+export { AgentSkill, SkillRegistry } from './loader';
+export { SkillEnabledAgent } from './agent';

--- a/agenkit-ts/src/skills/loader.ts
+++ b/agenkit-ts/src/skills/loader.ts
@@ -1,0 +1,288 @@
+/**
+ * Agent Skill loader and registry.
+ *
+ * Implements the Agent Skills specification: each skill is a directory containing
+ * a SKILL.md file with YAML frontmatter (name, description, optional license and
+ * metadata) followed by Markdown instructions.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as yaml from 'js-yaml';
+
+/**
+ * Represents a single agent skill loaded from a directory.
+ *
+ * A skill directory must contain a SKILL.md file structured as:
+ *   ---
+ *   name: skill-name
+ *   description: What this skill does.
+ *   license: Apache-2.0  # optional
+ *   metadata:            # optional
+ *     key: value
+ *   ---
+ *   # Skill Title
+ *   Markdown instructions here.
+ */
+export class AgentSkill {
+  /** Skill identifier. */
+  readonly name: string;
+
+  /** Human-readable description of what the skill does. */
+  readonly description: string;
+
+  /** Markdown instructions (body of SKILL.md). */
+  readonly instructions: string;
+
+  /** Optional license identifier. */
+  readonly license?: string;
+
+  /** Optional structured metadata. */
+  readonly metadata: Record<string, unknown>;
+
+  /** Optional path to the directory the skill was loaded from. */
+  readonly skillDir?: string;
+
+  constructor(params: {
+    name: string;
+    description: string;
+    instructions: string;
+    license?: string;
+    metadata?: Record<string, unknown>;
+    skillDir?: string;
+  }) {
+    this.name = params.name;
+    this.description = params.description;
+    this.instructions = params.instructions;
+    this.license = params.license;
+    this.metadata = params.metadata ?? {};
+    this.skillDir = params.skillDir;
+  }
+
+  /**
+   * Load a skill from a directory containing a SKILL.md file.
+   *
+   * @param skillDir Path to the skill directory.
+   * @returns AgentSkill instance.
+   * @throws Error if the directory lacks SKILL.md, has invalid frontmatter,
+   *         or is missing required fields (name, description).
+   */
+  static fromDirectory(skillDir: string): AgentSkill {
+    const skillFile = path.join(skillDir, 'SKILL.md');
+    if (!fs.existsSync(skillFile)) {
+      throw new Error(`No SKILL.md found in ${skillDir}`);
+    }
+
+    const raw = fs.readFileSync(skillFile, 'utf-8');
+
+    // Split on "---" delimiters. File must start with "---".
+    // Mirror Python's str.split("---", 2): at most 3 parts.
+    const parts = splitMax(raw, '---', 3);
+    if (parts.length < 3) {
+      throw new Error(`Invalid SKILL.md in ${skillDir}: missing frontmatter delimiters`);
+    }
+
+    const frontmatterText = parts[1].trim();
+    const instructions = parts[2].trim();
+
+    let fm: unknown;
+    try {
+      fm = yaml.load(frontmatterText);
+    } catch (exc) {
+      throw new Error(`Invalid YAML frontmatter in ${skillDir}/SKILL.md: ${String(exc)}`);
+    }
+
+    if (typeof fm !== 'object' || fm === null || Array.isArray(fm)) {
+      throw new Error(`Invalid frontmatter in ${skillDir}/SKILL.md: expected YAML mapping`);
+    }
+
+    const fmMap = fm as Record<string, unknown>;
+
+    const name = fmMap.name;
+    if (!name) {
+      throw new Error(`Missing required field 'name' in ${skillDir}/SKILL.md`);
+    }
+
+    const description = fmMap.description;
+    if (!description) {
+      throw new Error(`Missing required field 'description' in ${skillDir}/SKILL.md`);
+    }
+
+    const license = fmMap.license;
+    const metadata = fmMap.metadata;
+
+    return new AgentSkill({
+      name: String(name),
+      description: String(description),
+      instructions,
+      license: license != null ? String(license) : undefined,
+      metadata:
+        typeof metadata === 'object' && metadata !== null && !Array.isArray(metadata)
+          ? (metadata as Record<string, unknown>)
+          : {},
+      skillDir,
+    });
+  }
+
+  /**
+   * Render the skill as a prompt block for injection into agent messages.
+   *
+   * @returns Formatted string with skill name, description, and instructions.
+   */
+  toPrompt(): string {
+    return (
+      `# Skill: ${this.name}\n\n` +
+      `## Description\n${this.description}\n\n` +
+      `## Instructions\n${this.instructions}\n`
+    );
+  }
+}
+
+/**
+ * Split a string on a separator into at most `limit` parts, mirroring
+ * Python's ``str.split(sep, maxsplit)`` where ``maxsplit = limit - 1``.
+ * The final part retains any further occurrences of the separator.
+ */
+function splitMax(value: string, sep: string, limit: number): string[] {
+  const result: string[] = [];
+  let rest = value;
+  while (result.length < limit - 1) {
+    const idx = rest.indexOf(sep);
+    if (idx === -1) {
+      break;
+    }
+    result.push(rest.slice(0, idx));
+    rest = rest.slice(idx + sep.length);
+  }
+  result.push(rest);
+  return result;
+}
+
+/**
+ * Discovers and searches agent skills across filesystem paths.
+ *
+ * Skills are discovered by walking search paths and loading any subdirectory
+ * that contains a SKILL.md file. Invalid skill directories are skipped with
+ * a warning.
+ */
+export class SkillRegistry {
+  private readonly searchPaths: string[];
+  private readonly _skills: Map<string, AgentSkill> = new Map();
+
+  constructor(searchPaths: string[]) {
+    this.searchPaths = searchPaths;
+  }
+
+  /**
+   * Walk each search path and load all valid skill directories.
+   *
+   * Skill directories without a SKILL.md or with invalid format are
+   * skipped and logged as warnings.
+   */
+  discoverSkills(): void {
+    for (const searchPath of this.searchPaths) {
+      let stat: fs.Stats;
+      try {
+        stat = fs.statSync(searchPath);
+      } catch {
+        continue;
+      }
+      if (!stat.isDirectory()) {
+        continue;
+      }
+
+      let entries: string[];
+      try {
+        entries = fs.readdirSync(searchPath);
+      } catch {
+        continue;
+      }
+
+      for (const entry of entries) {
+        const entryPath = path.join(searchPath, entry);
+        let entryStat: fs.Stats;
+        try {
+          entryStat = fs.statSync(entryPath);
+        } catch {
+          continue;
+        }
+        if (!entryStat.isDirectory()) {
+          continue;
+        }
+        if (!fs.existsSync(path.join(entryPath, 'SKILL.md'))) {
+          continue;
+        }
+        try {
+          const skill = AgentSkill.fromDirectory(entryPath);
+          this._skills.set(skill.name, skill);
+        } catch (exc) {
+          // eslint-disable-next-line no-console
+          console.warn(`skipping skill directory ${entryPath}: ${String(exc)}`);
+        }
+      }
+    }
+  }
+
+  /**
+   * Return skills most relevant to the given query string.
+   *
+   * Scoring:
+   *   +10 if query (lowercased) appears in skill name (lowercased)
+   *   +5  if query (lowercased) appears in skill description (lowercased)
+   *   +N  for each word in query that also appears in description
+   *
+   * Only skills with score > 0 are returned, sorted descending.
+   *
+   * @param query Natural-language query to match against skills.
+   * @param maxResults Maximum number of skills to return.
+   * @returns Ordered list of matching AgentSkill instances (best match first).
+   */
+  findRelevantSkills(query: string, maxResults = 5): AgentSkill[] {
+    const queryLower = query.toLowerCase();
+    const queryWords = new Set(queryLower.split(/\s+/).filter((w) => w.length > 0));
+
+    const scored: Array<{ score: number; skill: AgentSkill }> = [];
+    for (const skill of this._skills.values()) {
+      let score = 0;
+      const nameLower = skill.name.toLowerCase();
+      const descLower = skill.description.toLowerCase();
+
+      if (nameLower.includes(queryLower)) {
+        score += 10;
+      }
+      if (descLower.includes(queryLower)) {
+        score += 5;
+      }
+
+      const descWords = new Set(descLower.split(/\s+/).filter((w) => w.length > 0));
+      let wordOverlap = 0;
+      for (const word of queryWords) {
+        if (descWords.has(word)) {
+          wordOverlap += 1;
+        }
+      }
+      score += wordOverlap;
+
+      if (score > 0) {
+        scored.push({ score, skill });
+      }
+    }
+
+    scored.sort((a, b) => b.score - a.score);
+    return scored.slice(0, maxResults).map((s) => s.skill);
+  }
+
+  /** Return the skill with the given name, or undefined if not found. */
+  getSkill(name: string): AgentSkill | undefined {
+    return this._skills.get(name);
+  }
+
+  /** Read-only copy of loaded skills keyed by name. */
+  get skills(): Record<string, AgentSkill> {
+    const copy: Record<string, AgentSkill> = {};
+    for (const [name, skill] of this._skills.entries()) {
+      copy[name] = skill;
+    }
+    return copy;
+  }
+}


### PR DESCRIPTION
Part of #629. Ports Agent Skills to TypeScript, mirroring the Python/Go reference.

## Added
- `src/skills/loader.ts` — `AgentSkill` (`fromDirectory` parses SKILL.md frontmatter+markdown via **js-yaml**, already a dep; `toPrompt`) + `SkillRegistry` (`discoverSkills`, `findRelevantSkills` with +10/+5/+1-per-word scoring, `getSkill`, `skills`).
- `src/skills/agent.ts` — `SkillEnabledAgent implements Agent`; prepends `<available_skills>`, sets `active_skills` metadata, adds `skill_injection`.
- `src/skills/index.ts` + re-export from package root.
- `src/__tests__/skills.test.ts` — 18 vitest cases ported from the Python suite.

Error messages match the Python strings byte-for-byte. `active_skills` metadata key kept snake_case to match the cross-language contract.

## Verified
- `npx tsc --noEmit` clean
- **18/18 skills tests pass**