### PR TITLE
feat(zig): Agent Skills — AgentSkill, SkillRegistry, SkillEnabledAgent (#629)

### DIFF
--- a/agenkit-zig/build.zig
+++ b/agenkit-zig/build.zig
@@ -239,6 +239,19 @@ pub fn build(b: *std.Build) void {
     });
     const run_mcp_tests = b.addRunArtifact(mcp_tests);
 
+    // Agent Skills tests (loader + registry + SkillEnabledAgent)
+    const skills_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("tests/skills/skills_test.zig"),
+            .target = target,
+            .optimize = optimize,
+            .imports = &.{
+                .{ .name = "agenkit", .module = mod },
+            },
+        }),
+    });
+    const run_skills_tests = b.addRunArtifact(skills_tests);
+
     // A top level step for running all tests. dependOn can be called multiple
     // times and since the two run steps do not depend on one another, this will
     // make the two of them run in parallel.
@@ -253,6 +266,7 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&run_prop_middleware_tests.step);
     test_step.dependOn(&run_prop_agent_tests.step);
     test_step.dependOn(&run_mcp_tests.step);
+    test_step.dependOn(&run_skills_tests.step);
 
     // Just like flags, top level steps are also listed in the `--help` menu.
     //

--- a/agenkit-zig/src/root.zig
+++ b/agenkit-zig/src/root.zig
@@ -247,6 +247,9 @@ pub const protocols = struct {
     pub const mcp = @import("protocols/mcp.zig");
 };
 
