### PR TITLE
feat(scala): Agent Skills — AgentSkill, SkillRegistry, SkillEnabledAgent (#629)

### DIFF
--- a/agenkit-scala/src/main/scala/io/agenkit/skills/AgentSkill.scala
+++ b/agenkit-scala/src/main/scala/io/agenkit/skills/AgentSkill.scala
@@ -1,0 +1,151 @@
+package io.agenkit.skills
+
+import java.nio.file.{Files, Path}
+import scala.io.Source
+import scala.util.Using
+
+/** Represents a single agent skill loaded from a directory.
+  *
+  * A skill directory must contain a `SKILL.md` file structured as:
+  * {{{
+  * ---
+  * name: skill-name
+  * description: What this skill does.
+  * license: Apache-2.0  # optional
+  * metadata:            # optional
+  *   key: value
+  * ---
+  * # Skill Title
+  * Markdown instructions here.
+  * }}}
+  */
+case class AgentSkill(
+  name: String,
+  description: String,
+  instructions: String,
+  license: Option[String] = None,
+  metadata: Map[String, Any] = Map.empty,
+  skillDir: Option[Path] = None
+):
+  /** Render the skill as a prompt block for injection into agent messages. */
+  def toPrompt: String =
+    s"# Skill: $name\n\n" +
+      s"## Description\n$description\n\n" +
+      s"## Instructions\n$instructions\n"
+
+object AgentSkill:
+  /** Load a skill from a directory containing a `SKILL.md` file.
+    *
+    * @throws IllegalArgumentException
+    *   if the directory lacks `SKILL.md`, has invalid frontmatter, or is
+    *   missing required fields (name, description).
+    */
+  def fromDirectory(skillDir: Path): AgentSkill =
+    val skillFile = skillDir.resolve("SKILL.md")
+    if !Files.exists(skillFile) then
+      throw new IllegalArgumentException(s"No SKILL.md found in $skillDir")
+
+    val raw = Using.resource(Source.fromFile(skillFile.toFile, "UTF-8"))(_.mkString)
+
+    // Split on "---" delimiters. File must start with "---".
+    val parts = splitOnDelimiter(raw, "---", limit = 3)
+    if parts.length < 3 then
+      throw new IllegalArgumentException(
+        s"Invalid SKILL.md in $skillDir: missing frontmatter delimiters"
+      )
+
+    val frontmatterText = parts(1).strip()
+    val instructions    = parts(2).strip()
+
+    val fm = parseFrontmatter(frontmatterText)
+
+    val name = fm.get("name").collect { case s: String => s }.filter(_.nonEmpty)
+    if name.isEmpty then
+      throw new IllegalArgumentException(s"Missing required field 'name' in $skillDir/SKILL.md")
+
+    val description = fm.get("description").collect { case s: String => s }.filter(_.nonEmpty)
+    if description.isEmpty then
+      throw new IllegalArgumentException(
+        s"Missing required field 'description' in $skillDir/SKILL.md"
+      )
+
+    val license = fm.get("license").collect { case s: String => s }
+    val metadata = fm.get("metadata") match
+      case Some(m: Map[?, ?]) => m.asInstanceOf[Map[String, Any]]
+      case _                  => Map.empty[String, Any]
+
+    AgentSkill(
+      name = name.get,
+      description = description.get,
+      instructions = instructions,
+      license = license,
+      metadata = metadata,
+      skillDir = Some(skillDir)
+    )
+
+  /** Split `text` on `delimiter`, producing at most `limit` parts (mirrors
+    * Python's `str.split(sep, maxsplit)` where `limit == maxsplit + 1`).
+    */
+  private def splitOnDelimiter(text: String, delimiter: String, limit: Int): Array[String] =
+    val parts  = scala.collection.mutable.ArrayBuffer.empty[String]
+    var start  = 0
+    var splits = 0
+    var idx    = text.indexOf(delimiter, start)
+    while idx >= 0 && splits < limit - 1 do
+      parts += text.substring(start, idx)
+      start = idx + delimiter.length
+      splits += 1
+      idx = text.indexOf(delimiter, start)
+    parts += text.substring(start)
+    parts.toArray
+
+  /** Minimal YAML frontmatter parser supporting the subset used by skills:
+    * top-level `key: value` scalars plus a single nested mapping (e.g.
+    * `metadata:` followed by indented `key: value` lines). Quotes are stripped.
+    */
+  private def parseFrontmatter(text: String): Map[String, Any] =
+    val result = scala.collection.mutable.LinkedHashMap.empty[String, Any]
+    val arr    = text.split("\n", -1)
+    var i      = 0
+    while i < arr.length do
+      val line    = arr(i)
+      val trimmed = line.strip()
+      if trimmed.isEmpty || trimmed.startsWith("#") then i += 1
+      else if isTopLevel(line) then
+        val (key, value) = splitKeyValue(trimmed)
+        if value.isEmpty then
+          // Possible nested mapping: gather following indented lines.
+          val nested = scala.collection.mutable.LinkedHashMap.empty[String, Any]
+          var j      = i + 1
+          while j < arr.length && (arr(j).strip().isEmpty || isIndented(arr(j))) do
+            val nl = arr(j).strip()
+            if nl.nonEmpty && !nl.startsWith("#") then
+              val (nk, nv) = splitKeyValue(nl)
+              nested(nk) = stripQuotes(nv)
+            j += 1
+          if nested.nonEmpty then result(key) = nested.toMap
+          else result(key) = stripQuotes(value)
+          i = j
+        else
+          result(key) = stripQuotes(value)
+          i += 1
+      else i += 1
+    result.toMap
+
+  private def isTopLevel(line: String): Boolean =
+    line.nonEmpty && !line.charAt(0).isWhitespace
+
+  private def isIndented(line: String): Boolean =
+    line.nonEmpty && line.charAt(0).isWhitespace
+
+  private def splitKeyValue(line: String): (String, String) =
+    val idx = line.indexOf(':')
+    if idx < 0 then (line.strip(), "")
+    else (line.substring(0, idx).strip(), line.substring(idx + 1).strip())
+
+  private def stripQuotes(value: String): String =
+    if value.length >= 2 &&
+      ((value.startsWith("\"") && value.endsWith("\"")) ||
+        (value.startsWith("'") && value.endsWith("'")))
+    then value.substring(1, value.length - 1)
+    else value

--- a/agenkit-scala/src/main/scala/io/agenkit/skills/SkillEnabledAgent.scala
+++ b/agenkit-scala/src/main/scala/io/agenkit/skills/SkillEnabledAgent.scala
@@ -1,0 +1,60 @@
+package io.agenkit.skills
+
+import io.agenkit.core.{Agent, IntrospectionResult, Message}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+/** Agent wrapper that automatically injects relevant skill instructions.
+  *
+  * Before delegating to the wrapped agent, this wrapper queries the registry
+  * for skills relevant to the incoming message and prepends their instructions
+  * inside an `<available_skills>` block. The augmented message's metadata
+  * contains `active_skills` listing the injected skill names.
+  *
+  * @param agent
+  *   base agent to delegate processing to
+  * @param registry
+  *   [[SkillRegistry]] used to look up relevant skills
+  * @param maxActiveSkills
+  *   maximum number of skills to inject (default 3)
+  * @param autoDiscover
+  *   whether to call `registry.discoverSkills()` at construction time
+  *   (default true)
+  */
+class SkillEnabledAgent(
+  agent: Agent,
+  registry: SkillRegistry,
+  maxActiveSkills: Int = 3,
+  autoDiscover: Boolean = true
+) extends Agent:
+  if autoDiscover then registry.discoverSkills()
+
+  def name: String = agent.name
+
+  def capabilities: List[String] =
+    val base = agent.capabilities
+    if base.contains("skill_injection") then base else base :+ "skill_injection"
+
+  def introspect(): IntrospectionResult = agent.introspect()
+
+  /** Process a message, injecting relevant skill instructions first.
+    *
+    * Finds skills relevant to the message content, builds an
+    * `<available_skills>` block, and prepends it to the message content before
+    * passing it to the wrapped agent. The augmented message's metadata includes
+    * `active_skills`.
+    */
+  def process(message: Message)(using ExecutionContext): Future[Message] =
+    val query    = message.contentString
+    val relevant = registry.findRelevantSkills(query, maxResults = maxActiveSkills)
+
+    val enhanced =
+      if relevant.nonEmpty then
+        val skillBlocks       = relevant.map(_.toPrompt).mkString("\n\n")
+        val prefix            = s"<available_skills>\n$skillBlocks\n</available_skills>\n\n"
+        val augmentedContent  = prefix + query
+        val newMetadata       = message.metadata + ("active_skills" -> relevant.map(_.name))
+        message.copy(content = Some(augmentedContent), metadata = newMetadata)
+      else message
+
+    agent.process(enhanced)

--- a/agenkit-scala/src/main/scala/io/agenkit/skills/SkillRegistry.scala
+++ b/agenkit-scala/src/main/scala/io/agenkit/skills/SkillRegistry.scala
@@ -1,0 +1,71 @@
+package io.agenkit.skills
+
+import org.slf4j.LoggerFactory
+
+import java.nio.file.{Files, Path}
+import scala.jdk.CollectionConverters.*
+import scala.util.Using
+
+/** Discovers and searches agent skills across filesystem paths.
+  *
+  * Skills are discovered by walking search paths and loading any subdirectory
+  * that contains a `SKILL.md` file. Invalid skill directories are skipped with
+  * a warning.
+  */
+class SkillRegistry(searchPaths: List[Path]):
+  private val logger  = LoggerFactory.getLogger(getClass)
+  private val _skills = scala.collection.mutable.LinkedHashMap.empty[String, AgentSkill]
+
+  /** Walk each search path and load all valid skill directories.
+    *
+    * Skill directories without a `SKILL.md` or with invalid format are skipped
+    * and logged as warnings.
+    */
+  def discoverSkills(): Unit =
+    for searchPath <- searchPaths if Files.isDirectory(searchPath) do
+      val entries = Using.resource(Files.list(searchPath))(_.iterator().asScala.toList)
+      for entry <- entries if Files.isDirectory(entry) do
+        if Files.exists(entry.resolve("SKILL.md")) then
+          try
+            val skill = AgentSkill.fromDirectory(entry)
+            _skills(skill.name) = skill
+          catch
+            case exc: IllegalArgumentException =>
+              logger.warn("skipping skill directory {}: {}", entry, exc.getMessage)
+
+  /** Return skills most relevant to the given query string.
+    *
+    * Scoring:
+    *   - +10 if query (lowercased) appears in skill name (lowercased)
+    *   - +5 if query (lowercased) appears in skill description (lowercased)
+    *   - +N for each word in query that also appears in the description
+    *
+    * Only skills with score > 0 are returned, sorted descending and capped at
+    * `maxResults`.
+    */
+  def findRelevantSkills(query: String, maxResults: Int = 5): List[AgentSkill] =
+    val queryLower = query.toLowerCase
+    val queryWords = queryLower.split("\\s+").filter(_.nonEmpty).toSet
+
+    val scored = _skills.values.flatMap { skill =>
+      var score    = 0
+      val nameLower = skill.name.toLowerCase
+      val descLower = skill.description.toLowerCase
+
+      if nameLower.contains(queryLower) then score += 10
+      if descLower.contains(queryLower) then score += 5
+
+      val descWords    = descLower.split("\\s+").filter(_.nonEmpty).toSet
+      val wordOverlap  = queryWords.intersect(descWords).size
+      score += wordOverlap
+
+      if score > 0 then Some((score, skill)) else None
+    }.toList
+
+    scored.sortBy(-_._1).take(maxResults).map(_._2)
+
+  /** Return the skill with the given name, or `None` if not found. */
+  def getSkill(name: String): Option[AgentSkill] = _skills.get(name)
+
+  /** Read-only copy of loaded skills keyed by name. */
+  def skills: Map[String, AgentSkill] = _skills.toMap

--- a/agenkit-scala/src/test/scala/io/agenkit/skills/SkillEnabledAgentSpec.scala
+++ b/agenkit-scala/src/test/scala/io/agenkit/skills/SkillEnabledAgentSpec.scala
@@ -1,0 +1,73 @@
+package io.agenkit.skills
+
+import io.agenkit.core.{Agent, IntrospectionResult, Message}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import java.nio.file.{Files, Path}
+import scala.concurrent.duration.*
+import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class SkillEnabledAgentSpec extends AnyFunSuite with Matchers:
+
+  private def tempDir(): Path = Files.createTempDirectory("agenkit-skills-agent-")
+
+  private def makeSkillDir(
+    parent: Path,
+    name: String,
+    description: String,
+    body: String = "Instructions here."
+  ): Path =
+    val skillDir = Files.createDirectory(parent.resolve(name))
+    val content  = s"---\nname: $name\ndescription: $description\n---\n$body"
+    Files.writeString(skillDir.resolve("SKILL.md"), content)
+    skillDir
+
+  /** Agent that echoes its input content back. */
+  private class EchoAgent extends Agent:
+    def name: String                = "echo"
+    def capabilities: List[String]  = List.empty
+    def introspect(): IntrospectionResult = IntrospectionResult(name = name)
+    def process(message: Message)(using ExecutionContext): Future[Message] =
+      Future.successful(Message(role = "agent", content = message.content, metadata = message.metadata))
+
+  test("augments message with available_skills block"):
+    val parent = tempDir()
+    makeSkillDir(parent, "pdf-processing", "Extract text from PDF documents.")
+    val registry = SkillRegistry(List(parent))
+    val agent    = SkillEnabledAgent(EchoAgent(), registry, autoDiscover = true)
+
+    val response = Await.result(agent.process(Message.user("How do I parse pdf files?")), 5.seconds)
+    response.contentString should include("<available_skills>")
+    response.contentString should include("pdf-processing")
+
+  test("passthrough when no skills are relevant"):
+    val parent = tempDir()
+    makeSkillDir(parent, "email-compose", "Compose professional emails.")
+    val registry = SkillRegistry(List(parent))
+    val agent    = SkillEnabledAgent(EchoAgent(), registry, autoDiscover = true)
+
+    val response = Await.result(agent.process(Message.user("tell me a joke")), 5.seconds)
+    response.contentString should not include "<available_skills>"
+    response.contentString shouldBe "tell me a joke"
+
+  test("active_skills metadata is set"):
+    val parent = tempDir()
+    makeSkillDir(parent, "csv-tools", "Handle and transform CSV spreadsheets.")
+    val registry = SkillRegistry(List(parent))
+    val agent    = SkillEnabledAgent(EchoAgent(), registry, autoDiscover = true)
+
+    val response = Await.result(agent.process(Message.user("parse this csv spreadsheet data")), 5.seconds)
+    response.metadata should contain key "active_skills"
+    response.metadata("active_skills").asInstanceOf[List[String]] should contain("csv-tools")
+
+  test("capabilities include skill_injection"):
+    val registry = SkillRegistry(List(tempDir()))
+    val agent    = SkillEnabledAgent(EchoAgent(), registry, autoDiscover = false)
+    agent.capabilities should contain("skill_injection")
+
+  test("name delegates to wrapped agent"):
+    val registry = SkillRegistry(List(tempDir()))
+    val agent    = SkillEnabledAgent(EchoAgent(), registry, autoDiscover = false)
+    agent.name shouldBe "echo"

--- a/agenkit-scala/src/test/scala/io/agenkit/skills/SkillLoaderSpec.scala
+++ b/agenkit-scala/src/test/scala/io/agenkit/skills/SkillLoaderSpec.scala
@@ -1,0 +1,149 @@
+package io.agenkit.skills
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import java.nio.file.{Files, Path}
+
+class SkillLoaderSpec extends AnyFunSuite with Matchers:
+
+  private def tempDir(): Path = Files.createTempDirectory("agenkit-skills-")
+
+  private def makeSkillDir(
+    parent: Path,
+    name: String,
+    description: String,
+    body: String = "Instructions here."
+  ): Path =
+    val skillDir = Files.createDirectory(parent.resolve(name))
+    val content  = s"---\nname: $name\ndescription: $description\n---\n$body"
+    Files.writeString(skillDir.resolve("SKILL.md"), content)
+    skillDir
+
+  // -------------------------------------------------------------------------
+  // AgentSkill.fromDirectory
+  // -------------------------------------------------------------------------
+
+  test("load valid skill"):
+    val dir   = makeSkillDir(tempDir(), "pdf-processing", "Extract text from PDFs.", "# PDF\nDo stuff.")
+    val skill = AgentSkill.fromDirectory(dir)
+
+    skill.name shouldBe "pdf-processing"
+    skill.description shouldBe "Extract text from PDFs."
+    skill.instructions should include("Do stuff.")
+    skill.skillDir shouldBe Some(dir)
+
+  test("load skill with license and metadata"):
+    val parent  = tempDir()
+    val dir     = Files.createDirectory(parent.resolve("advanced"))
+    val content =
+      "---\n" +
+        "name: advanced\n" +
+        "description: Advanced skill.\n" +
+        "license: Apache-2.0\n" +
+        "metadata:\n" +
+        "  version: '1.0'\n" +
+        "---\n" +
+        "Advanced instructions."
+    Files.writeString(dir.resolve("SKILL.md"), content)
+    val skill = AgentSkill.fromDirectory(dir)
+
+    skill.license shouldBe Some("Apache-2.0")
+    skill.metadata shouldBe Map("version" -> "1.0")
+
+  test("missing SKILL.md throws"):
+    val emptyDir = Files.createDirectory(tempDir().resolve("empty"))
+    val ex       = intercept[IllegalArgumentException](AgentSkill.fromDirectory(emptyDir))
+    ex.getMessage should include("No SKILL.md found")
+
+  test("invalid frontmatter (missing delimiters) throws"):
+    val dir = Files.createDirectory(tempDir().resolve("bad"))
+    Files.writeString(dir.resolve("SKILL.md"), "name: foo\ndescription: bar\n")
+    val ex = intercept[IllegalArgumentException](AgentSkill.fromDirectory(dir))
+    ex.getMessage should include("missing frontmatter delimiters")
+
+  test("missing name throws"):
+    val dir = Files.createDirectory(tempDir().resolve("noname"))
+    Files.writeString(dir.resolve("SKILL.md"), "---\ndescription: A skill without a name.\n---\nInstructions.")
+    val ex = intercept[IllegalArgumentException](AgentSkill.fromDirectory(dir))
+    ex.getMessage should include("Missing required field 'name'")
+
+  test("missing description throws"):
+    val dir = Files.createDirectory(tempDir().resolve("nodesc"))
+    Files.writeString(dir.resolve("SKILL.md"), "---\nname: nodesc\n---\nInstructions.")
+    val ex = intercept[IllegalArgumentException](AgentSkill.fromDirectory(dir))
+    ex.getMessage should include("Missing required field 'description'")
+
+  test("toPrompt renders name, description, instructions"):
+    val dir    = makeSkillDir(tempDir(), "csv-tools", "Handle CSV files.", "Parse and write CSV.")
+    val skill  = AgentSkill.fromDirectory(dir)
+    val prompt = skill.toPrompt
+
+    prompt should include("# Skill: csv-tools")
+    prompt should include("## Description")
+    prompt should include("Handle CSV files.")
+    prompt should include("## Instructions")
+    prompt should include("Parse and write CSV.")
+
+  // -------------------------------------------------------------------------
+  // SkillRegistry
+  // -------------------------------------------------------------------------
+
+  test("discover skips non-directories at search path level"):
+    val parent = tempDir()
+    Files.writeString(parent.resolve("not_a_dir.md"), "ignored")
+    val registry = SkillRegistry(List(parent))
+    registry.discoverSkills()
+    registry.skills shouldBe empty
+
+  test("discover loads valid skills"):
+    val parent = tempDir()
+    makeSkillDir(parent, "skill-a", "Skill A description.")
+    makeSkillDir(parent, "skill-b", "Skill B description.")
+    val registry = SkillRegistry(List(parent))
+    registry.discoverSkills()
+
+    registry.skills.keySet should contain("skill-a")
+    registry.skills.keySet should contain("skill-b")
+
+  test("discover skips invalid skill directories with a warning"):
+    val parent = tempDir()
+    makeSkillDir(parent, "good", "A good skill.")
+    val badDir = Files.createDirectory(parent.resolve("broken"))
+    // Has a SKILL.md but it is missing the name field.
+    Files.writeString(badDir.resolve("SKILL.md"), "---\ndescription: no name here.\n---\nbody")
+    val registry = SkillRegistry(List(parent))
+    registry.discoverSkills()
+
+    registry.skills.keySet should contain("good")
+    registry.skills.keySet should not contain "broken"
+
+  test("findRelevantSkills name match ranks first"):
+    val parent = tempDir()
+    makeSkillDir(parent, "pdf-processing", "Work with PDF documents.")
+    makeSkillDir(parent, "csv-tools", "Handle CSV spreadsheets.")
+    val registry = SkillRegistry(List(parent))
+    registry.discoverSkills()
+
+    val results = registry.findRelevantSkills("pdf")
+    results.size should be >= 1
+    results.head.name shouldBe "pdf-processing"
+
+  test("findRelevantSkills respects maxResults"):
+    val parent = tempDir()
+    for i <- 0 until 6 do
+      makeSkillDir(parent, s"skill-$i", s"A skill about document processing number $i.")
+    val registry = SkillRegistry(List(parent))
+    registry.discoverSkills()
+
+    val results = registry.findRelevantSkills("document", maxResults = 3)
+    results.size should be <= 3
+
+  test("getSkill returns Some for known and None for unknown"):
+    val parent = tempDir()
+    makeSkillDir(parent, "email-compose", "Compose professional emails.")
+    val registry = SkillRegistry(List(parent))
+    registry.discoverSkills()
+
+    registry.getSkill("email-compose").map(_.name) shouldBe Some("email-compose")
+    registry.getSkill("nonexistent") shouldBe None


### PR DESCRIPTION
Part of #629. Ports Agent Skills to Scala 3, mirroring the Python/Go reference.

## Added
- `AgentSkill.scala` — case class + companion `fromDirectory(Path)` parsing SKILL.md; `toPrompt`; `license`/`skillDir` are `Option`; throws `IllegalArgumentException` with the reference messages. Minimal frontmatter parser (no YAML dep).
- `SkillRegistry.scala` — `discoverSkills`, `findRelevantSkills` (+10/+5/+1-per-word), `getSkill: Option`, `skills: Map` (copy); slf4j warn on skip.
- `SkillEnabledAgent.scala` — extends `Agent`, prepends `<available_skills>`, sets `active_skills` metadata, adds `skill_injection`.
- 18 scalatest cases ported from the Python suite.

## Verified
- `sbt Test/compile` clean
- **18/18 skills tests pass**; full suite green