### PR TITLE
feat(cs): Agent Skills — AgentSkill, SkillRegistry, SkillEnabledAgent (#629)

### DIFF
--- a/agenkit-cs/src/Agenkit/Skills/AgentSkill.cs
+++ b/agenkit-cs/src/Agenkit/Skills/AgentSkill.cs
@@ -1,0 +1,127 @@
+namespace Agenkit.Skills;
+
+/// <summary>
+/// Represents a single agent skill loaded from a directory.
+///
+/// A skill directory must contain a SKILL.md file structured as:
+/// <code>
+/// ---
+/// name: skill-name
+/// description: What this skill does.
+/// license: Apache-2.0  # optional
+/// metadata:            # optional
+///   key: value
+/// ---
+/// # Skill Title
+/// Markdown instructions here.
+/// </code>
+/// </summary>
+public sealed class AgentSkill
+{
+    /// <summary>Unique name of the skill.</summary>
+    public string Name { get; }
+
+    /// <summary>Short human-readable description of what the skill does.</summary>
+    public string Description { get; }
+
+    /// <summary>Markdown instruction body for the skill.</summary>
+    public string Instructions { get; }
+
+    /// <summary>Optional SPDX license identifier.</summary>
+    public string? License { get; }
+
+    /// <summary>Optional metadata key/value pairs from the frontmatter.</summary>
+    public IReadOnlyDictionary<string, object> Metadata { get; }
+
+    /// <summary>Directory the skill was loaded from, or null if constructed directly.</summary>
+    public string? SkillDir { get; }
+
+    /// <summary>Creates an AgentSkill.</summary>
+    public AgentSkill(
+        string name,
+        string description,
+        string instructions,
+        string? license = null,
+        IReadOnlyDictionary<string, object>? metadata = null,
+        string? skillDir = null)
+    {
+        Name = name;
+        Description = description;
+        Instructions = instructions;
+        License = license;
+        Metadata = metadata ?? new Dictionary<string, object>();
+        SkillDir = skillDir;
+    }
+
+    /// <summary>
+    /// Loads a skill from a directory containing a SKILL.md file.
+    /// </summary>
+    /// <param name="skillDir">Path to the skill directory.</param>
+    /// <returns>An <see cref="AgentSkill"/> instance.</returns>
+    /// <exception cref="ArgumentException">
+    /// If the directory lacks SKILL.md, has invalid frontmatter, or is missing
+    /// required fields (name, description).
+    /// </exception>
+    public static AgentSkill FromDirectory(string skillDir)
+    {
+        var skillFile = Path.Combine(skillDir, "SKILL.md");
+        if (!File.Exists(skillFile))
+            throw new ArgumentException($"No SKILL.md found in {skillDir}");
+
+        var raw = File.ReadAllText(skillFile);
+
+        // Split on "---" delimiters (max 3 parts). File must start with "---".
+        var parts = SplitFrontmatter(raw);
+        if (parts.Length < 3)
+            throw new ArgumentException($"Invalid SKILL.md in {skillDir}: missing frontmatter delimiters");
+
+        var frontmatterText = parts[1].Trim();
+        var instructions = parts[2].Trim();
+
+        var fm = SimpleYaml.ParseMapping(frontmatterText);
+
+        if (!fm.TryGetValue("name", out var nameObj) || nameObj is not string name || string.IsNullOrEmpty(name))
+            throw new ArgumentException($"Missing required field 'name' in {skillDir}/SKILL.md");
+
+        if (!fm.TryGetValue("description", out var descObj) || descObj is not string description ||
+            string.IsNullOrEmpty(description))
+            throw new ArgumentException($"Missing required field 'description' in {skillDir}/SKILL.md");
+
+        string? license = fm.TryGetValue("license", out var licObj) ? licObj as string : null;
+
+        var metadata = fm.TryGetValue("metadata", out var metaObj) &&
+                       metaObj is IReadOnlyDictionary<string, object> meta
+            ? meta
+            : new Dictionary<string, object>();
+
+        return new AgentSkill(name, description, instructions, license, metadata, skillDir);
+    }
+
+    /// <summary>
+    /// Renders the skill as a prompt block for injection into agent messages.
+    /// </summary>
+    public string ToPrompt() =>
+        $"# Skill: {Name}\n\n" +
+        $"## Description\n{Description}\n\n" +
+        $"## Instructions\n{Instructions}\n";
+
+    // Splits raw text on "---" into at most 3 parts, mirroring Python's str.split("---", 2).
+    private static string[] SplitFrontmatter(string raw)
+    {
+        const string delim = "---";
+        var first = raw.IndexOf(delim, StringComparison.Ordinal);
+        if (first < 0)
+            return new[] { raw };
+
+        var second = raw.IndexOf(delim, first + delim.Length, StringComparison.Ordinal);
+        if (second < 0)
+            return new[] { raw[..first], raw[(first + delim.Length)..] };
+
+        return new[]
+        {
+            raw[..first],
+            raw[(first + delim.Length)..second],
+            raw[(second + delim.Length)..],
+        };
+    }
+}

--- a/agenkit-cs/src/Agenkit/Skills/SimpleYaml.cs
+++ b/agenkit-cs/src/Agenkit/Skills/SimpleYaml.cs
@@ -1,0 +1,95 @@
+namespace Agenkit.Skills;
+
+/// <summary>
+/// Minimal YAML mapping parser for skill frontmatter. Supports a flat set of
+/// <c>key: value</c> pairs plus a single level of nested mapping (e.g. a
+/// <c>metadata:</c> block whose child keys are indented). This deliberately
+/// covers only the subset of YAML used by SKILL.md frontmatter and avoids a
+/// third-party dependency.
+/// </summary>
+internal static class SimpleYaml
+{
+    /// <summary>
+    /// Parses frontmatter text into a string-keyed mapping. Nested blocks are
+    /// represented as <see cref="IReadOnlyDictionary{TKey,TValue}"/> values.
+    /// </summary>
+    public static IReadOnlyDictionary<string, object> ParseMapping(string text)
+    {
+        var result = new Dictionary<string, object>();
+        var lines = text.Replace("\r\n", "\n").Replace('\r', '\n').Split('\n');
+
+        for (var i = 0; i < lines.Length; i++)
+        {
+            var line = lines[i];
+            if (IsBlankOrComment(line))
+                continue;
+
+            // Top-level entries have no leading whitespace.
+            if (char.IsWhiteSpace(line[0]))
+                continue; // nested lines are consumed by their parent below
+
+            var colon = line.IndexOf(':');
+            if (colon < 0)
+                continue;
+
+            var key = line[..colon].Trim();
+            var valuePart = line[(colon + 1)..].Trim();
+
+            if (valuePart.Length == 0)
+            {
+                // Possible nested mapping: collect following indented lines.
+                var nested = new Dictionary<string, object>();
+                while (i + 1 < lines.Length)
+                {
+                    var next = lines[i + 1];
+                    if (IsBlankOrComment(next))
+                    {
+                        i++;
+                        continue;
+                    }
+
+                    if (!char.IsWhiteSpace(next[0]))
+                        break; // back to top level
+
+                    var nColon = next.IndexOf(':');
+                    if (nColon >= 0)
+                    {
+                        var nKey = next[..nColon].Trim();
+                        var nVal = next[(nColon + 1)..].Trim();
+                        if (nKey.Length > 0)
+                            nested[nKey] = Unquote(nVal);
+                    }
+
+                    i++;
+                }
+
+                result[key] = nested;
+            }
+            else
+            {
+                result[key] = Unquote(valuePart);
+            }
+        }
+
+        return result;
+    }
+
+    private static bool IsBlankOrComment(string line)
+    {
+        var trimmed = line.Trim();
+        return trimmed.Length == 0 || trimmed[0] == '#';
+    }
+
+    private static string Unquote(string value)
+    {
+        // Strip a trailing inline comment only when the value is unquoted.
+        if (value.Length >= 2 &&
+            ((value[0] == '\'' && value[^1] == '\'') ||
+             (value[0] == '"' && value[^1] == '"')))
+        {
+            return value[1..^1];
+        }
+
+        return value;
+    }
+}

--- a/agenkit-cs/src/Agenkit/Skills/SkillEnabledAgent.cs
+++ b/agenkit-cs/src/Agenkit/Skills/SkillEnabledAgent.cs
@@ -1,0 +1,75 @@
+using Agenkit.Core;
+
+namespace Agenkit.Skills;
+
+/// <summary>
+/// Agent wrapper that automatically injects relevant skill instructions.
+///
+/// Before delegating to the wrapped agent, this wrapper queries the registry
+/// for skills relevant to the incoming message and prepends their instructions
+/// inside an <c>&lt;available_skills&gt;</c> block. The augmented message's
+/// metadata contains <c>active_skills</c> listing the injected skill names.
+/// </summary>
+public sealed class SkillEnabledAgent : IAgent
+{
+    private readonly IAgent _agent;
+    private readonly SkillRegistry _registry;
+    private readonly int _maxActiveSkills;
+
+    /// <summary>Creates a skill-enabled agent wrapping <paramref name="agent"/>.</summary>
+    /// <param name="agent">Base agent to delegate processing to.</param>
+    /// <param name="registry">Registry used to look up relevant skills.</param>
+    /// <param name="maxActiveSkills">Maximum number of skills to inject (default 3).</param>
+    /// <param name="autoDiscover">Whether to call <see cref="SkillRegistry.DiscoverSkills"/> at construction (default true).</param>
+    public SkillEnabledAgent(
+        IAgent agent,
+        SkillRegistry registry,
+        int maxActiveSkills = 3,
+        bool autoDiscover = true)
+    {
+        _agent = agent;
+        _registry = registry;
+        _maxActiveSkills = maxActiveSkills;
+        if (autoDiscover)
+            _registry.DiscoverSkills();
+    }
+
+    /// <inheritdoc />
+    public string Name => _agent.Name;
+
+    /// <inheritdoc />
+    public IReadOnlyList<string> Capabilities
+    {
+        get
+        {
+            var caps = new List<string>(_agent.Capabilities);
+            if (!caps.Contains("skill_injection"))
+                caps.Add("skill_injection");
+            return caps;
+        }
+    }
+
+    /// <inheritdoc />
+    public IntrospectionResult Introspect() => _agent.Introspect();
+
+    /// <inheritdoc />
+    public Task<Message> ProcessAsync(Message message, CancellationToken ct = default)
+    {
+        var query = message.ContentString();
+        var relevant = _registry.FindRelevantSkills(query, _maxActiveSkills);
+
+        if (relevant.Count == 0)
+            return _agent.ProcessAsync(message, ct);
+
+        var skillBlocks = string.Join("\n\n", relevant.Select(s => s.ToPrompt()));
+        var augmentedContent = $"<available_skills>\n{skillBlocks}\n</available_skills>\n\n{query}";
+
+        var metadata = message.Metadata is not null
+            ? new Dictionary<string, object>(message.Metadata)
+            : new Dictionary<string, object>();
+        metadata["active_skills"] = relevant.Select(s => s.Name).ToList();
+
+        var enhanced = message with { Content = augmentedContent, Metadata = metadata };
+        return _agent.ProcessAsync(enhanced, ct);
+    }
+}

--- a/agenkit-cs/src/Agenkit/Skills/SkillRegistry.cs
+++ b/agenkit-cs/src/Agenkit/Skills/SkillRegistry.cs
@@ -1,0 +1,111 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Agenkit.Skills;
+
+/// <summary>
+/// Discovers and searches agent skills across filesystem paths.
+///
+/// Skills are discovered by walking search paths and loading any subdirectory
+/// that contains a SKILL.md file. Invalid skill directories are skipped with
+/// a warning.
+/// </summary>
+public sealed class SkillRegistry
+{
+    private readonly IReadOnlyList<string> _searchPaths;
+    private readonly Dictionary<string, AgentSkill> _skills = new(StringComparer.Ordinal);
+    private readonly ILogger _logger;
+
+    /// <summary>Creates a registry over the given search paths.</summary>
+    public SkillRegistry(IEnumerable<string> searchPaths, ILogger<SkillRegistry>? logger = null)
+    {
+        _searchPaths = searchPaths.ToList();
+        _logger = logger ?? NullLogger<SkillRegistry>.Instance;
+    }
+
+    /// <summary>
+    /// Walks each search path and loads all valid skill directories. Skill
+    /// directories without a SKILL.md or with invalid format are skipped and
+    /// logged as warnings.
+    /// </summary>
+    public void DiscoverSkills()
+    {
+        foreach (var searchPath in _searchPaths)
+        {
+            if (!Directory.Exists(searchPath))
+                continue;
+
+            foreach (var entry in Directory.EnumerateDirectories(searchPath))
+            {
+                if (!File.Exists(Path.Combine(entry, "SKILL.md")))
+                    continue;
+
+                try
+                {
+                    var skill = AgentSkill.FromDirectory(entry);
+                    _skills[skill.Name] = skill;
+                }
+                catch (ArgumentException ex)
+                {
+                    _logger.LogWarning("skipping skill directory {Entry}: {Message}", entry, ex.Message);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Returns skills most relevant to the given query string.
+    ///
+    /// Scoring:
+    /// <list type="bullet">
+    /// <item>+10 if query (lowercased) appears in the skill name (lowercased)</item>
+    /// <item>+5 if query (lowercased) appears in the skill description (lowercased)</item>
+    /// <item>+N for each query word that also appears in the description</item>
+    /// </list>
+    /// Only skills with score &gt; 0 are returned, sorted descending and capped
+    /// at <paramref name="maxResults"/>.
+    /// </summary>
+    public IReadOnlyList<AgentSkill> FindRelevantSkills(string query, int maxResults = 5)
+    {
+        var queryLower = query.ToLowerInvariant();
+        var queryWords = new HashSet<string>(
+            queryLower.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries),
+            StringComparer.Ordinal);
+
+        var scored = new List<(int Score, AgentSkill Skill)>();
+        foreach (var skill in _skills.Values)
+        {
+            var score = 0;
+            var nameLower = skill.Name.ToLowerInvariant();
+            var descLower = skill.Description.ToLowerInvariant();
+
+            if (nameLower.Contains(queryLower, StringComparison.Ordinal))
+                score += 10;
+            if (descLower.Contains(queryLower, StringComparison.Ordinal))
+                score += 5;
+
+            var descWords = new HashSet<string>(
+                descLower.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries),
+                StringComparer.Ordinal);
+            descWords.IntersectWith(queryWords);
+            score += descWords.Count;
+
+            if (score > 0)
+                scored.Add((score, skill));
+        }
+
+        return scored
+            .OrderByDescending(s => s.Score)
+            .Take(maxResults)
+            .Select(s => s.Skill)
+            .ToList();
+    }
+
+    /// <summary>Returns the skill with the given name, or null if not found.</summary>
+    public AgentSkill? GetSkill(string name) =>
+        _skills.TryGetValue(name, out var skill) ? skill : null;
+
+    /// <summary>Read-only copy of loaded skills keyed by name.</summary>
+    public IReadOnlyDictionary<string, AgentSkill> Skills =>
+        new Dictionary<string, AgentSkill>(_skills, StringComparer.Ordinal);
+}

--- a/agenkit-cs/tests/Agenkit.Tests/Skills/SkillEnabledAgentTests.cs
+++ b/agenkit-cs/tests/Agenkit.Tests/Skills/SkillEnabledAgentTests.cs
@@ -1,0 +1,103 @@
+using Agenkit.Core;
+using Agenkit.Skills;
+
+namespace Agenkit.Tests.Skills;
+
+public sealed class SkillEnabledAgentTests : IDisposable
+{
+    private readonly string _tmp;
+
+    public SkillEnabledAgentTests()
+    {
+        _tmp = Path.Combine(Path.GetTempPath(), "agenkit-skillagent-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tmp);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tmp))
+            Directory.Delete(_tmp, recursive: true);
+    }
+
+    private void MakeSkillDir(string name, string description, string body = "Instructions here.")
+    {
+        var skillDir = Path.Combine(_tmp, name);
+        Directory.CreateDirectory(skillDir);
+        var content = $"---\nname: {name}\ndescription: {description}\n---\n{body}";
+        File.WriteAllText(Path.Combine(skillDir, "SKILL.md"), content);
+    }
+
+    /// <summary>Agent that echoes its input content (and metadata) back.</summary>
+    private sealed class EchoAgent : IAgent
+    {
+        public string Name => "echo";
+        public IReadOnlyList<string> Capabilities => Array.Empty<string>();
+
+        public Task<Message> ProcessAsync(Message message, CancellationToken ct = default) =>
+            Task.FromResult(new Message("agent", message.Content, message.Metadata));
+
+        public IntrospectionResult Introspect() => new(Name, Capabilities);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_AugmentsMessage()
+    {
+        MakeSkillDir("pdf-processing", "Extract text from PDF documents.");
+        var registry = new SkillRegistry(new[] { _tmp });
+        var agent = new SkillEnabledAgent(new EchoAgent(), registry, autoDiscover: true);
+
+        var msg = new Message("user", "How do I parse pdf files?");
+        var response = await agent.ProcessAsync(msg);
+
+        response.ContentString().Should().Contain("<available_skills>");
+        response.ContentString().Should().Contain("pdf-processing");
+    }
+
+    [Fact]
+    public async Task ProcessAsync_NoSkillsPassthrough()
+    {
+        MakeSkillDir("email-compose", "Compose professional emails.");
+        var registry = new SkillRegistry(new[] { _tmp });
+        var agent = new SkillEnabledAgent(new EchoAgent(), registry, autoDiscover: true);
+
+        var msg = new Message("user", "tell me a joke");
+        var response = await agent.ProcessAsync(msg);
+
+        response.ContentString().Should().NotContain("<available_skills>");
+        response.ContentString().Should().Be("tell me a joke");
+    }
+
+    [Fact]
+    public async Task ProcessAsync_ActiveSkillsMetadata()
+    {
+        MakeSkillDir("csv-tools", "Handle and transform CSV spreadsheets.");
+        var registry = new SkillRegistry(new[] { _tmp });
+        var agent = new SkillEnabledAgent(new EchoAgent(), registry, autoDiscover: true);
+
+        var msg = new Message("user", "parse this csv spreadsheet data");
+        var response = await agent.ProcessAsync(msg);
+
+        response.Metadata.Should().NotBeNull();
+        response.Metadata!.Should().ContainKey("active_skills");
+        var active = (IReadOnlyList<string>)response.Metadata!["active_skills"];
+        active.Should().Contain("csv-tools");
+    }
+
+    [Fact]
+    public void Capabilities_IncludesSkillInjection()
+    {
+        var registry = new SkillRegistry(new[] { _tmp });
+        var agent = new SkillEnabledAgent(new EchoAgent(), registry, autoDiscover: false);
+
+        agent.Capabilities.Should().Contain("skill_injection");
+    }
+
+    [Fact]
+    public void Name_Delegates()
+    {
+        var registry = new SkillRegistry(new[] { _tmp });
+        var agent = new SkillEnabledAgent(new EchoAgent(), registry, autoDiscover: false);
+
+        agent.Name.Should().Be("echo");
+    }
+}

--- a/agenkit-cs/tests/Agenkit.Tests/Skills/SkillLoaderTests.cs
+++ b/agenkit-cs/tests/Agenkit.Tests/Skills/SkillLoaderTests.cs
@@ -1,0 +1,191 @@
+using Agenkit.Skills;
+
+namespace Agenkit.Tests.Skills;
+
+public sealed class SkillLoaderTests : IDisposable
+{
+    private readonly string _tmp;
+
+    public SkillLoaderTests()
+    {
+        _tmp = Path.Combine(Path.GetTempPath(), "agenkit-skills-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tmp);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tmp))
+            Directory.Delete(_tmp, recursive: true);
+    }
+
+    private string MakeSkillDir(string name, string description, string body = "Instructions here.")
+    {
+        var skillDir = Path.Combine(_tmp, name);
+        Directory.CreateDirectory(skillDir);
+        var content = $"---\nname: {name}\ndescription: {description}\n---\n{body}";
+        File.WriteAllText(Path.Combine(skillDir, "SKILL.md"), content);
+        return skillDir;
+    }
+
+    // ----- AgentSkill.FromDirectory -----
+
+    [Fact]
+    public void FromDirectory_ValidSkill()
+    {
+        var skillDir = MakeSkillDir("pdf-processing", "Extract text from PDFs.", "# PDF\nDo stuff.");
+        var skill = AgentSkill.FromDirectory(skillDir);
+
+        skill.Name.Should().Be("pdf-processing");
+        skill.Description.Should().Be("Extract text from PDFs.");
+        skill.Instructions.Should().Contain("Do stuff.");
+        skill.SkillDir.Should().Be(skillDir);
+    }
+
+    [Fact]
+    public void FromDirectory_WithLicenseAndMetadata()
+    {
+        var skillDir = Path.Combine(_tmp, "advanced");
+        Directory.CreateDirectory(skillDir);
+        var content =
+            "---\n" +
+            "name: advanced\n" +
+            "description: Advanced skill.\n" +
+            "license: Apache-2.0\n" +
+            "metadata:\n" +
+            "  version: '1.0'\n" +
+            "---\n" +
+            "Advanced instructions.";
+        File.WriteAllText(Path.Combine(skillDir, "SKILL.md"), content);
+
+        var skill = AgentSkill.FromDirectory(skillDir);
+
+        skill.License.Should().Be("Apache-2.0");
+        skill.Metadata.Should().ContainKey("version");
+        skill.Metadata["version"].Should().Be("1.0");
+    }
+
+    [Fact]
+    public void FromDirectory_MissingSkillMd_Throws()
+    {
+        var emptyDir = Path.Combine(_tmp, "empty");
+        Directory.CreateDirectory(emptyDir);
+
+        var act = () => AgentSkill.FromDirectory(emptyDir);
+        act.Should().Throw<ArgumentException>().WithMessage("*No SKILL.md found*");
+    }
+
+    [Fact]
+    public void FromDirectory_InvalidFrontmatter_Throws()
+    {
+        var skillDir = Path.Combine(_tmp, "bad");
+        Directory.CreateDirectory(skillDir);
+        // Missing second "---" delimiter.
+        File.WriteAllText(Path.Combine(skillDir, "SKILL.md"), "name: foo\ndescription: bar\n");
+
+        var act = () => AgentSkill.FromDirectory(skillDir);
+        act.Should().Throw<ArgumentException>().WithMessage("*missing frontmatter delimiters*");
+    }
+
+    [Fact]
+    public void FromDirectory_MissingName_Throws()
+    {
+        var skillDir = Path.Combine(_tmp, "noname");
+        Directory.CreateDirectory(skillDir);
+        File.WriteAllText(
+            Path.Combine(skillDir, "SKILL.md"),
+            "---\ndescription: A skill without a name.\n---\nInstructions.");
+
+        var act = () => AgentSkill.FromDirectory(skillDir);
+        act.Should().Throw<ArgumentException>().WithMessage("*Missing required field 'name'*");
+    }
+
+    [Fact]
+    public void FromDirectory_MissingDescription_Throws()
+    {
+        var skillDir = Path.Combine(_tmp, "nodesc");
+        Directory.CreateDirectory(skillDir);
+        File.WriteAllText(
+            Path.Combine(skillDir, "SKILL.md"),
+            "---\nname: nodesc\n---\nInstructions.");
+
+        var act = () => AgentSkill.FromDirectory(skillDir);
+        act.Should().Throw<ArgumentException>().WithMessage("*Missing required field 'description'*");
+    }
+
+    [Fact]
+    public void ToPrompt_RendersBlock()
+    {
+        var skillDir = MakeSkillDir("csv-tools", "Handle CSV files.", "Parse and write CSV.");
+        var skill = AgentSkill.FromDirectory(skillDir);
+        var prompt = skill.ToPrompt();
+
+        prompt.Should().Contain("# Skill: csv-tools");
+        prompt.Should().Contain("## Description");
+        prompt.Should().Contain("Handle CSV files.");
+        prompt.Should().Contain("## Instructions");
+        prompt.Should().Contain("Parse and write CSV.");
+    }
+
+    // ----- SkillRegistry -----
+
+    [Fact]
+    public void Discover_SkipsNonDirs()
+    {
+        File.WriteAllText(Path.Combine(_tmp, "not_a_dir.md"), "ignored");
+        var registry = new SkillRegistry(new[] { _tmp });
+        registry.DiscoverSkills();
+
+        registry.Skills.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Discover_LoadsValidSkills()
+    {
+        MakeSkillDir("skill-a", "Skill A description.");
+        MakeSkillDir("skill-b", "Skill B description.");
+        var registry = new SkillRegistry(new[] { _tmp });
+        registry.DiscoverSkills();
+
+        registry.Skills.Should().ContainKey("skill-a");
+        registry.Skills.Should().ContainKey("skill-b");
+    }
+
+    [Fact]
+    public void FindRelevant_NameMatch()
+    {
+        MakeSkillDir("pdf-processing", "Work with PDF documents.");
+        MakeSkillDir("csv-tools", "Handle CSV spreadsheets.");
+        var registry = new SkillRegistry(new[] { _tmp });
+        registry.DiscoverSkills();
+
+        var results = registry.FindRelevantSkills("pdf");
+        results.Should().HaveCountGreaterThanOrEqualTo(1);
+        results[0].Name.Should().Be("pdf-processing");
+    }
+
+    [Fact]
+    public void FindRelevant_MaxResults()
+    {
+        for (var i = 0; i < 6; i++)
+            MakeSkillDir($"skill-{i}", $"A skill about document processing number {i}.");
+        var registry = new SkillRegistry(new[] { _tmp });
+        registry.DiscoverSkills();
+
+        var results = registry.FindRelevantSkills("document", maxResults: 3);
+        results.Count.Should().BeLessThanOrEqualTo(3);
+    }
+
+    [Fact]
+    public void GetSkill_ReturnsOrNull()
+    {
+        MakeSkillDir("email-compose", "Compose professional emails.");
+        var registry = new SkillRegistry(new[] { _tmp });
+        registry.DiscoverSkills();
+
+        var skill = registry.GetSkill("email-compose");
+        skill.Should().NotBeNull();
+        skill!.Name.Should().Be("email-compose");
+
+        registry.GetSkill("nonexistent").Should().BeNull();
+    }
+}


### PR DESCRIPTION
Part of #629. Ports Agent Skills to C#/.NET, mirroring the Python/Go reference.

## Added
- `src/Agenkit/Skills/AgentSkill.cs` — `FromDirectory` parses SKILL.md frontmatter+markdown; `ToPrompt`; throws `ArgumentException` with the reference messages.
- `SimpleYaml.cs` — minimal frontmatter parser (no YAML NuGet dep).
- `SkillRegistry.cs` — `DiscoverSkills`, `FindRelevantSkills` (+10/+5/+1-per-word), `GetSkill`, `Skills`; optional `ILogger` (DI convention, defaults to Null).
- `SkillEnabledAgent.cs` — implements `IAgent`, prepends `<available_skills>`, sets `active_skills` metadata, adds `skill_injection`.
- `tests/.../Skills/` — 17 xUnit cases (FluentAssertions v8) ported from the Python suite.

## Verified
- `dotnet build` clean (0 errors)
- **17/17 skills tests pass**; full suite **270 passed**