### PR TITLE
feat(java): Agent Skills — AgentSkill, SkillRegistry, SkillEnabledAgent (#629)

### DIFF
--- a/agenkit-java/src/main/java/io/agenkit/skills/AgentSkill.java
+++ b/agenkit-java/src/main/java/io/agenkit/skills/AgentSkill.java
@@ -1,0 +1,209 @@
+package io.agenkit.skills;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Represents a single agent skill loaded from a directory.
+ *
+ * <p>A skill directory must contain a {@code SKILL.md} file structured as:
+ * <pre>{@code
+ * ---
+ * name: skill-name
+ * description: What this skill does.
+ * license: Apache-2.0  # optional
+ * metadata:            # optional
+ *   key: value
+ * ---
+ * # Skill Title
+ * Markdown instructions here.
+ * }</pre>
+ */
+public final class AgentSkill {
+
+    private final String name;
+    private final String description;
+    private final String instructions;
+    private final String license;
+    private final Map<String, Object> metadata;
+    private final Path skillDir;
+
+    public AgentSkill(
+            String name,
+            String description,
+            String instructions,
+            String license,
+            Map<String, Object> metadata,
+            Path skillDir) {
+        this.name = name;
+        this.description = description;
+        this.instructions = instructions;
+        this.license = license;
+        this.metadata = metadata != null
+                ? Collections.unmodifiableMap(new LinkedHashMap<>(metadata))
+                : Collections.emptyMap();
+        this.skillDir = skillDir;
+    }
+
+    /**
+     * Load a skill from a directory containing a {@code SKILL.md} file.
+     *
+     * @param skillDir path to the skill directory
+     * @return the loaded skill
+     * @throws IllegalArgumentException if the directory lacks SKILL.md, has
+     *         invalid frontmatter, or is missing required fields (name, description)
+     */
+    public static AgentSkill fromDirectory(Path skillDir) {
+        Path skillFile = skillDir.resolve("SKILL.md");
+        if (!Files.exists(skillFile)) {
+            throw new IllegalArgumentException("No SKILL.md found in " + skillDir);
+        }
+
+        String raw;
+        try {
+            raw = Files.readString(skillFile, StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new UncheckedIOException("failed to read " + skillFile, e);
+        }
+
+        // Split on "---" delimiters into at most 3 parts. File must start with "---".
+        String[] parts = raw.split("---", 3);
+        if (parts.length < 3) {
+            throw new IllegalArgumentException(
+                    "Invalid SKILL.md in " + skillDir + ": missing frontmatter delimiters");
+        }
+
+        String frontmatterText = parts[1].strip();
+        String instructions = parts[2].strip();
+
+        Map<String, Object> fm = parseFrontmatter(frontmatterText);
+
+        Object name = fm.get("name");
+        if (name == null || name.toString().isEmpty()) {
+            throw new IllegalArgumentException(
+                    "Missing required field 'name' in " + skillDir + "/SKILL.md");
+        }
+
+        Object description = fm.get("description");
+        if (description == null || description.toString().isEmpty()) {
+            throw new IllegalArgumentException(
+                    "Missing required field 'description' in " + skillDir + "/SKILL.md");
+        }
+
+        Object license = fm.get("license");
+        Object metadata = fm.get("metadata");
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> metadataMap = metadata instanceof Map
+                ? (Map<String, Object>) metadata
+                : Collections.emptyMap();
+
+        return new AgentSkill(
+                name.toString(),
+                description.toString(),
+                instructions,
+                license != null ? license.toString() : null,
+                metadataMap,
+                skillDir);
+    }
+
+    /**
+     * Minimal YAML frontmatter parser. Supports flat {@code key: value} pairs
+     * and a single level of nested mapping under a key with an empty value
+     * (e.g. {@code metadata:}) whose entries are indented. Quotes around scalar
+     * values are stripped.
+     */
+    private static Map<String, Object> parseFrontmatter(String text) {
+        Map<String, Object> result = new LinkedHashMap<>();
+        Map<String, Object> nested = null;
+        String[] lines = text.split("\n", -1);
+
+        for (String line : lines) {
+            if (line.isBlank() || line.strip().startsWith("#")) {
+                continue;
+            }
+
+            boolean indented = line.startsWith("  ") || line.startsWith("\t");
+            String trimmed = line.strip();
+            int colon = trimmed.indexOf(':');
+            if (colon < 0) {
+                continue;
+            }
+
+            String key = trimmed.substring(0, colon).strip();
+            String value = trimmed.substring(colon + 1).strip();
+
+            if (indented && nested != null) {
+                nested.put(key, parseScalar(value));
+                continue;
+            }
+
+            if (value.isEmpty()) {
+                // Begin a nested mapping (e.g. "metadata:").
+                nested = new LinkedHashMap<>();
+                result.put(key, nested);
+            } else {
+                nested = null;
+                result.put(key, parseScalar(value));
+            }
+        }
+
+        return result;
+    }
+
+    private static Object parseScalar(String value) {
+        if (value.length() >= 2
+                && ((value.startsWith("\"") && value.endsWith("\""))
+                || (value.startsWith("'") && value.endsWith("'")))) {
+            return value.substring(1, value.length() - 1);
+        }
+        return value;
+    }
+
+    /**
+     * Render the skill as a prompt block for injection into agent messages.
+     *
+     * @return formatted string with skill name, description, and instructions
+     */
+    public String toPrompt() {
+        return "# Skill: " + name + "\n\n"
+                + "## Description\n" + description + "\n\n"
+                + "## Instructions\n" + instructions + "\n";
+    }
+
+    public String getName() { return name; }
+    public String getDescription() { return description; }
+    public String getInstructions() { return instructions; }
+    public Optional<String> getLicense() { return Optional.ofNullable(license); }
+    public Map<String, Object> getMetadata() { return metadata; }
+    public Optional<Path> getSkillDir() { return Optional.ofNullable(skillDir); }
+
+    @Override
+    public String toString() {
+        return "AgentSkill{name='" + name + "', description='" + description + "'}";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof AgentSkill s)) return false;
+        return name.equals(s.name)
+                && description.equals(s.description)
+                && instructions.equals(s.instructions)
+                && java.util.Objects.equals(license, s.license)
+                && metadata.equals(s.metadata)
+                && java.util.Objects.equals(skillDir, s.skillDir);
+    }
+
+    @Override
+    public int hashCode() {
+        return java.util.Objects.hash(name, description, instructions, license, metadata, skillDir);
+    }
+}

