### PR TITLE
test(ts): make Redis suite hermetic — skip when no server (part of #627)

### DIFF
--- a/agenkit-ts/src/__tests__/memory/redis.test.ts
+++ b/agenkit-ts/src/__tests__/memory/redis.test.ts
@@ -11,7 +11,37 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { RedisMemory } from '../../memory/redisMemory';
 import { createMessage } from '../../core/interfaces';
 
-describe('RedisMemory', () => {
+/**
+ * Probe Redis availability once. Without a running server these tests would
+ * otherwise each open a client that retries the connection until the test
+ * timeout, hanging CI. When Redis is absent we skip the whole suite instead.
+ */
+const redisUrl = process.env.REDIS_URL || 'redis://localhost:6379';
+const redisAvailable = await (async (): Promise<boolean> => {
+  const probe = new RedisMemory({ redisUrl, keyPrefix: 'agenkit:test:probe' });
+  const timeout = new Promise<never>((_, reject) =>
+    setTimeout(() => reject(new Error('redis probe timeout')), 1500).unref(),
+  );
+  try {
+    // Race the probe against a short timeout: the redis client otherwise
+    // buffers and retries the connection, hanging when no server is present.
+    await Promise.race([probe.getAllSessions(), timeout]);
+    return true;
+  } catch {
+    return false;
+  } finally {
+    try {
+      await Promise.race([
+        probe.close(),
+        new Promise((resolve) => setTimeout(resolve, 500).unref()),
+      ]);
+    } catch {
+      /* ignore */
+    }
+  }
+})();
+
+describe.skipIf(!redisAvailable)('RedisMemory', () => {
   let memory: RedisMemory;
 
   beforeEach(() => {


### PR DESCRIPTION
Partial fix for #627 (test-suite hardening).

## The concrete CI-staller
The `RedisMemory` test suite opened a client per test that **retried the connection until the test timeout** when no Redis was present — this is the hang that forced the 5-min `timeout 300` cap on the TS CI test step.

## Fix
Probe Redis availability **once at load** — racing `getAllSessions()` against a 1.5s timeout (the redis client buffers + retries, so a bare await still hangs) — and `describe.skipIf`-skip the whole suite when absent.

## Verified
- No Redis present → suite **skips 18 tests in ~2.5s** instead of hanging
- `tsc --noEmit` clean

## Still open under #627 (not in this PR)
The wall-clock timing assertions in `middleware/retry`, `rate-limiter`, chaos, and property suites (e.g. `expect(elapsed).toBeGreaterThanOrEqual(250)`) are inherently flaky on loaded runners and need **fake-timer** conversion — a deeper per-test rewrite. They remain non-blocking in CI. One (`should cap delay at maxDelay`) may also surface a real `maxDelay` bug worth investigating during that conversion.