### PR TITLE
feat(python): Reasoning Memory — Verifier, ReasoningArtifact, ReasoningMemory (#630)

### DIFF
--- a/agenkit/reasoning/__init__.py
+++ b/agenkit/reasoning/__init__.py
@@ -1,0 +1,25 @@
+"""
+Reasoning memory: structured reasoning artifacts, verification, and persistence.
+
+Ports the Go reference (agenkit-go/agenkit/interfaces.go + memory/memory.go):
+
+- ``Verifier`` — exact/binary check of an answer against ground truth, distinct
+  from the heuristic float scores used to prune search.
+- ``ReasoningArtifact`` — structured intermediate reasoning output (the scored
+  candidates a technique explored), not just the final answer text.
+- ``ReasoningMemory`` — a ``Memory`` that can also persist and retrieve
+  reasoning artifacts per session and technique.
+"""
+
+from .artifact import ReasoningArtifact, ScoredCandidate
+from .memory import InMemoryReasoningMemory, ReasoningMemory
+from .verifier import VerificationResult, Verifier
+
+__all__ = [
+    "InMemoryReasoningMemory",
+    "ReasoningArtifact",
+    "ReasoningMemory",
+    "ScoredCandidate",
+    "VerificationResult",
+    "Verifier",
+]

--- a/agenkit/reasoning/artifact.py
+++ b/agenkit/reasoning/artifact.py
@@ -1,0 +1,54 @@
+"""
+ReasoningArtifact: structured intermediate reasoning output.
+
+All reasoning techniques ultimately return a final answer, but the structure
+they computed along the way — the candidates explored and their scores — is
+useful information that is otherwise discarded. A ``ReasoningArtifact`` captures
+that structure so it can be persisted (see :mod:`agenkit.reasoning.memory`),
+inspected, or resumed.
+
+Mirrors the Go ``ReasoningArtifact`` interface and ``ScoredCandidate`` struct.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ScoredCandidate:
+    """A candidate answer paired with its evaluation score."""
+
+    text: str
+    score: float = 0.0
+
+
+@dataclass(frozen=True)
+class ReasoningArtifact:
+    """
+    Structured intermediate reasoning output from a technique.
+
+    Attributes:
+        technique: Technique name, e.g. ``"tree_of_thought"``,
+            ``"chain_of_thought"``, ``"self_consistency"``.
+        session_id: Session this artifact belongs to.
+        candidates: The scored candidates the technique explored.
+        metadata: Arbitrary technique-specific metadata.
+    """
+
+    technique: str
+    session_id: str
+    candidates: list[ScoredCandidate] = field(default_factory=list)
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def best_candidate(self) -> ScoredCandidate | None:
+        """
+        Return the highest-scoring candidate, or ``None`` if there are none.
+
+        Mirrors the Go ``BestCandidate`` (which returns a zero value); here a
+        missing best is represented as ``None`` per Python idiom.
+        """
+        if not self.candidates:
+            return None
+        return max(self.candidates, key=lambda c: c.score)

--- a/agenkit/reasoning/memory.py
+++ b/agenkit/reasoning/memory.py
@@ -1,0 +1,108 @@
+"""
+ReasoningMemory: a Memory that also persists reasoning artifacts.
+
+Mirrors the Go ``ReasoningMemory`` interface (memory.Memory + StoreArtifact /
+RetrieveArtifacts). Flat message storage destroys the structure of a reasoning
+tree/graph/sample-set; this interface lets backends persist the structured
+:class:`~agenkit.reasoning.artifact.ReasoningArtifact` alongside conversation
+history so prior reasoning can be loaded and built on.
+"""
+
+from __future__ import annotations
+
+from abc import abstractmethod
+from typing import TYPE_CHECKING
+
+from ..interfaces import Message
+from ..memory.base import Memory
+
+if TYPE_CHECKING:
+    from .artifact import ReasoningArtifact
+
+
+class ReasoningMemory(Memory):
+    """
+    A :class:`~agenkit.memory.base.Memory` extended with artifact persistence.
+
+    Implementations store and retrieve :class:`ReasoningArtifact` objects keyed
+    by session, filterable by technique, in addition to the normal message
+    store/retrieve contract.
+    """
+
+    @abstractmethod
+    async def store_artifact(self, session_id: str, artifact: ReasoningArtifact) -> None:
+        """Persist a reasoning artifact for ``session_id``."""
+        raise NotImplementedError
+
+    @abstractmethod
+    async def retrieve_artifacts(
+        self, session_id: str, technique: str | None = None
+    ) -> list[ReasoningArtifact]:
+        """
+        Return artifacts for ``session_id``.
+
+        Args:
+            session_id: Session to read from.
+            technique: If given, return only artifacts from that technique;
+                otherwise return all artifacts for the session.
+
+        Returns:
+            Artifacts in insertion order (oldest first).
+        """
+        raise NotImplementedError
+
+
+class InMemoryReasoningMemory(ReasoningMemory):
+    """
+    In-memory :class:`ReasoningMemory` for tests and single-process use.
+
+    Messages and artifacts are kept in plain dicts keyed by session id. Not
+    persistent and not thread/host shared — see RedisMemory/EndlessMemory for
+    durable backends.
+    """
+
+    def __init__(self) -> None:
+        self._messages: dict[str, list[Message]] = {}
+        self._artifacts: dict[str, list[ReasoningArtifact]] = {}
+
+    # --- Memory contract ---------------------------------------------------
+
+    async def store(self, session_id: str, message: Message, metadata: dict | None = None) -> None:
+        self._messages.setdefault(session_id, []).append(message)
+
+    async def retrieve(
+        self, session_id: str, query: str | None = None, limit: int = 10, **kwargs
+    ) -> list[Message]:
+        msgs = self._messages.get(session_id, [])
+        # Most recent first, capped at limit (mirrors the other backends).
+        return list(reversed(msgs))[:limit]
+
+    async def summarize(self, session_id: str, **kwargs) -> Message:
+        msgs = self._messages.get(session_id, [])
+        if not msgs:
+            return Message(role="system", content=f"No messages in session {session_id}.")
+        return Message(
+            role="system",
+            content=f"Session {session_id}: {len(msgs)} messages.",
+        )
+
+    async def clear(self, session_id: str) -> None:
+        self._messages.pop(session_id, None)
+        self._artifacts.pop(session_id, None)
+
+    # --- ReasoningMemory contract -----------------------------------------
+
+    async def store_artifact(self, session_id: str, artifact: ReasoningArtifact) -> None:
+        self._artifacts.setdefault(session_id, []).append(artifact)
+
+    async def retrieve_artifacts(
+        self, session_id: str, technique: str | None = None
+    ) -> list[ReasoningArtifact]:
+        artifacts = self._artifacts.get(session_id, [])
+        if technique is None:
+            return list(artifacts)
+        return [a for a in artifacts if a.technique == technique]
+
+    @property
+    def capabilities(self) -> list[str]:
+        return ["message_store", "reasoning_artifacts"]

--- a/agenkit/reasoning/verifier.py
+++ b/agenkit/reasoning/verifier.py
@@ -1,0 +1,53 @@
+"""
+Verifier: exact, binary checking of a candidate answer against ground truth.
+
+Mirrors the Go ``Verifier`` interface and ``VerificationResult`` struct. Unlike
+an evaluator heuristic (a float used to prune branches during search), a
+verifier produces ground truth — for code generation the only honest verifier
+is execution (``build && test``), which is binary, not approximate.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class VerificationResult:
+    """
+    Outcome of a :class:`Verifier` check.
+
+    Attributes:
+        passed: Whether the answer is considered correct.
+        score: Confidence in [0.0, 1.0]; 1.0 = fully correct.
+        reason: Human-readable explanation of the verdict.
+    """
+
+    passed: bool
+    score: float = 0.0
+    reason: str = ""
+
+
+class Verifier(ABC):
+    """
+    Checks a candidate answer against ground truth.
+
+    Exact and binary, in contrast to the heuristic float scores produced by an
+    evaluator function. Implementations might run code, check a known answer,
+    or call a stricter model.
+    """
+
+    @abstractmethod
+    async def verify(self, question: str, answer: str) -> VerificationResult:
+        """
+        Verify ``answer`` for ``question``.
+
+        Args:
+            question: The original problem statement.
+            answer: The candidate answer to check.
+
+        Returns:
+            A :class:`VerificationResult`.
+        """
+        raise NotImplementedError

--- a/tests/reasoning/test_reasoning_memory.py
+++ b/tests/reasoning/test_reasoning_memory.py
@@ -1,0 +1,180 @@
+"""Tests for reasoning memory: Verifier, ReasoningArtifact, ReasoningMemory."""
+
+import pytest
+
+from agenkit.interfaces import Message
+from agenkit.reasoning import (
+    InMemoryReasoningMemory,
+    ReasoningArtifact,
+    ScoredCandidate,
+    VerificationResult,
+    Verifier,
+)
+
+# ---------------------------------------------------------------------------
+# ScoredCandidate / ReasoningArtifact
+# ---------------------------------------------------------------------------
+
+
+def test_scored_candidate_defaults() -> None:
+    c = ScoredCandidate(text="answer")
+    assert c.text == "answer"
+    assert c.score == 0.0
+
+
+def test_artifact_fields() -> None:
+    art = ReasoningArtifact(
+        technique="tree_of_thought",
+        session_id="s1",
+        candidates=[ScoredCandidate("a", 0.2), ScoredCandidate("b", 0.9)],
+        metadata={"depth": 3},
+    )
+    assert art.technique == "tree_of_thought"
+    assert art.session_id == "s1"
+    assert len(art.candidates) == 2
+    assert art.metadata["depth"] == 3
+
+
+def test_best_candidate_returns_highest_score() -> None:
+    art = ReasoningArtifact(
+        technique="self_consistency",
+        session_id="s1",
+        candidates=[
+            ScoredCandidate("low", 0.1),
+            ScoredCandidate("high", 0.95),
+            ScoredCandidate("mid", 0.5),
+        ],
+    )
+    best = art.best_candidate()
+    assert best is not None
+    assert best.text == "high"
+    assert best.score == 0.95
+
+
+def test_best_candidate_empty_is_none() -> None:
+    art = ReasoningArtifact(technique="chain_of_thought", session_id="s1")
+    assert art.best_candidate() is None
+
+
+# ---------------------------------------------------------------------------
+# Verifier
+# ---------------------------------------------------------------------------
+
+
+class _EqualityVerifier(Verifier):
+    """Passes iff the answer equals the expected ground truth."""
+
+    def __init__(self, expected: str) -> None:
+        self._expected = expected
+
+    async def verify(self, question: str, answer: str) -> VerificationResult:
+        if answer.strip() == self._expected:
+            return VerificationResult(passed=True, score=1.0, reason="exact match")
+        return VerificationResult(passed=False, score=0.0, reason="mismatch")
+
+
+@pytest.mark.asyncio
+async def test_verifier_pass() -> None:
+    v = _EqualityVerifier("42")
+    result = await v.verify("what is 6*7?", "42")
+    assert result.passed is True
+    assert result.score == 1.0
+    assert result.reason == "exact match"
+
+
+@pytest.mark.asyncio
+async def test_verifier_fail() -> None:
+    v = _EqualityVerifier("42")
+    result = await v.verify("what is 6*7?", "41")
+    assert result.passed is False
+    assert result.score == 0.0
+
+
+def test_verification_result_defaults() -> None:
+    r = VerificationResult(passed=True)
+    assert r.passed is True
+    assert r.score == 0.0
+    assert r.reason == ""
+
+
+# ---------------------------------------------------------------------------
+# InMemoryReasoningMemory
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_memory_store_and_retrieve_messages() -> None:
+    mem = InMemoryReasoningMemory()
+    await mem.store("s1", Message(role="user", content="hello"))
+    await mem.store("s1", Message(role="assistant", content="hi"))
+    msgs = await mem.retrieve("s1", limit=10)
+    assert len(msgs) == 2
+    # Most recent first
+    assert msgs[0].content == "hi"
+
+
+@pytest.mark.asyncio
+async def test_memory_retrieve_respects_limit() -> None:
+    mem = InMemoryReasoningMemory()
+    for i in range(5):
+        await mem.store("s1", Message(role="user", content=f"m{i}"))
+    msgs = await mem.retrieve("s1", limit=2)
+    assert len(msgs) == 2
+
+
+@pytest.mark.asyncio
+async def test_store_and_retrieve_artifacts() -> None:
+    mem = InMemoryReasoningMemory()
+    art = ReasoningArtifact(
+        technique="tree_of_thought",
+        session_id="s1",
+        candidates=[ScoredCandidate("x", 0.7)],
+    )
+    await mem.store_artifact("s1", art)
+    out = await mem.retrieve_artifacts("s1")
+    assert len(out) == 1
+    assert out[0].technique == "tree_of_thought"
+
+
+@pytest.mark.asyncio
+async def test_retrieve_artifacts_filters_by_technique() -> None:
+    mem = InMemoryReasoningMemory()
+    await mem.store_artifact("s1", ReasoningArtifact(technique="tot", session_id="s1"))
+    await mem.store_artifact("s1", ReasoningArtifact(technique="cot", session_id="s1"))
+    await mem.store_artifact("s1", ReasoningArtifact(technique="tot", session_id="s1"))
+
+    assert len(await mem.retrieve_artifacts("s1")) == 3
+    assert len(await mem.retrieve_artifacts("s1", technique="tot")) == 2
+    assert len(await mem.retrieve_artifacts("s1", technique="cot")) == 1
+    assert len(await mem.retrieve_artifacts("s1", technique="missing")) == 0
+
+
+@pytest.mark.asyncio
+async def test_artifacts_are_session_isolated() -> None:
+    mem = InMemoryReasoningMemory()
+    await mem.store_artifact("s1", ReasoningArtifact(technique="tot", session_id="s1"))
+    await mem.store_artifact("s2", ReasoningArtifact(technique="tot", session_id="s2"))
+    assert len(await mem.retrieve_artifacts("s1")) == 1
+    assert len(await mem.retrieve_artifacts("s2")) == 1
+    assert await mem.retrieve_artifacts("nonexistent") == []
+
+
+@pytest.mark.asyncio
+async def test_clear_removes_messages_and_artifacts() -> None:
+    mem = InMemoryReasoningMemory()
+    await mem.store("s1", Message(role="user", content="hi"))
+    await mem.store_artifact("s1", ReasoningArtifact(technique="tot", session_id="s1"))
+    await mem.clear("s1")
+    assert await mem.retrieve("s1") == []
+    assert await mem.retrieve_artifacts("s1") == []
+
+
+@pytest.mark.asyncio
+async def test_is_usable_as_memory() -> None:
+    from agenkit.memory.base import Memory
+
+    mem = InMemoryReasoningMemory()
+    assert isinstance(mem, Memory)  # ReasoningMemory is a Memory
+    assert "reasoning_artifacts" in mem.capabilities
+    summary = await mem.summarize("empty")
+    assert summary.role == "system"


### PR DESCRIPTION
Closes #630 (Python parity). Python had **none** of the v0.84.0 Reasoning Memory abstractions that already exist in Go; this brings it to parity (the issue's stated minimum acceptance).

## Added — new `agenkit/reasoning/` package
Ports `agenkit-go/agenkit/interfaces.go` + `memory/memory.go`:
- `verifier.py` — `Verifier` ABC (`async verify → VerificationResult`): exact/binary check of an answer vs ground truth, distinct from heuristic evaluator floats. `VerificationResult(passed, score, reason)`.
- `artifact.py` — `ScoredCandidate(text, score)` and `ReasoningArtifact(technique, session_id, candidates, metadata)` with `best_candidate()`.
- `memory.py` — `ReasoningMemory(Memory)` ABC adding `store_artifact` / `retrieve_artifacts(technique filter)`, plus `InMemoryReasoningMemory`.

## Tests
14 tests covering artifacts, best-candidate (incl. empty), verifier pass/fail + defaults, artifact store/retrieve, technique filtering, session isolation, clear, and Memory-subtype conformance. ruff clean; 14/14 pass.

## Follow-up (noted in #630)
Cross-language ports (TS, Rust, C++, Zig, C#, Java, Scala) — Go + Python now have it; the rest tracked for a later pass.