--- a/agenkit-java/src/main/java/io/agenkit/skills/SkillEnabledAgent.java
+++ b/agenkit-java/src/main/java/io/agenkit/skills/SkillEnabledAgent.java
@@ -1,0 +1,98 @@
+package io.agenkit.skills;
+
+import io.agenkit.core.Agent;
+import io.agenkit.core.IntrospectionResult;
+import io.agenkit.core.Message;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+/**
+ * Agent wrapper that automatically injects relevant skill instructions.
+ *
+ * <p>Before delegating to the wrapped agent, this wrapper queries the registry
+ * for skills relevant to the incoming message and prepends their instructions
+ * inside an {@code <available_skills>} block. The response's metadata will
+ * contain {@code active_skills} listing the skill names that were injected.
+ */
+public final class SkillEnabledAgent implements Agent {
+
+    private static final String SKILL_INJECTION = "skill_injection";
+
+    private final Agent agent;
+    private final SkillRegistry registry;
+    private final int maxActiveSkills;
+
+    /**
+     * @param agent base agent to delegate processing to
+     * @param registry registry used to look up relevant skills
+     * @param maxActiveSkills maximum number of skills to inject (default 3)
+     * @param autoDiscover whether to call {@link SkillRegistry#discoverSkills()}
+     *        at construction time (default true)
+     */
+    public SkillEnabledAgent(
+            Agent agent,
+            SkillRegistry registry,
+            int maxActiveSkills,
+            boolean autoDiscover) {
+        this.agent = agent;
+        this.registry = registry;
+        this.maxActiveSkills = maxActiveSkills;
+        if (autoDiscover) {
+            this.registry.discoverSkills();
+        }
+    }
+
+    /** Construct with the default maximum of 3 active skills and auto-discovery enabled. */
+    public SkillEnabledAgent(Agent agent, SkillRegistry registry) {
+        this(agent, registry, 3, true);
+    }
+
+    @Override
+    public String getName() {
+        return agent.getName();
+    }
+
+    @Override
+    public List<String> getCapabilities() {
+        List<String> base = new ArrayList<>(agent.getCapabilities());
+        if (!base.contains(SKILL_INJECTION)) {
+            base.add(SKILL_INJECTION);
+        }
+        return base;
+    }
+
+    @Override
+    public IntrospectionResult introspect() {
+        return agent.introspect();
+    }
+
+    @Override
+    public CompletableFuture<Message> process(Message message) {
+        String query = message.contentString();
+        List<AgentSkill> relevant = registry.findRelevantSkills(query, maxActiveSkills);
+
+        if (relevant.isEmpty()) {
+            return agent.process(message);
+        }
+
+        String skillBlocks = relevant.stream()
+                .map(AgentSkill::toPrompt)
+                .collect(Collectors.joining("\n\n"));
+        String prefix = "<available_skills>\n" + skillBlocks + "\n</available_skills>\n\n";
+        String augmentedContent = prefix + query;
+
+        Map<String, Object> newMetadata = new HashMap<>(message.getMetadata());
+        newMetadata.put("active_skills",
+                relevant.stream().map(AgentSkill::getName).collect(Collectors.toList()));
+
+        Message enhanced = new Message(
+                message.getRole(), augmentedContent, newMetadata, message.getTimestamp());
+
+        return agent.process(enhanced);
+    }
+}