+// Agent Skills
+pub const skills = @import("skills.zig");
+
 // Techniques
 pub const techniques = struct {
     // Reasoning techniques
@@ -319,6 +322,10 @@ test {
     _ = @import("middleware/mod.zig");
     // Also test infrastructure
     _ = @import("infrastructure/mod.zig");
+    // Also test agent skills
+    _ = @import("skills.zig");
+    _ = @import("skills/loader.zig");
+    _ = @import("skills/agent.zig");
     // Also test techniques
     _ = @import("techniques/reasoning/self_consistency.zig");
     _ = @import("techniques/reasoning/chain_of_thought.zig");

--- a/agenkit-zig/src/skills.zig
+++ b/agenkit-zig/src/skills.zig
@@ -1,0 +1,41 @@
+/// Agenkit Agent Skills for Zig
+///
+/// Agent Skills let you package reusable instructions as directories containing
+/// a `SKILL.md` file (YAML frontmatter + Markdown body) and inject the relevant
+/// ones into an agent's input at runtime.
+///
+/// This is the Zig port of the Python reference (`agenkit/skills/`).
+///
+/// ## Example
+///
+/// ```zig
+/// const skills = @import("agenkit").skills;
+///
+/// const paths = [_][]const u8{"./skills"};
+/// var registry = skills.SkillRegistry.init(allocator, &paths);
+/// defer registry.deinit();
+///
+/// var echo = try agenkit.EchoAgent.init(allocator);
+/// defer echo.agent().deinit();
+///
+/// var agent = try skills.SkillEnabledAgent.init(allocator, echo.agent(), &registry, 3, true);
+/// defer agent.agent().deinit();
+///
+/// const result = try agent.agent().process(msg);
+/// ```
+const loader = @import("skills/loader.zig");
+
+pub const AgentSkill = loader.AgentSkill;
+pub const SkillRegistry = loader.SkillRegistry;
+pub const SkillError = loader.SkillError;
+pub const MetadataEntry = loader.MetadataEntry;
+pub const SkillEnabledAgent = @import("skills/agent.zig").SkillEnabledAgent;
+pub const DEFAULT_MAX_ACTIVE_SKILLS = @import("skills/agent.zig").DEFAULT_MAX_ACTIVE_SKILLS;
+
+pub const version = "0.86.0";
+
+test {
+    @import("std").testing.refAllDecls(@This());
+    _ = @import("skills/loader.zig");
+    _ = @import("skills/agent.zig");
+}

--- a/agenkit-zig/src/skills/agent.zig
+++ b/agenkit-zig/src/skills/agent.zig
@@ -1,0 +1,353 @@
+/// SkillEnabledAgent — wraps an Agent and injects relevant skill instructions.
+///
+/// Zig port of the Python reference (`agenkit/skills/agent.py`).
+///
+/// Before delegating to the wrapped agent, the wrapper queries the registry for
+/// skills relevant to the incoming message and prepends their instructions
+/// inside an `<available_skills>` block. The response (when skills match)
+/// carries an `active_skills` metadata entry listing the injected skill names.
+///
+/// ## Memory ownership
+///
+/// - The `SkillEnabledAgent` does NOT own the wrapped agent or the registry;
+///   the caller is responsible for their lifetimes. `deinit` frees only the
+///   wrapper's own allocation (its name copy and the struct itself).
+/// - On each `process` call the wrapper builds a temporary augmented `Message`
+///   (owned text + `active_skills` array), passes it to the wrapped agent, and
+///   frees it before returning. The returned `Result` message is produced and
+///   owned by the wrapped agent, exactly as in the unwrapped case.
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const Agent = @import("../agent.zig").Agent;
+const AgentError = @import("../agent.zig").AgentError;
+const StreamCallbacks = @import("../agent.zig").StreamCallbacks;
+const Result = @import("../agent.zig").Result;
+const Message = @import("../message.zig").Message;
+const IntrospectionResult = @import("../introspection.zig").IntrospectionResult;
+const createDefaultIntrospectionResult = @import("../introspection.zig").createDefaultIntrospectionResult;
+const SkillRegistry = @import("loader.zig").SkillRegistry;
+
+/// Default number of skills to inject per request.
+pub const DEFAULT_MAX_ACTIVE_SKILLS: usize = 3;
+
+/// Agent wrapper that automatically injects relevant skill instructions.
+pub const SkillEnabledAgent = struct {
+    allocator: Allocator,
+    agent_name: []const u8,
+    inner: Agent,
+    registry: *SkillRegistry,
+    max_active_skills: usize,
+
+    /// Create a skill-enabled wrapper around `inner`.
+    ///
+    /// Args:
+    ///   - allocator: allocator for the wrapper's own state and per-request work
+    ///   - inner: base agent to delegate processing to (borrowed, not owned)
+    ///   - registry: registry used to look up relevant skills (borrowed)
+    ///   - max_active_skills: maximum number of skills to inject
+    ///   - auto_discover: whether to call `registry.discoverSkills()` now
+    pub fn init(
+        allocator: Allocator,
+        inner: Agent,
+        registry: *SkillRegistry,
+        max_active_skills: usize,
+        auto_discover: bool,
+    ) !*SkillEnabledAgent {
+        if (auto_discover) {
+            try registry.discoverSkills();
+        }
+        const self = try allocator.create(SkillEnabledAgent);
+        errdefer allocator.destroy(self);
+        self.* = SkillEnabledAgent{
+            .allocator = allocator,
+            .agent_name = try allocator.dupe(u8, inner.name()),
+            .inner = inner,
+            .registry = registry,
+            .max_active_skills = max_active_skills,
+        };
+        return self;
+    }
+
+    /// Create the `Agent` interface for this wrapper.
+    pub fn agent(self: *SkillEnabledAgent) Agent {
+        return Agent{
+            .ptr = self,
+            .vtable = &.{
+                .name = nameImpl,
+                .capabilities = capabilitiesImpl,
+                .process = processImpl,
+                .process_stream = processStreamImpl,
+                .introspect = introspectImpl,
+                .deinit = deinitImpl,
+            },
+        };
+    }
+
+    fn nameImpl(ptr: *anyopaque) []const u8 {
+        const self: *SkillEnabledAgent = @ptrCast(@alignCast(ptr));
+        return self.agent_name;
+    }
+
+    fn capabilitiesImpl(ptr: *anyopaque, allocator: Allocator) Allocator.Error![]const []const u8 {
+        const self: *SkillEnabledAgent = @ptrCast(@alignCast(ptr));
+
+        const base = try self.inner.capabilities(allocator);
+        defer {
+            for (base) |cap| allocator.free(cap);
+            allocator.free(base);
+        }
+
+        var out = std.ArrayList([]const u8).init(allocator);
+        errdefer {
+            for (out.items) |cap| allocator.free(cap);
+            out.deinit();
+        }
+
+        var has_injection = false;
+        for (base) |cap| {
+            if (std.mem.eql(u8, cap, "skill_injection")) has_injection = true;
+            try out.append(try allocator.dupe(u8, cap));
+        }
+        if (!has_injection) {
+            try out.append(try allocator.dupe(u8, "skill_injection"));
+        }
+
+        return out.toOwnedSlice();
+    }
+
+    fn processImpl(ptr: *anyopaque, message: Message) AgentError!Result {
+        const self: *SkillEnabledAgent = @ptrCast(@alignCast(ptr));
+
+        // Query string is the message text; structured content yields an empty
+        // query (mirrors Python's `str(content) if content is not None else ""`
+        // for the text path — structured content simply produces no match).
+        const query: []const u8 = message.contentAsText() catch "";
+
+        const relevant = self.registry.findRelevantSkills(
+            self.allocator,
+            query,
+            self.max_active_skills,
+        ) catch return AgentError.ProcessingFailed;
+        defer self.allocator.free(relevant);
+
+        if (relevant.len == 0) {
+            // Passthrough: delegate the original message untouched.
+            return self.inner.process(message);
+        }
+
+        // Build the "<available_skills>...</available_skills>\n\n" + query prefix.
+        var content_buf = std.ArrayList(u8).init(self.allocator);
+        defer content_buf.deinit();
+        content_buf.appendSlice("<available_skills>\n") catch return AgentError.ProcessingFailed;
+        for (relevant, 0..) |skill, i| {
+            if (i > 0) content_buf.appendSlice("\n\n") catch return AgentError.ProcessingFailed;
+            const block = skill.toPrompt(self.allocator) catch return AgentError.ProcessingFailed;
+            defer self.allocator.free(block);
+            content_buf.appendSlice(block) catch return AgentError.ProcessingFailed;
+        }
+        content_buf.appendSlice("\n</available_skills>\n\n") catch return AgentError.ProcessingFailed;
+        content_buf.appendSlice(query) catch return AgentError.ProcessingFailed;
+
+        const augmented_text = content_buf.toOwnedSlice() catch return AgentError.ProcessingFailed;
+
+        // Construct the augmented message with active_skills metadata.
+        var augmented = Message.withText(self.allocator, message.role, augmented_text) catch {
+            self.allocator.free(augmented_text);
+            return AgentError.ProcessingFailed;
+        };
+        self.allocator.free(augmented_text); // withText duped the text
+        defer augmented.deinit();
+
+        // Copy existing metadata from the source message.
+        var meta_it = message.metadata.object.iterator();
+        while (meta_it.next()) |entry| {
+            augmented.setMetadata(entry.key_ptr.*, entry.value_ptr.*) catch
+                return AgentError.ProcessingFailed;
+        }
+
+        // Build the active_skills JSON array of skill-name strings.
+        var skill_names = std.json.Array.init(self.allocator);
+        for (relevant) |skill| {
+            const name_copy = self.allocator.dupe(u8, skill.name) catch return AgentError.ProcessingFailed;
+            skill_names.append(std.json.Value{ .string = name_copy }) catch return AgentError.ProcessingFailed;
+        }
+        augmented.setMetadata("active_skills", std.json.Value{ .array = skill_names }) catch
+            return AgentError.ProcessingFailed;
+
+        return self.inner.process(augmented);
+    }
+
+    fn processStreamImpl(ptr: *anyopaque, message: Message, callbacks: StreamCallbacks) AgentError!void {
+        _ = ptr;
+        _ = message;
+        callbacks.onError(AgentError.NotImplemented);
+    }
+
+    fn introspectImpl(ptr: *anyopaque, allocator: Allocator) Allocator.Error!IntrospectionResult {
+        const self: *SkillEnabledAgent = @ptrCast(@alignCast(ptr));
+        const caps = try capabilitiesImpl(ptr, allocator);
+        defer {
+            for (caps) |cap| allocator.free(cap);
+            allocator.free(caps);
+        }
+        return createDefaultIntrospectionResult(allocator, self.agent_name, caps);
+    }
+
+    fn deinitImpl(ptr: *anyopaque) void {
+        const self: *SkillEnabledAgent = @ptrCast(@alignCast(ptr));
+        self.allocator.free(self.agent_name);
+        self.allocator.destroy(self);
+    }
+};
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+const testing = std.testing;
+const EchoAgent = @import("../agent.zig").EchoAgent;
+
+fn makeSkillDir(dir: std.fs.Dir, name: []const u8, description: []const u8) !void {
+    try dir.makeDir(name);
+    var sub = try dir.openDir(name, .{});
+    defer sub.close();
+    var buf: [4096]u8 = undefined;
+    const content = try std.fmt.bufPrint(
+        &buf,
+        "---\nname: {s}\ndescription: {s}\n---\nInstructions here.",
+        .{ name, description },
+    );
+    const file = try sub.createFile("SKILL.md", .{});
+    defer file.close();
+    try file.writeAll(content);
+}
+
+test "skill agent augments matching message" {
+    const allocator = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try makeSkillDir(tmp.dir, "pdf-processing", "Extract text from PDF documents.");
+    const root = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(root);
+
+    const paths = [_][]const u8{root};
+    var registry = SkillRegistry.init(allocator, &paths);
+    defer registry.deinit();
+
+    var echo = try EchoAgent.init(allocator);
+    defer echo.agent().deinit();
+
+    var skill_agent = try SkillEnabledAgent.init(allocator, echo.agent(), &registry, 3, true);
+    defer skill_agent.agent().deinit();
+
+    var msg = try Message.withText(allocator, .user, "How do I parse pdf files?");
+    defer msg.deinit();
+
+    const result = try skill_agent.agent().process(msg);
+    var response = try result.unwrap();
+    defer response.deinit();
+
+    const content = try response.contentAsText();
+    try testing.expect(std.mem.indexOf(u8, content, "<available_skills>") != null);
+    try testing.expect(std.mem.indexOf(u8, content, "pdf-processing") != null);
+}
+
+test "skill agent passthrough when no skills match" {
+    const allocator = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try makeSkillDir(tmp.dir, "email-compose", "Compose professional emails.");
+    const root = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(root);
+
+    const paths = [_][]const u8{root};
+    var registry = SkillRegistry.init(allocator, &paths);
+    defer registry.deinit();
+
+    var echo = try EchoAgent.init(allocator);
+    defer echo.agent().deinit();
+
+    var skill_agent = try SkillEnabledAgent.init(allocator, echo.agent(), &registry, 3, true);
+    defer skill_agent.agent().deinit();
+
+    var msg = try Message.withText(allocator, .user, "tell me a joke");
+    defer msg.deinit();
+
+    const result = try skill_agent.agent().process(msg);
+    var response = try result.unwrap();
+    defer response.deinit();
+
+    const content = try response.contentAsText();
+    try testing.expect(std.mem.indexOf(u8, content, "<available_skills>") == null);
+    try testing.expectEqualStrings("tell me a joke", content);
+}
+
+test "skill agent sets active_skills metadata" {
+    const allocator = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try makeSkillDir(tmp.dir, "csv-tools", "Handle and transform CSV spreadsheets.");
+    const root = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(root);
+
+    const paths = [_][]const u8{root};
+    var registry = SkillRegistry.init(allocator, &paths);
+    defer registry.deinit();
+
+    var echo = try EchoAgent.init(allocator);
+    defer echo.agent().deinit();
+
+    var skill_agent = try SkillEnabledAgent.init(allocator, echo.agent(), &registry, 3, true);
+    defer skill_agent.agent().deinit();
+
+    var msg = try Message.withText(allocator, .user, "parse this csv spreadsheet data");
+    defer msg.deinit();
+
+    const result = try skill_agent.agent().process(msg);
+    var response = try result.unwrap();
+    defer response.deinit();
+
+    const active = response.getMetadata("active_skills");
+    try testing.expect(active != null);
+    try testing.expect(active.? == .array);
+    var found = false;
+    for (active.?.array.items) |item| {
+        if (item == .string and std.mem.eql(u8, item.string, "csv-tools")) found = true;
+    }
+    try testing.expect(found);
+}
+
+test "skill agent advertises skill_injection capability" {
+    const allocator = testing.allocator;
+    var registry = SkillRegistry.init(allocator, &[_][]const u8{});
+    defer registry.deinit();
+
+    var echo = try EchoAgent.init(allocator);
+    defer echo.agent().deinit();
+
+    var skill_agent = try SkillEnabledAgent.init(allocator, echo.agent(), &registry, 3, false);
+    defer skill_agent.agent().deinit();
+
+    const caps = try skill_agent.agent().capabilities(allocator);
+    defer {
+        for (caps) |c| allocator.free(c);
+        allocator.free(caps);
+    }
+    var found = false;
+    for (caps) |c| {
+        if (std.mem.eql(u8, c, "skill_injection")) found = true;
+    }
+    try testing.expect(found);
+}
+
+test "skill agent name delegates to inner" {
+    const allocator = testing.allocator;
+    var registry = SkillRegistry.init(allocator, &[_][]const u8{});
+    defer registry.deinit();
+
+    var echo = try EchoAgent.init(allocator);
+    defer echo.agent().deinit();
+
+    var skill_agent = try SkillEnabledAgent.init(allocator, echo.agent(), &registry, 3, false);
+    defer skill_agent.agent().deinit();
+
+    try testing.expectEqualStrings("echo", skill_agent.agent().name());
+}

--- a/agenkit-zig/src/skills/loader.zig
+++ b/agenkit-zig/src/skills/loader.zig
@@ -1,0 +1,706 @@
+/// Agent Skill loader and registry.
+///
+/// Implements the Agent Skills specification: each skill is a directory
+/// containing a `SKILL.md` file with YAML frontmatter (name, description,
+/// optional license and metadata) followed by Markdown instructions.
+///
+/// This is the Zig port of the Python reference implementation
+/// (`agenkit/skills/loader.py`). It follows Agenkit Zig conventions:
+/// - Explicit allocators on every fallible operation
+/// - Error unions instead of exceptions
+/// - Explicit memory ownership (documented per type)
+///
+/// ## SKILL.md format
+///
+/// ```text
+/// ---
+/// name: skill-name
+/// description: What this skill does.
+/// license: Apache-2.0   # optional
+/// metadata:             # optional
+///   key: value
+/// ---
+/// # Skill Title
+/// Markdown instructions here.
+/// ```
+///
+/// ## Memory ownership
+///
+/// - `AgentSkill` owns every string field it holds (`name`, `description`,
+///   `instructions`, `license`, `skill_dir`) plus all keys/values in
+///   `metadata`. Call `AgentSkill.deinit` to free them.
+/// - `SkillRegistry` owns the `AgentSkill` values stored in its map and the
+///   duplicated key strings. `SkillRegistry.deinit` frees all of them. The
+///   slice returned by `findRelevantSkills` is owned by the caller (free the
+///   slice itself with the allocator), but the `AgentSkill` elements inside it
+///   remain owned by the registry — do NOT deinit them.
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+
+/// Errors raised while loading a skill from disk.
+pub const SkillError = error{
+    /// The directory does not contain a `SKILL.md` file.
+    MissingSkillFile,
+    /// The `SKILL.md` file lacks the two `---` frontmatter delimiters.
+    MissingDelimiters,
+    /// The frontmatter does not declare a `name:` field.
+    MissingName,
+    /// The frontmatter does not declare a `description:` field.
+    MissingDescription,
+};
+
+/// A single key/value pair parsed from the optional `metadata:` block.
+///
+/// Both `key` and `value` are owned by the enclosing `AgentSkill`.
+pub const MetadataEntry = struct {
+    key: []const u8,
+    value: []const u8,
+};
+
+/// Represents a single agent skill loaded from a directory.
+///
+/// All string fields are heap-allocated and owned by the skill. Use `deinit`
+/// to release them.
+pub const AgentSkill = struct {
+    allocator: Allocator,
+    name: []const u8,
+    description: []const u8,
+    instructions: []const u8,
+    license: ?[]const u8,
+    metadata: []MetadataEntry,
+    skill_dir: ?[]const u8,
+
+    /// Load a skill from a directory containing a `SKILL.md` file.
+    ///
+    /// `skill_dir` is the path to the skill directory (relative to the current
+    /// working directory or absolute).
+    ///
+    /// Returns a `SkillError` if the directory lacks `SKILL.md`, the
+    /// frontmatter delimiters are missing, or a required field
+    /// (`name`/`description`) is absent.
+    ///
+    /// The returned skill owns all of its memory; the caller must `deinit` it.
+    pub fn fromDirectory(allocator: Allocator, skill_dir: []const u8) !AgentSkill {
+        var dir = std.fs.cwd().openDir(skill_dir, .{}) catch {
+            return SkillError.MissingSkillFile;
+        };
+        defer dir.close();
+
+        const file = dir.openFile("SKILL.md", .{}) catch {
+            return SkillError.MissingSkillFile;
+        };
+        defer file.close();
+
+        const raw = try file.readToEndAlloc(allocator, 16 * 1024 * 1024); // 16MB cap
+        defer allocator.free(raw);
+
+        return fromContent(allocator, raw, skill_dir);
+    }
+
+    /// Parse a skill from raw `SKILL.md` content.
+    ///
+    /// Split on the first two `---` delimiters into frontmatter + markdown body,
+    /// matching the Python `raw.split("---", 2)` semantics (file must start with
+    /// `---`). Exposed for testing without touching the filesystem.
+    pub fn fromContent(allocator: Allocator, raw: []const u8, skill_dir: ?[]const u8) !AgentSkill {
+        // Equivalent to Python's raw.split("---", 2): at most 3 parts.
+        // parts[0] is the text before the first delimiter (must be empty for a
+        // well-formed file), parts[1] is the frontmatter, parts[2] is the body.
+        const first = std.mem.indexOf(u8, raw, "---") orelse
+            return SkillError.MissingDelimiters;
+        const after_first = first + 3;
+        const second_rel = std.mem.indexOf(u8, raw[after_first..], "---") orelse
+            return SkillError.MissingDelimiters;
+        const second = after_first + second_rel;
+
+        const frontmatter_text = std.mem.trim(u8, raw[after_first..second], " \t\r\n");
+        const instructions_raw = std.mem.trim(u8, raw[second + 3 ..], " \t\r\n");
+
+        var fm = try Frontmatter.parse(allocator, frontmatter_text);
+        defer fm.deinit();
+
+        const name = fm.get("name") orelse return SkillError.MissingName;
+        if (name.len == 0) return SkillError.MissingName;
+
+        const description = fm.get("description") orelse return SkillError.MissingDescription;
+        if (description.len == 0) return SkillError.MissingDescription;
+
+        // Duplicate everything so the skill owns its memory independent of `fm`.
+        const name_owned = try allocator.dupe(u8, name);
+        errdefer allocator.free(name_owned);
+
+        const desc_owned = try allocator.dupe(u8, description);
+        errdefer allocator.free(desc_owned);
+
+        const instr_owned = try allocator.dupe(u8, instructions_raw);
+        errdefer allocator.free(instr_owned);
+
+        const license_owned: ?[]const u8 = if (fm.get("license")) |lic|
+            try allocator.dupe(u8, lic)
+        else
+            null;
+        errdefer if (license_owned) |l| allocator.free(l);
+
+        const dir_owned: ?[]const u8 = if (skill_dir) |d|
+            try allocator.dupe(u8, d)
+        else
+            null;
+        errdefer if (dir_owned) |d| allocator.free(d);
+
+        const metadata = try fm.takeMetadata(allocator);
+        errdefer freeMetadata(allocator, metadata);
+
+        return AgentSkill{
+            .allocator = allocator,
+            .name = name_owned,
+            .description = desc_owned,
+            .instructions = instr_owned,
+            .license = license_owned,
+            .metadata = metadata,
+            .skill_dir = dir_owned,
+        };
+    }
+
+    /// Free all memory owned by this skill.
+    pub fn deinit(self: *AgentSkill) void {
+        self.allocator.free(self.name);
+        self.allocator.free(self.description);
+        self.allocator.free(self.instructions);
+        if (self.license) |l| self.allocator.free(l);
+        if (self.skill_dir) |d| self.allocator.free(d);
+        freeMetadata(self.allocator, self.metadata);
+    }
+
+    /// Look up a metadata value by key, or null if absent.
+    pub fn getMetadata(self: *const AgentSkill, key: []const u8) ?[]const u8 {
+        for (self.metadata) |entry| {
+            if (std.mem.eql(u8, entry.key, key)) return entry.value;
+        }
+        return null;
+    }
+
+    /// Render the skill as a prompt block for injection into agent messages.
+    ///
+    /// The returned string is allocated with `allocator` and owned by the
+    /// caller.
+    pub fn toPrompt(self: *const AgentSkill, allocator: Allocator) ![]u8 {
+        return std.fmt.allocPrint(
+            allocator,
+            "# Skill: {s}\n\n## Description\n{s}\n\n## Instructions\n{s}\n",
+            .{ self.name, self.description, self.instructions },
+        );
+    }
+};
+
+fn freeMetadata(allocator: Allocator, metadata: []MetadataEntry) void {
+    for (metadata) |entry| {
+        allocator.free(entry.key);
+        allocator.free(entry.value);
+    }
+    allocator.free(metadata);
+}
+
+/// Minimal YAML frontmatter parser.
+///
+/// Supports exactly the subset used by SKILL.md frontmatter:
+/// - top-level `key: value` scalars
+/// - a `metadata:` block whose immediate two-space-indented children are
+///   `key: value` scalars
+///
+/// Values are unquoted (surrounding single or double quotes are stripped).
+/// This is intentionally small — there is no external YAML dependency.
+const Frontmatter = struct {
+    allocator: Allocator,
+    /// Top-level scalar fields (name, description, license, ...). Borrowed
+    /// slices into the input text; not owned.
+    fields: std.StringHashMap([]const u8),
+    /// Children of the `metadata:` block. Borrowed slices into the input text.
+    metadata: std.ArrayList(MetadataEntry),
+
+    fn parse(allocator: Allocator, text: []const u8) !Frontmatter {
+        var self = Frontmatter{
+            .allocator = allocator,
+            .fields = std.StringHashMap([]const u8).init(allocator),
+            .metadata = std.ArrayList(MetadataEntry).init(allocator),
+        };
+        errdefer self.deinit();
+
+        var in_metadata = false;
+        var lines = std.mem.splitScalar(u8, text, '\n');
+        while (lines.next()) |raw_line| {
+            const line = std.mem.trimRight(u8, raw_line, " \t\r");
+            if (line.len == 0) continue;
+
+            const indent = leadingSpaces(line);
+            const trimmed = line[indent..];
+            if (trimmed.len == 0) continue;
+            // Skip YAML comments.
+            if (trimmed[0] == '#') continue;
+
+            const colon = std.mem.indexOfScalar(u8, trimmed, ':') orelse continue;
+            const key = std.mem.trim(u8, trimmed[0..colon], " \t");
+            const value = stripQuotes(std.mem.trim(u8, trimmed[colon + 1 ..], " \t"));
+
+            if (indent == 0) {
+                if (std.mem.eql(u8, key, "metadata")) {
+                    in_metadata = true;
+                    continue;
+                }
+                in_metadata = false;
+                try self.fields.put(key, value);
+            } else if (in_metadata) {
+                // Indented child of the metadata block.
+                if (value.len == 0) continue;
+                try self.metadata.append(.{ .key = key, .value = value });
+            }
+        }
+
+        return self;
+    }
+
+    fn get(self: *const Frontmatter, key: []const u8) ?[]const u8 {
+        return self.fields.get(key);
+    }
+
+    /// Build an owned copy of the metadata entries for transfer to an
+    /// `AgentSkill`. The caller owns the returned slice and its strings.
+    fn takeMetadata(self: *const Frontmatter, allocator: Allocator) ![]MetadataEntry {
+        const out = try allocator.alloc(MetadataEntry, self.metadata.items.len);
+        var filled: usize = 0;
+        errdefer {
+            for (out[0..filled]) |e| {
+                allocator.free(e.key);
+                allocator.free(e.value);
+            }
+            allocator.free(out);
+        }
+        for (self.metadata.items, 0..) |entry, i| {
+            const key_copy = try allocator.dupe(u8, entry.key);
+            errdefer allocator.free(key_copy);
+            const value_copy = try allocator.dupe(u8, entry.value);
+            out[i] = .{ .key = key_copy, .value = value_copy };
+            filled = i + 1;
+        }
+        return out;
+    }
+
+    fn deinit(self: *Frontmatter) void {
+        self.fields.deinit();
+        self.metadata.deinit();
+    }
+};
+
+fn leadingSpaces(line: []const u8) usize {
+    var i: usize = 0;
+    while (i < line.len and line[i] == ' ') : (i += 1) {}
+    return i;
+}
+
+fn stripQuotes(s: []const u8) []const u8 {
+    if (s.len >= 2) {
+        const first = s[0];
+        const last = s[s.len - 1];
+        if ((first == '\'' and last == '\'') or (first == '"' and last == '"')) {
+            return s[1 .. s.len - 1];
+        }
+    }
+    return s;
+}
+
+/// Discovers and searches agent skills across filesystem paths.
+///
+/// Skills are discovered by walking search paths and loading any subdirectory
+/// that contains a `SKILL.md` file. Invalid skill directories are skipped.
+///
+/// The registry owns every `AgentSkill` it holds and the duplicated key
+/// strings of its internal map. `deinit` frees them all.
+pub const SkillRegistry = struct {
+    allocator: Allocator,
+    /// Search paths to scan during `discoverSkills`. Borrowed; not owned.
+    search_paths: []const []const u8,
+    /// name -> skill. Keys are owned (duplicated from `skill.name`); values are
+    /// owned skills.
+    skills: std.StringHashMap(AgentSkill),
+
+    /// Create a registry over the given search paths.
+    ///
+    /// `search_paths` is borrowed and must outlive the registry; the registry
+    /// does not copy it.
+    pub fn init(allocator: Allocator, search_paths: []const []const u8) SkillRegistry {
+        return SkillRegistry{
+            .allocator = allocator,
+            .search_paths = search_paths,
+            .skills = std.StringHashMap(AgentSkill).init(allocator),
+        };
+    }
+
+    /// Free all loaded skills and the registry's internal storage.
+    pub fn deinit(self: *SkillRegistry) void {
+        var it = self.skills.iterator();
+        while (it.next()) |entry| {
+            self.allocator.free(entry.key_ptr.*);
+            entry.value_ptr.deinit();
+        }
+        self.skills.deinit();
+    }
+
+    /// Walk each search path and load all valid skill directories.
+    ///
+    /// Subdirectories without a `SKILL.md` or with invalid format are skipped.
+    /// If a skill name is already loaded it is replaced (matching the Python
+    /// `self._skills[skill.name] = skill` behaviour).
+    pub fn discoverSkills(self: *SkillRegistry) !void {
+        for (self.search_paths) |search_path| {
+            var dir = std.fs.cwd().openDir(search_path, .{ .iterate = true }) catch continue;
+            defer dir.close();
+
+            var iter = dir.iterate();
+            while (try iter.next()) |entry| {
+                if (entry.kind != .directory) continue;
+
+                const skill_path = try std.fs.path.join(
+                    self.allocator,
+                    &.{ search_path, entry.name },
+                );
+                defer self.allocator.free(skill_path);
+
+                var skill = AgentSkill.fromDirectory(self.allocator, skill_path) catch continue;
+                self.putSkill(&skill) catch {
+                    skill.deinit();
+                    return error.OutOfMemory;
+                };
+            }
+        }
+    }
+
+    /// Insert a skill, replacing any existing skill with the same name and
+    /// freeing the old one. Takes ownership of `skill`'s memory on success.
+    fn putSkill(self: *SkillRegistry, skill: *AgentSkill) !void {
+        if (self.skills.getEntry(skill.name)) |existing| {
+            // Replace value in place; key already matches by name.
+            existing.value_ptr.deinit();
+            existing.value_ptr.* = skill.*;
+            return;
+        }
+        const key = try self.allocator.dupe(u8, skill.name);
+        errdefer self.allocator.free(key);
+        try self.skills.put(key, skill.*);
+    }
+
+    /// Return skills most relevant to `query`, best match first.
+    ///
+    /// Scoring (mirrors the Python reference):
+    ///   +10 if query (lowercased) appears in the skill name (lowercased)
+    ///   +5  if query (lowercased) appears in the skill description (lowercased)
+    ///   +1  for each whitespace-delimited query word also present as a word in
+    ///       the description
+    ///
+    /// Only skills with score > 0 are returned, capped at `max_results`.
+    ///
+    /// The returned slice is owned by the caller and must be freed with
+    /// `allocator.free`. The `*const AgentSkill` elements remain owned by the
+    /// registry — do not deinit them.
+    pub fn findRelevantSkills(
+        self: *const SkillRegistry,
+        allocator: Allocator,
+        query: []const u8,
+        max_results: usize,
+    ) ![]*const AgentSkill {
+        const query_lower = try std.ascii.allocLowerString(allocator, query);
+        defer allocator.free(query_lower);
+
+        const Scored = struct {
+            score: i64,
+            skill: *const AgentSkill,
+        };
+
+        var scored = std.ArrayList(Scored).init(allocator);
+        defer scored.deinit();
+
+        var it = self.skills.iterator();
+        while (it.next()) |entry| {
+            const skill = entry.value_ptr;
+
+            const name_lower = try std.ascii.allocLowerString(allocator, skill.name);
+            defer allocator.free(name_lower);
+            const desc_lower = try std.ascii.allocLowerString(allocator, skill.description);
+            defer allocator.free(desc_lower);
+
+            var score: i64 = 0;
+            if (query_lower.len > 0 and std.mem.indexOf(u8, name_lower, query_lower) != null) {
+                score += 10;
+            }
+            if (query_lower.len > 0 and std.mem.indexOf(u8, desc_lower, query_lower) != null) {
+                score += 5;
+            }
+            score += wordOverlap(query_lower, desc_lower);
+
+            if (score > 0) {
+                try scored.append(.{ .score = score, .skill = skill });
+            }
+        }
+
+        // Sort by score descending (stable so ties keep iteration order).
+        std.mem.sort(Scored, scored.items, {}, struct {
+            fn lessThan(_: void, a: Scored, b: Scored) bool {
+                return a.score > b.score;
+            }
+        }.lessThan);
+
+        const count_out = @min(max_results, scored.items.len);
+        const out = try allocator.alloc(*const AgentSkill, count_out);
+        for (out, 0..) |*slot, i| slot.* = scored.items[i].skill;
+        return out;
+    }
+
+    /// Return the skill with the given name, or null if not found.
+    ///
+    /// The returned pointer is borrowed from the registry.
+    pub fn getSkill(self: *const SkillRegistry, name: []const u8) ?*const AgentSkill {
+        return self.skills.getPtr(name);
+    }
+
+    /// Number of loaded skills.
+    pub fn count(self: *const SkillRegistry) usize {
+        return self.skills.count();
+    }
+};
+
+/// Count how many unique whitespace-delimited words in `query_lower` appear as
+/// whole words in `desc_lower`. Mirrors Python's
+/// `len(query_words & set(desc_lower.split()))` (set semantics: each query word
+/// counts at most once).
+fn wordOverlap(query_lower: []const u8, desc_lower: []const u8) i64 {
+    var overlap: i64 = 0;
+
+    var qwords = std.mem.tokenizeAny(u8, query_lower, " \t\r\n");
+    outer: while (qwords.next()) |qw| {
+        // De-duplicate query words (set semantics): skip if this exact word
+        // already appeared earlier in the query.
+        var prior = std.mem.tokenizeAny(u8, query_lower, " \t\r\n");
+        while (prior.next()) |pw| {
+            if (pw.ptr == qw.ptr) break; // reached the current word
+            if (std.mem.eql(u8, pw, qw)) continue :outer; // earlier duplicate
+        }
+
+        var dwords = std.mem.tokenizeAny(u8, desc_lower, " \t\r\n");
+        while (dwords.next()) |dw| {
+            if (std.mem.eql(u8, dw, qw)) {
+                overlap += 1;
+                continue :outer;
+            }
+        }
+    }
+    return overlap;
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+const testing = std.testing;
+
+/// Create a minimal valid skill directory inside `dir`.
+fn makeSkillDir(dir: std.fs.Dir, name: []const u8, description: []const u8, body: []const u8) !void {
+    try dir.makeDir(name);
+    var sub = try dir.openDir(name, .{});
+    defer sub.close();
+    var buf: [4096]u8 = undefined;
+    const content = try std.fmt.bufPrint(
+        &buf,
+        "---\nname: {s}\ndescription: {s}\n---\n{s}",
+        .{ name, description, body },
+    );
+    const file = try sub.createFile("SKILL.md", .{});
+    defer file.close();
+    try file.writeAll(content);
+}
+
+fn writeRawFile(dir: std.fs.Dir, sub_path: []const u8, data: []const u8) !void {
+    const file = try dir.createFile(sub_path, .{});
+    defer file.close();
+    try file.writeAll(data);
+}
+
+test "fromContent loads a valid skill" {
+    var skill = try AgentSkill.fromContent(
+        testing.allocator,
+        "---\nname: pdf-processing\ndescription: Extract text from PDFs.\n---\n# PDF\nDo stuff.",
+        "skills/pdf-processing",
+    );
+    defer skill.deinit();
+
+    try testing.expectEqualStrings("pdf-processing", skill.name);
+    try testing.expectEqualStrings("Extract text from PDFs.", skill.description);
+    try testing.expect(std.mem.indexOf(u8, skill.instructions, "Do stuff.") != null);
+    try testing.expectEqualStrings("skills/pdf-processing", skill.skill_dir.?);
+}
+
+test "fromContent parses license and metadata" {
+    var skill = try AgentSkill.fromContent(
+        testing.allocator,
+        "---\nname: advanced\ndescription: Advanced skill.\nlicense: Apache-2.0\nmetadata:\n  version: '1.0'\n---\nAdvanced instructions.",
+        null,
+    );
+    defer skill.deinit();
+
+    try testing.expectEqualStrings("Apache-2.0", skill.license.?);
+    try testing.expectEqualStrings("1.0", skill.getMetadata("version").?);
+}
+
+test "fromContent missing delimiters" {
+    try testing.expectError(
+        SkillError.MissingDelimiters,
+        AgentSkill.fromContent(testing.allocator, "name: foo\ndescription: bar\n", null),
+    );
+}
+
+test "fromContent missing name" {
+    try testing.expectError(
+        SkillError.MissingName,
+        AgentSkill.fromContent(testing.allocator, "---\ndescription: A skill without a name.\n---\nInstructions.", null),
+    );
+}
+
+test "fromContent missing description" {
+    try testing.expectError(
+        SkillError.MissingDescription,
+        AgentSkill.fromContent(testing.allocator, "---\nname: nodesc\n---\nInstructions.", null),
+    );
+}
+
+test "fromDirectory missing SKILL.md" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.makeDir("empty");
+    const path = try tmp.dir.realpathAlloc(testing.allocator, "empty");
+    defer testing.allocator.free(path);
+
+    try testing.expectError(SkillError.MissingSkillFile, AgentSkill.fromDirectory(testing.allocator, path));
+}
+
+test "fromDirectory loads from disk" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try makeSkillDir(tmp.dir, "csv-tools", "Handle CSV files.", "Parse and write CSV.");
+    const path = try tmp.dir.realpathAlloc(testing.allocator, "csv-tools");
+    defer testing.allocator.free(path);
+
+    var skill = try AgentSkill.fromDirectory(testing.allocator, path);
+    defer skill.deinit();
+    try testing.expectEqualStrings("csv-tools", skill.name);
+}
+
+test "toPrompt formatting" {
+    var skill = try AgentSkill.fromContent(
+        testing.allocator,
+        "---\nname: csv-tools\ndescription: Handle CSV files.\n---\nParse and write CSV.",
+        null,
+    );
+    defer skill.deinit();
+
+    const prompt = try skill.toPrompt(testing.allocator);
+    defer testing.allocator.free(prompt);
+
+    try testing.expect(std.mem.indexOf(u8, prompt, "# Skill: csv-tools") != null);
+    try testing.expect(std.mem.indexOf(u8, prompt, "## Description") != null);
+    try testing.expect(std.mem.indexOf(u8, prompt, "Handle CSV files.") != null);
+    try testing.expect(std.mem.indexOf(u8, prompt, "## Instructions") != null);
+    try testing.expect(std.mem.indexOf(u8, prompt, "Parse and write CSV.") != null);
+}
+
+test "registry skips non-directories" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try writeRawFile(tmp.dir, "not_a_dir.md", "ignored");
+    const root = try tmp.dir.realpathAlloc(testing.allocator, ".");
+    defer testing.allocator.free(root);
+
+    const paths = [_][]const u8{root};
+    var registry = SkillRegistry.init(testing.allocator, &paths);
+    defer registry.deinit();
+    try registry.discoverSkills();
+    try testing.expectEqual(@as(usize, 0), registry.count());
+}
+
+test "registry discovers valid skills" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try makeSkillDir(tmp.dir, "skill-a", "Skill A description.", "Body.");
+    try makeSkillDir(tmp.dir, "skill-b", "Skill B description.", "Body.");
+    const root = try tmp.dir.realpathAlloc(testing.allocator, ".");
+    defer testing.allocator.free(root);
+
+    const paths = [_][]const u8{root};
+    var registry = SkillRegistry.init(testing.allocator, &paths);
+    defer registry.deinit();
+    try registry.discoverSkills();
+
+    try testing.expect(registry.getSkill("skill-a") != null);
+    try testing.expect(registry.getSkill("skill-b") != null);
+}
+
+test "registry find relevant name match" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try makeSkillDir(tmp.dir, "pdf-processing", "Work with PDF documents.", "Body.");
+    try makeSkillDir(tmp.dir, "csv-tools", "Handle CSV spreadsheets.", "Body.");
+    const root = try tmp.dir.realpathAlloc(testing.allocator, ".");
+    defer testing.allocator.free(root);
+
+    const paths = [_][]const u8{root};
+    var registry = SkillRegistry.init(testing.allocator, &paths);
+    defer registry.deinit();
+    try registry.discoverSkills();
+
+    const results = try registry.findRelevantSkills(testing.allocator, "pdf", 5);
+    defer testing.allocator.free(results);
+    try testing.expect(results.len >= 1);
+    try testing.expectEqualStrings("pdf-processing", results[0].name);
+}
+
+test "registry find relevant respects max_results" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var i: usize = 0;
+    while (i < 6) : (i += 1) {
+        var name_buf: [16]u8 = undefined;
+        var desc_buf: [64]u8 = undefined;
+        const name = try std.fmt.bufPrint(&name_buf, "skill-{d}", .{i});
+        const desc = try std.fmt.bufPrint(&desc_buf, "A skill about document processing number {d}.", .{i});
+        try makeSkillDir(tmp.dir, name, desc, "Body.");
+    }
+    const root = try tmp.dir.realpathAlloc(testing.allocator, ".");
+    defer testing.allocator.free(root);
+
+    const paths = [_][]const u8{root};
+    var registry = SkillRegistry.init(testing.allocator, &paths);
+    defer registry.deinit();
+    try registry.discoverSkills();
+
+    const results = try registry.findRelevantSkills(testing.allocator, "document", 3);
+    defer testing.allocator.free(results);
+    try testing.expect(results.len <= 3);
+}
+
+test "registry get skill" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try makeSkillDir(tmp.dir, "email-compose", "Compose professional emails.", "Body.");
+    const root = try tmp.dir.realpathAlloc(testing.allocator, ".");
+    defer testing.allocator.free(root);
+
+    const paths = [_][]const u8{root};
+    var registry = SkillRegistry.init(testing.allocator, &paths);
+    defer registry.deinit();
+    try registry.discoverSkills();
+
+    const skill = registry.getSkill("email-compose");
+    try testing.expect(skill != null);
+    try testing.expectEqualStrings("email-compose", skill.?.name);
+    try testing.expect(registry.getSkill("nonexistent") == null);
+}
+
+test "wordOverlap counts each query word once" {
+    try testing.expectEqual(@as(i64, 1), wordOverlap("document document", "about document processing"));
+    try testing.expectEqual(@as(i64, 2), wordOverlap("parse csv", "parse the csv data"));
+    try testing.expectEqual(@as(i64, 0), wordOverlap("xyz", "nothing here"));
+}

--- a/agenkit-zig/tests/skills/skills_test.zig
+++ b/agenkit-zig/tests/skills/skills_test.zig
@@ -1,0 +1,349 @@
+/// Agent Skills tests — exercises the public `agenkit.skills` API.
+///
+/// Ports the Python suites tests/skills/test_skill_loader.py and
+/// tests/skills/test_skill_agent.py through the public package surface.
+/// (The implementation files also carry their own inline `test` blocks; this
+/// file verifies the API as consumers see it.)
+///
+/// Run with: zig build test
+
+const std = @import("std");
+const testing = std.testing;
+const agenkit = @import("agenkit");
+const skills = agenkit.skills;
+const Message = agenkit.Message;
+const EchoAgent = agenkit.EchoAgent;
+
+/// Create a minimal valid skill directory inside `dir`.
+fn makeSkillDir(dir: std.fs.Dir, name: []const u8, description: []const u8) !void {
+    try dir.makeDir(name);
+    var sub = try dir.openDir(name, .{});
+    defer sub.close();
+    var buf: [4096]u8 = undefined;
+    const content = try std.fmt.bufPrint(
+        &buf,
+        "---\nname: {s}\ndescription: {s}\n---\nInstructions here.",
+        .{ name, description },
+    );
+    const file = try sub.createFile("SKILL.md", .{});
+    defer file.close();
+    try file.writeAll(content);
+}
+
+// ── AgentSkill.fromDirectory / fromContent ────────────────────────────────────
+
+test "load skill valid" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    {
+        try tmp.dir.makeDir("pdf-processing");
+        var sub = try tmp.dir.openDir("pdf-processing", .{});
+        defer sub.close();
+        const file = try sub.createFile("SKILL.md", .{});
+        defer file.close();
+        try file.writeAll("---\nname: pdf-processing\ndescription: Extract text from PDFs.\n---\n# PDF\nDo stuff.");
+    }
+    const path = try tmp.dir.realpathAlloc(testing.allocator, "pdf-processing");
+    defer testing.allocator.free(path);
+
+    var skill = try skills.AgentSkill.fromDirectory(testing.allocator, path);
+    defer skill.deinit();
+
+    try testing.expectEqualStrings("pdf-processing", skill.name);
+    try testing.expectEqualStrings("Extract text from PDFs.", skill.description);
+    try testing.expect(std.mem.indexOf(u8, skill.instructions, "Do stuff.") != null);
+    try testing.expectEqualStrings(path, skill.skill_dir.?);
+}
+
+test "load skill with license and metadata" {
+    var skill = try skills.AgentSkill.fromContent(
+        testing.allocator,
+        "---\nname: advanced\ndescription: Advanced skill.\nlicense: Apache-2.0\nmetadata:\n  version: '1.0'\n---\nAdvanced instructions.",
+        null,
+    );
+    defer skill.deinit();
+
+    try testing.expectEqualStrings("Apache-2.0", skill.license.?);
+    try testing.expectEqualStrings("1.0", skill.getMetadata("version").?);
+}
+
+test "load skill missing SKILL.md" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.makeDir("empty");
+    const path = try tmp.dir.realpathAlloc(testing.allocator, "empty");
+    defer testing.allocator.free(path);
+
+    try testing.expectError(skills.SkillError.MissingSkillFile, skills.AgentSkill.fromDirectory(testing.allocator, path));
+}
+
+test "load skill invalid frontmatter" {
+    try testing.expectError(
+        skills.SkillError.MissingDelimiters,
+        skills.AgentSkill.fromContent(testing.allocator, "name: foo\ndescription: bar\n", null),
+    );
+}
+
+test "load skill missing name" {
+    try testing.expectError(
+        skills.SkillError.MissingName,
+        skills.AgentSkill.fromContent(testing.allocator, "---\ndescription: A skill without a name.\n---\nInstructions.", null),
+    );
+}
+
+test "load skill missing description" {
+    try testing.expectError(
+        skills.SkillError.MissingDescription,
+        skills.AgentSkill.fromContent(testing.allocator, "---\nname: nodesc\n---\nInstructions.", null),
+    );
+}
+
+test "skill to prompt" {
+    var skill = try skills.AgentSkill.fromContent(
+        testing.allocator,
+        "---\nname: csv-tools\ndescription: Handle CSV files.\n---\nParse and write CSV.",
+        null,
+    );
+    defer skill.deinit();
+
+    const prompt = try skill.toPrompt(testing.allocator);
+    defer testing.allocator.free(prompt);
+
+    try testing.expect(std.mem.indexOf(u8, prompt, "# Skill: csv-tools") != null);
+    try testing.expect(std.mem.indexOf(u8, prompt, "## Description") != null);
+    try testing.expect(std.mem.indexOf(u8, prompt, "Handle CSV files.") != null);
+    try testing.expect(std.mem.indexOf(u8, prompt, "## Instructions") != null);
+    try testing.expect(std.mem.indexOf(u8, prompt, "Parse and write CSV.") != null);
+}
+
+// ── SkillRegistry ─────────────────────────────────────────────────────────────
+
+test "registry discover skips non-dirs" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    {
+        const file = try tmp.dir.createFile("not_a_dir.md", .{});
+        defer file.close();
+        try file.writeAll("ignored");
+    }
+    const root = try tmp.dir.realpathAlloc(testing.allocator, ".");
+    defer testing.allocator.free(root);
+
+    const paths = [_][]const u8{root};
+    var registry = skills.SkillRegistry.init(testing.allocator, &paths);
+    defer registry.deinit();
+    try registry.discoverSkills();
+    try testing.expectEqual(@as(usize, 0), registry.count());
+}
+
+test "registry discovers valid skills" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try makeSkillDir(tmp.dir, "skill-a", "Skill A description.");
+    try makeSkillDir(tmp.dir, "skill-b", "Skill B description.");
+    const root = try tmp.dir.realpathAlloc(testing.allocator, ".");
+    defer testing.allocator.free(root);
+
+    const paths = [_][]const u8{root};
+    var registry = skills.SkillRegistry.init(testing.allocator, &paths);
+    defer registry.deinit();
+    try registry.discoverSkills();
+
+    try testing.expect(registry.getSkill("skill-a") != null);
+    try testing.expect(registry.getSkill("skill-b") != null);
+}
+
+test "registry find relevant name match" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try makeSkillDir(tmp.dir, "pdf-processing", "Work with PDF documents.");
+    try makeSkillDir(tmp.dir, "csv-tools", "Handle CSV spreadsheets.");
+    const root = try tmp.dir.realpathAlloc(testing.allocator, ".");
+    defer testing.allocator.free(root);
+
+    const paths = [_][]const u8{root};
+    var registry = skills.SkillRegistry.init(testing.allocator, &paths);
+    defer registry.deinit();
+    try registry.discoverSkills();
+
+    const results = try registry.findRelevantSkills(testing.allocator, "pdf", 5);
+    defer testing.allocator.free(results);
+    try testing.expect(results.len >= 1);
+    try testing.expectEqualStrings("pdf-processing", results[0].name);
+}
+
+test "registry find relevant max results" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    var i: usize = 0;
+    while (i < 6) : (i += 1) {
+        var name_buf: [16]u8 = undefined;
+        var desc_buf: [64]u8 = undefined;
+        const name = try std.fmt.bufPrint(&name_buf, "skill-{d}", .{i});
+        const desc = try std.fmt.bufPrint(&desc_buf, "A skill about document processing number {d}.", .{i});
+        try makeSkillDir(tmp.dir, name, desc);
+    }
+    const root = try tmp.dir.realpathAlloc(testing.allocator, ".");
+    defer testing.allocator.free(root);
+
+    const paths = [_][]const u8{root};
+    var registry = skills.SkillRegistry.init(testing.allocator, &paths);
+    defer registry.deinit();
+    try registry.discoverSkills();
+
+    const results = try registry.findRelevantSkills(testing.allocator, "document", 3);
+    defer testing.allocator.free(results);
+    try testing.expect(results.len <= 3);
+}
+
+test "registry get skill" {
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try makeSkillDir(tmp.dir, "email-compose", "Compose professional emails.");
+    const root = try tmp.dir.realpathAlloc(testing.allocator, ".");
+    defer testing.allocator.free(root);
+
+    const paths = [_][]const u8{root};
+    var registry = skills.SkillRegistry.init(testing.allocator, &paths);
+    defer registry.deinit();
+    try registry.discoverSkills();
+
+    const skill = registry.getSkill("email-compose");
+    try testing.expect(skill != null);
+    try testing.expectEqualStrings("email-compose", skill.?.name);
+    try testing.expect(registry.getSkill("nonexistent") == null);
+}
+
+// ── SkillEnabledAgent ─────────────────────────────────────────────────────────
+
+test "skill agent augments message" {
+    const allocator = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try makeSkillDir(tmp.dir, "pdf-processing", "Extract text from PDF documents.");
+    const root = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(root);
+
+    const paths = [_][]const u8{root};
+    var registry = skills.SkillRegistry.init(allocator, &paths);
+    defer registry.deinit();
+
+    var echo = try EchoAgent.init(allocator);
+    defer echo.agent().deinit();
+
+    var skill_agent = try skills.SkillEnabledAgent.init(allocator, echo.agent(), &registry, 3, true);
+    defer skill_agent.agent().deinit();
+
+    var msg = try Message.withText(allocator, .user, "How do I parse pdf files?");
+    defer msg.deinit();
+
+    const result = try skill_agent.agent().process(msg);
+    var response = try result.unwrap();
+    defer response.deinit();
+
+    const content = try response.contentAsText();
+    try testing.expect(std.mem.indexOf(u8, content, "<available_skills>") != null);
+    try testing.expect(std.mem.indexOf(u8, content, "pdf-processing") != null);
+}
+
+test "skill agent no skills passthrough" {
+    const allocator = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try makeSkillDir(tmp.dir, "email-compose", "Compose professional emails.");
+    const root = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(root);
+
+    const paths = [_][]const u8{root};
+    var registry = skills.SkillRegistry.init(allocator, &paths);
+    defer registry.deinit();
+
+    var echo = try EchoAgent.init(allocator);
+    defer echo.agent().deinit();
+
+    var skill_agent = try skills.SkillEnabledAgent.init(allocator, echo.agent(), &registry, 3, true);
+    defer skill_agent.agent().deinit();
+
+    var msg = try Message.withText(allocator, .user, "tell me a joke");
+    defer msg.deinit();
+
+    const result = try skill_agent.agent().process(msg);
+    var response = try result.unwrap();
+    defer response.deinit();
+
+    const content = try response.contentAsText();
+    try testing.expect(std.mem.indexOf(u8, content, "<available_skills>") == null);
+    try testing.expectEqualStrings("tell me a joke", content);
+}
+
+test "skill agent active_skills metadata" {
+    const allocator = testing.allocator;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try makeSkillDir(tmp.dir, "csv-tools", "Handle and transform CSV spreadsheets.");
+    const root = try tmp.dir.realpathAlloc(allocator, ".");
+    defer allocator.free(root);
+
+    const paths = [_][]const u8{root};
+    var registry = skills.SkillRegistry.init(allocator, &paths);
+    defer registry.deinit();
+
+    var echo = try EchoAgent.init(allocator);
+    defer echo.agent().deinit();
+
+    var skill_agent = try skills.SkillEnabledAgent.init(allocator, echo.agent(), &registry, 3, true);
+    defer skill_agent.agent().deinit();
+
+    var msg = try Message.withText(allocator, .user, "parse this csv spreadsheet data");
+    defer msg.deinit();
+
+    const result = try skill_agent.agent().process(msg);
+    var response = try result.unwrap();
+    defer response.deinit();
+
+    const active = response.getMetadata("active_skills");
+    try testing.expect(active != null);
+    try testing.expect(active.? == .array);
+    var found = false;
+    for (active.?.array.items) |item| {
+        if (item == .string and std.mem.eql(u8, item.string, "csv-tools")) found = true;
+    }
+    try testing.expect(found);
+}
+
+test "skill agent capabilities include skill_injection" {
+    const allocator = testing.allocator;
+    var registry = skills.SkillRegistry.init(allocator, &[_][]const u8{});
+    defer registry.deinit();
+
+    var echo = try EchoAgent.init(allocator);
+    defer echo.agent().deinit();
+
+    var skill_agent = try skills.SkillEnabledAgent.init(allocator, echo.agent(), &registry, 3, false);
+    defer skill_agent.agent().deinit();
+
+    const caps = try skill_agent.agent().capabilities(allocator);
+    defer {
+        for (caps) |c| allocator.free(c);
+        allocator.free(caps);
+    }
+    var found = false;
+    for (caps) |c| {
+        if (std.mem.eql(u8, c, "skill_injection")) found = true;
+    }
+    try testing.expect(found);
+}
+
+test "skill agent name delegates" {
+    const allocator = testing.allocator;
+    var registry = skills.SkillRegistry.init(allocator, &[_][]const u8{});
+    defer registry.deinit();
+
+    var echo = try EchoAgent.init(allocator);
+    defer echo.agent().deinit();
+
+    var skill_agent = try skills.SkillEnabledAgent.init(allocator, echo.agent(), &registry, 3, false);
+    defer skill_agent.agent().deinit();
+
+    try testing.expectEqualStrings("echo", skill_agent.agent().name());
+}