--- a/agenkit-java/src/main/java/io/agenkit/skills/SkillRegistry.java
+++ b/agenkit-java/src/main/java/io/agenkit/skills/SkillRegistry.java
@@ -1,0 +1,132 @@
+package io.agenkit.skills;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Discovers and searches agent skills across filesystem paths.
+ *
+ * <p>Skills are discovered by walking search paths and loading any subdirectory
+ * that contains a {@code SKILL.md} file. Invalid skill directories are skipped
+ * with a warning.
+ */
+public final class SkillRegistry {
+
+    private static final Logger log = LoggerFactory.getLogger(SkillRegistry.class);
+
+    private final List<Path> searchPaths;
+    private final Map<String, AgentSkill> skills = new LinkedHashMap<>();
+
+    public SkillRegistry(List<Path> searchPaths) {
+        this.searchPaths = new ArrayList<>(searchPaths);
+    }
+
+    /**
+     * Walk each search path and load all valid skill directories.
+     *
+     * <p>Skill directories without a {@code SKILL.md} or with invalid format are
+     * skipped and logged as warnings.
+     */
+    public void discoverSkills() {
+        for (Path searchPath : searchPaths) {
+            if (!Files.isDirectory(searchPath)) {
+                continue;
+            }
+            try (Stream<Path> entries = Files.list(searchPath)) {
+                List<Path> dirs = entries
+                        .filter(Files::isDirectory)
+                        .filter(entry -> Files.exists(entry.resolve("SKILL.md")))
+                        .collect(Collectors.toList());
+                for (Path entry : dirs) {
+                    try {
+                        AgentSkill skill = AgentSkill.fromDirectory(entry);
+                        skills.put(skill.getName(), skill);
+                    } catch (IllegalArgumentException exc) {
+                        log.warn("skipping skill directory {}: {}", entry, exc.getMessage());
+                    }
+                }
+            } catch (IOException exc) {
+                log.warn("failed to list search path {}: {}", searchPath, exc.getMessage());
+            }
+        }
+    }
+
+    /**
+     * Return skills most relevant to the given query string.
+     *
+     * <p>Scoring:
+     * <ul>
+     *   <li>+10 if query (lowercased) appears in skill name (lowercased)</li>
+     *   <li>+5 if query (lowercased) appears in skill description (lowercased)</li>
+     *   <li>+N for each word in query that also appears in description</li>
+     * </ul>
+     * Only skills with score &gt; 0 are returned, sorted descending.
+     *
+     * @param query natural-language query to match against skills
+     * @param maxResults maximum number of skills to return
+     * @return ordered list of matching skills (best match first)
+     */
+    public List<AgentSkill> findRelevantSkills(String query, int maxResults) {
+        String queryLower = query.toLowerCase();
+        Set<String> queryWords = new HashSet<>(Arrays.asList(queryLower.split("\\s+")));
+
+        List<AgentSkill> scored = skills.values().stream()
+                .map(skill -> Map.entry(score(skill, queryLower, queryWords), skill))
+                .filter(e -> e.getKey() > 0)
+                .sorted(Comparator.comparingInt(Map.Entry<Integer, AgentSkill>::getKey).reversed())
+                .limit(Math.max(0, maxResults))
+                .map(Map.Entry::getValue)
+                .collect(Collectors.toList());
+
+        return scored;
+    }
+
+    /** Find relevant skills using the default maximum of 5 results. */
+    public List<AgentSkill> findRelevantSkills(String query) {
+        return findRelevantSkills(query, 5);
+    }
+
+    private static int score(AgentSkill skill, String queryLower, Set<String> queryWords) {
+        int score = 0;
+        String nameLower = skill.getName().toLowerCase();
+        String descLower = skill.getDescription().toLowerCase();
+
+        if (nameLower.contains(queryLower)) {
+            score += 10;
+        }
+        if (descLower.contains(queryLower)) {
+            score += 5;
+        }
+
+        Set<String> descWords = new HashSet<>(Arrays.asList(descLower.split("\\s+")));
+        descWords.retainAll(queryWords);
+        score += descWords.size();
+
+        return score;
+    }
+
+    /** Return the skill with the given name, if present. */
+    public Optional<AgentSkill> getSkill(String name) {
+        return Optional.ofNullable(skills.get(name));
+    }
+
+    /** Read-only copy of loaded skills keyed by name. */
+    public Map<String, AgentSkill> getSkills() {
+        return new LinkedHashMap<>(skills);
+    }
+}