### PR DESCRIPTION
Part of #629 (completes the 9-language Agent Skills parity). Ports the spec to Zig 0.15.2.

## Added
- `src/skills/loader.zig` — `SkillError`, `AgentSkill` (`fromDirectory`/`fromContent`, `toPrompt`, `deinit`), `SkillRegistry` (`discoverSkills`, `findRelevantSkills` +10/+5/+1-per-word, `getSkill`, `deinit`). Dependency-free frontmatter parser.
- `src/skills/agent.zig` — `SkillEnabledAgent` (Agent vtable); prepends `<available_skills>`, sets `active_skills`, adds `skill_injection`.
- `src/skills.zig` aggregator; `tests/skills/skills_test.zig` ports the Python suites.
- `root.zig` + `build.zig`: registered the module + `skills_tests` (same pattern as `mcp_tests`).

Memory ownership documented in the loader (registry owns skills; `findRelevantSkills` returns a caller-owned slice of borrowed pointers; wrapper borrows agent+registry).

## ⚠️ Verification caveat
Verified via `zig ast-check` (all files pass) **but not a full `zig build test`**: the local toolchain is 0.16.0 while the repo targets 0.15.2 — the *entire* agenkit-zig tree fails to compile under 0.16.0, so a local green run was unattainable. **The zig CI job (0.15.2 via `mlugg/setup-zig`) is the authoritative check** — please confirm it's green before merge. The skills code uses the same 0.15.2 std APIs as the rest of the module.

(The Zig CI test step is currently non-blocking per #627.)