--- a/agenkit-java/src/test/java/io/agenkit/skills/SkillEnabledAgentTest.java
+++ b/agenkit-java/src/test/java/io/agenkit/skills/SkillEnabledAgentTest.java
@@ -1,0 +1,113 @@
+package io.agenkit.skills;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.agenkit.core.Agent;
+import io.agenkit.core.IntrospectionResult;
+import io.agenkit.core.Message;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class SkillEnabledAgentTest {
+
+    private static Path makeSkillDir(Path base, String name, String description) throws IOException {
+        Path skillDir = base.resolve(name);
+        Files.createDirectories(skillDir);
+        String content = "---\nname: " + name + "\ndescription: " + description
+                + "\n---\nInstructions here.";
+        Files.writeString(skillDir.resolve("SKILL.md"), content, StandardCharsets.UTF_8);
+        return skillDir;
+    }
+
+    /** Agent that echoes its input content back. */
+    private static final class EchoAgent implements Agent {
+        @Override
+        public String getName() {
+            return "echo";
+        }
+
+        @Override
+        public List<String> getCapabilities() {
+            return List.of();
+        }
+
+        @Override
+        public CompletableFuture<Message> process(Message message) {
+            return CompletableFuture.completedFuture(
+                    new Message("agent", message.getContent(),
+                            new HashMap<>(message.getMetadata()), message.getTimestamp()));
+        }
+
+        @Override
+        public IntrospectionResult introspect() {
+            return new IntrospectionResult("echo", List.of(), null, null, null);
+        }
+    }
+
+    @Test
+    void skillAgentAugmentsMessage(@TempDir Path tmp) throws IOException, ExecutionException, InterruptedException {
+        makeSkillDir(tmp, "pdf-processing", "Extract text from PDF documents.");
+        SkillRegistry registry = new SkillRegistry(List.of(tmp));
+        SkillEnabledAgent agent = new SkillEnabledAgent(new EchoAgent(), registry, 3, true);
+
+        Message msg = Message.of("user", "How do I parse pdf files?");
+        Message response = agent.process(msg).get();
+
+        assertThat(response.contentString()).contains("<available_skills>");
+        assertThat(response.contentString()).contains("pdf-processing");
+    }
+
+    @Test
+    void skillAgentNoSkillsPassthrough(@TempDir Path tmp) throws IOException, ExecutionException, InterruptedException {
+        makeSkillDir(tmp, "email-compose", "Compose professional emails.");
+        SkillRegistry registry = new SkillRegistry(List.of(tmp));
+        SkillEnabledAgent agent = new SkillEnabledAgent(new EchoAgent(), registry, 3, true);
+
+        Message msg = Message.of("user", "tell me a joke");
+        Message response = agent.process(msg).get();
+
+        assertThat(response.contentString()).doesNotContain("<available_skills>");
+        assertThat(response.contentString()).isEqualTo("tell me a joke");
+    }
+
+    @Test
+    void skillAgentActiveSkillsMetadata(@TempDir Path tmp) throws IOException, ExecutionException, InterruptedException {
+        makeSkillDir(tmp, "csv-tools", "Handle and transform CSV spreadsheets.");
+        SkillRegistry registry = new SkillRegistry(List.of(tmp));
+        SkillEnabledAgent agent = new SkillEnabledAgent(new EchoAgent(), registry, 3, true);
+
+        Message msg = Message.of("user", "parse this csv spreadsheet data");
+        Message response = agent.process(msg).get();
+
+        assertThat(response.getMetadata()).containsKey("active_skills");
+        @SuppressWarnings("unchecked")
+        List<String> active = (List<String>) response.getMetadata().get("active_skills");
+        assertThat(active).contains("csv-tools");
+    }
+
+    @Test
+    void skillAgentCapabilities(@TempDir Path tmp) {
+        SkillRegistry registry = new SkillRegistry(List.of(tmp));
+        SkillEnabledAgent agent = new SkillEnabledAgent(new EchoAgent(), registry, 3, false);
+
+        assertThat(agent.getCapabilities()).contains("skill_injection");
+    }
+
+    @Test
+    void skillAgentNameDelegates(@TempDir Path tmp) {
+        SkillRegistry registry = new SkillRegistry(List.of(tmp));
+        SkillEnabledAgent agent = new SkillEnabledAgent(new EchoAgent(), registry, 3, false);
+
+        assertThat(agent.getName()).isEqualTo("echo");
+    }
+}

--- a/agenkit-java/src/test/java/io/agenkit/skills/SkillLoaderTest.java
+++ b/agenkit-java/src/test/java/io/agenkit/skills/SkillLoaderTest.java
@@ -1,0 +1,199 @@
+package io.agenkit.skills;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class SkillLoaderTest {
+
+    private static Path makeSkillDir(Path base, String name, String description) throws IOException {
+        return makeSkillDir(base, name, description, "Instructions here.");
+    }
+
+    private static Path makeSkillDir(Path base, String name, String description, String body)
+            throws IOException {
+        Path skillDir = base.resolve(name);
+        Files.createDirectories(skillDir);
+        String content = "---\nname: " + name + "\ndescription: " + description + "\n---\n" + body;
+        Files.writeString(skillDir.resolve("SKILL.md"), content, StandardCharsets.UTF_8);
+        return skillDir;
+    }
+
+    // -----------------------------------------------------------------------
+    // AgentSkill.fromDirectory
+    // -----------------------------------------------------------------------
+
+    @Test
+    void loadSkillValid(@TempDir Path tmp) throws IOException {
+        Path skillDir = makeSkillDir(tmp, "pdf-processing", "Extract text from PDFs.", "# PDF\nDo stuff.");
+        AgentSkill skill = AgentSkill.fromDirectory(skillDir);
+
+        assertThat(skill.getName()).isEqualTo("pdf-processing");
+        assertThat(skill.getDescription()).isEqualTo("Extract text from PDFs.");
+        assertThat(skill.getInstructions()).contains("Do stuff.");
+        assertThat(skill.getSkillDir()).hasValue(skillDir);
+    }
+
+    @Test
+    void loadSkillWithLicenseAndMetadata(@TempDir Path tmp) throws IOException {
+        Path skillDir = tmp.resolve("advanced");
+        Files.createDirectories(skillDir);
+        String content = "---\n"
+                + "name: advanced\n"
+                + "description: Advanced skill.\n"
+                + "license: Apache-2.0\n"
+                + "metadata:\n"
+                + "  version: '1.0'\n"
+                + "---\n"
+                + "Advanced instructions.";
+        Files.writeString(skillDir.resolve("SKILL.md"), content, StandardCharsets.UTF_8);
+
+        AgentSkill skill = AgentSkill.fromDirectory(skillDir);
+
+        assertThat(skill.getLicense()).hasValue("Apache-2.0");
+        assertThat(skill.getMetadata()).containsEntry("version", "1.0");
+    }
+
+    @Test
+    void loadSkillMissingSkillMd(@TempDir Path tmp) throws IOException {
+        Path emptyDir = tmp.resolve("empty");
+        Files.createDirectories(emptyDir);
+
+        assertThatThrownBy(() -> AgentSkill.fromDirectory(emptyDir))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("No SKILL.md found");
+    }
+
+    @Test
+    void loadSkillInvalidFrontmatter(@TempDir Path tmp) throws IOException {
+        Path skillDir = tmp.resolve("bad");
+        Files.createDirectories(skillDir);
+        // Missing second "---" delimiter.
+        Files.writeString(skillDir.resolve("SKILL.md"),
+                "name: foo\ndescription: bar\n", StandardCharsets.UTF_8);
+
+        assertThatThrownBy(() -> AgentSkill.fromDirectory(skillDir))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("missing frontmatter delimiters");
+    }
+
+    @Test
+    void loadSkillMissingName(@TempDir Path tmp) throws IOException {
+        Path skillDir = tmp.resolve("noname");
+        Files.createDirectories(skillDir);
+        String content = "---\ndescription: A skill without a name.\n---\nInstructions.";
+        Files.writeString(skillDir.resolve("SKILL.md"), content, StandardCharsets.UTF_8);
+
+        assertThatThrownBy(() -> AgentSkill.fromDirectory(skillDir))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Missing required field 'name'");
+    }
+
+    @Test
+    void loadSkillMissingDescription(@TempDir Path tmp) throws IOException {
+        Path skillDir = tmp.resolve("nodesc");
+        Files.createDirectories(skillDir);
+        String content = "---\nname: nodesc\n---\nInstructions.";
+        Files.writeString(skillDir.resolve("SKILL.md"), content, StandardCharsets.UTF_8);
+
+        assertThatThrownBy(() -> AgentSkill.fromDirectory(skillDir))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Missing required field 'description'");
+    }
+
+    @Test
+    void skillToPrompt(@TempDir Path tmp) throws IOException {
+        Path skillDir = makeSkillDir(tmp, "csv-tools", "Handle CSV files.", "Parse and write CSV.");
+        AgentSkill skill = AgentSkill.fromDirectory(skillDir);
+        String prompt = skill.toPrompt();
+
+        assertThat(prompt).contains("# Skill: csv-tools");
+        assertThat(prompt).contains("## Description");
+        assertThat(prompt).contains("Handle CSV files.");
+        assertThat(prompt).contains("## Instructions");
+        assertThat(prompt).contains("Parse and write CSV.");
+    }
+
+    // -----------------------------------------------------------------------
+    // SkillRegistry
+    // -----------------------------------------------------------------------
+
+    @Test
+    void registryDiscoverSkipsNonDirs(@TempDir Path tmp) throws IOException {
+        // A file (not directory) at the search path level must be ignored.
+        Files.writeString(tmp.resolve("not_a_dir.md"), "ignored", StandardCharsets.UTF_8);
+        SkillRegistry registry = new SkillRegistry(List.of(tmp));
+        registry.discoverSkills();
+
+        assertThat(registry.getSkills()).isEmpty();
+    }
+
+    @Test
+    void registryDiscoversValidSkills(@TempDir Path tmp) throws IOException {
+        makeSkillDir(tmp, "skill-a", "Skill A description.");
+        makeSkillDir(tmp, "skill-b", "Skill B description.");
+        SkillRegistry registry = new SkillRegistry(List.of(tmp));
+        registry.discoverSkills();
+
+        assertThat(registry.getSkills()).containsKeys("skill-a", "skill-b");
+    }
+
+    @Test
+    void registryDiscoverSkipsInvalidSkills(@TempDir Path tmp) throws IOException {
+        makeSkillDir(tmp, "good", "A valid skill.");
+        // Invalid: present SKILL.md but missing the required 'name' field.
+        Path bad = tmp.resolve("bad");
+        Files.createDirectories(bad);
+        Files.writeString(bad.resolve("SKILL.md"),
+                "---\ndescription: missing name.\n---\nbody", StandardCharsets.UTF_8);
+
+        SkillRegistry registry = new SkillRegistry(List.of(tmp));
+        registry.discoverSkills();
+
+        assertThat(registry.getSkills()).containsKey("good");
+        assertThat(registry.getSkills()).hasSize(1);
+    }
+
+    @Test
+    void registryFindRelevantNameMatch(@TempDir Path tmp) throws IOException {
+        makeSkillDir(tmp, "pdf-processing", "Work with PDF documents.");
+        makeSkillDir(tmp, "csv-tools", "Handle CSV spreadsheets.");
+        SkillRegistry registry = new SkillRegistry(List.of(tmp));
+        registry.discoverSkills();
+
+        List<AgentSkill> results = registry.findRelevantSkills("pdf");
+        assertThat(results).isNotEmpty();
+        assertThat(results.get(0).getName()).isEqualTo("pdf-processing");
+    }
+
+    @Test
+    void registryFindRelevantMaxResults(@TempDir Path tmp) throws IOException {
+        for (int i = 0; i < 6; i++) {
+            makeSkillDir(tmp, "skill-" + i, "A skill about document processing number " + i + ".");
+        }
+        SkillRegistry registry = new SkillRegistry(List.of(tmp));
+        registry.discoverSkills();
+
+        List<AgentSkill> results = registry.findRelevantSkills("document", 3);
+        assertThat(results).hasSizeLessThanOrEqualTo(3);
+    }
+
+    @Test
+    void registryGetSkill(@TempDir Path tmp) throws IOException {
+        makeSkillDir(tmp, "email-compose", "Compose professional emails.");
+        SkillRegistry registry = new SkillRegistry(List.of(tmp));
+        registry.discoverSkills();
+
+        assertThat(registry.getSkill("email-compose"))
+                .hasValueSatisfying(s -> assertThat(s.getName()).isEqualTo("email-compose"));
+        assertThat(registry.getSkill("nonexistent")).isEmpty();
+    }
+}


### PR DESCRIPTION
Part of #629. Ports Agent Skills to Java 17, mirroring the Python/Go reference.

## Added
- `AgentSkill.java` — `fromDirectory(Path)` parses SKILL.md; `toPrompt`; `getLicense`/`getSkillDir` return `Optional`; throws `IllegalArgumentException` with the reference messages. Minimal hand-written frontmatter parser (no YAML dep).
- `SkillRegistry.java` — `discoverSkills`, `findRelevantSkills` (+10/+5/+1-per-word) + maxResults overload, `getSkill` (Optional), `getSkills` (copy).
- `SkillEnabledAgent.java` — implements `Agent`, prepends `<available_skills>`, sets `active_skills` metadata, adds `skill_injection`.
- 18 JUnit 5 cases ported from the Python suite.

## Verified
- `mvn test-compile` clean
- **18/18 skills tests pass** (13 loader + 5 agent)