### PR TITLE
feat(zig): migrate to Zig 0.16.0 + raise language floor (closes #646)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -196,17 +196,11 @@ jobs:
         uses: mlugg/setup-zig@v2
         with:
           # Matches build.zig.zon .minimum_zig_version
-          version: 0.15.2
-      # `zig build` (default) compiles the examples too, some of which don't
-      # build under 0.15.2 (ignored error unions — pre-existing). `zig build
-      # test` builds + runs the library/test modules; it currently has a
-      # failing test (evaluation.prompt_optimizer.sampleRandomConfig), so it's
-      # non-blocking until that's fixed (tracked as a follow-up). build.zig
-      # couples compile and run, so there's no compile-only gate to keep
-      # blocking here.
-      - name: Zig build + test (non-blocking)
+          version: 0.16.0
+      # `zig build test` builds + runs the library/test modules. Migrated to
+      # Zig 0.16.0 (#646), so this is the real compile+test gate.
+      - name: Zig build + test (blocking)
         if: matrix.lang == 'zig'
-        continue-on-error: true
         working-directory: agenkit-zig
         run: zig build test
 

--- a/agenkit-zig/benchmarks/patterns.zig
+++ b/agenkit-zig/benchmarks/patterns.zig
@@ -204,7 +204,7 @@ fn processStreamImpl(ptr: *anyopaque, message: Message, callbacks: StreamCallbac
     callbacks.onError(AgentError.NotImplemented);
 }
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/agenkit-zig/benchmarks/patterns.zig
+++ b/agenkit-zig/benchmarks/patterns.zig
@@ -4,6 +4,7 @@
 /// to isolate pattern logic from LLM latency.
 
 const std = @import("std");
+const agktime = agenkit.time_compat;
 const agenkit = @import("agenkit");
 const Agent = agenkit.Agent;
 const StreamCallbacks = agenkit.StreamCallbacks;
@@ -96,12 +97,12 @@ pub fn benchmark(
     }
 
     // Benchmark
-    const start = std.time.nanoTimestamp();
+    const start = agktime.nanoTimestamp();
     i = 0;
     while (i < iterations) : (i += 1) {
         try func(allocator);
     }
-    const end = std.time.nanoTimestamp();
+    const end = agktime.nanoTimestamp();
     const total_ns: u64 = @intCast(end - start);
 
     const avg_us = @as(f64, @floatFromInt(total_ns)) / @as(f64, @floatFromInt(iterations)) / 1000.0;

--- a/agenkit-zig/build.zig
+++ b/agenkit-zig/build.zig
@@ -39,6 +39,10 @@ pub fn build(b: *std.Build) void {
         // Later on we'll use this module as the root module of a test executable
         // which requires us to specify a target.
         .target = target,
+        // libc is required: env_compat reads `std.c.environ`, and the HTTP/LLM
+        // adapters use the C networking stack. On macOS std.c is implicitly
+        // available, but Linux requires it declared explicitly here.
+        .link_libc = true,
     });
 
     // Here we define an executable. An executable needs to have a root module

--- a/agenkit-zig/build.zig
+++ b/agenkit-zig/build.zig
@@ -743,6 +743,9 @@ pub fn build(b: *std.Build) void {
             .root_source_file = b.path("tests/cross_language_harness.zig"),
             .target = target,
             .optimize = optimize,
+            .imports = &.{
+                .{ .name = "agenkit", .module = mod },
+            },
         }),
     });
     b.installArtifact(test_harness);

--- a/agenkit-zig/build.zig.zon
+++ b/agenkit-zig/build.zig.zon
@@ -25,7 +25,7 @@
     .fingerprint = 0x88a29eca532cb725, // Changing this has security and trust implications.
     // Tracks the earliest Zig version that the package considers to be a
     // supported use case.
-    .minimum_zig_version = "0.16.0",
+    .minimum_zig_version = "0.15.2",
     // This field is optional.
     // Each dependency must either provide a `url` and `hash`, or a `path`.
     // `zig build --fetch` can be used to fetch all dependencies of a package, recursively.

--- a/agenkit-zig/build.zig.zon
+++ b/agenkit-zig/build.zig.zon
@@ -25,7 +25,7 @@
     .fingerprint = 0x88a29eca532cb725, // Changing this has security and trust implications.
     // Tracks the earliest Zig version that the package considers to be a
     // supported use case.
-    .minimum_zig_version = "0.15.2",
+    .minimum_zig_version = "0.16.0",
     // This field is optional.
     // Each dependency must either provide a `url` and `hash`, or a `path`.
     // `zig build --fetch` can be used to fetch all dependencies of a package, recursively.

--- a/agenkit-zig/examples/adapters/anthropic_basic.zig
+++ b/agenkit-zig/examples/adapters/anthropic_basic.zig
@@ -19,7 +19,7 @@ const Role = agenkit.Role;
 const llm_mod = agenkit.adapter;
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/agenkit-zig/examples/adapters/anthropic_basic.zig
+++ b/agenkit-zig/examples/adapters/anthropic_basic.zig
@@ -65,7 +65,7 @@ fn simpleCompletion(allocator: std.mem.Allocator, llm: llm_mod.LLM) !void {
 
     var options = llm_mod.CallOptions.init(allocator);
     defer options.deinit();
-    options.withMaxTokens(300); // max_tokens is required for Anthropic
+    try options.withMaxTokens(300); // max_tokens is required for Anthropic
 
     std.debug.print("Request: {s}\n", .{msg.content.text});
 
@@ -109,8 +109,8 @@ fn systemMessageExample(allocator: std.mem.Allocator, llm: llm_mod.LLM) !void {
 
     var options = llm_mod.CallOptions.init(allocator);
     defer options.deinit();
-    options.withMaxTokens(500);
-    options.withTemperature(0.3); // Lower temp for technical accuracy
+    try options.withMaxTokens(500);
+    try options.withTemperature(0.3); // Lower temp for technical accuracy
 
     std.debug.print("System: {s}\n", .{system.content.text});
     std.debug.print("Request: {s}\n", .{user.content.text});
@@ -145,9 +145,9 @@ fn creativeWriting(allocator: std.mem.Allocator, llm: llm_mod.LLM) !void {
 
     var options = llm_mod.CallOptions.init(allocator);
     defer options.deinit();
-    options.withMaxTokens(500);
-    options.withTemperature(0.9); // Higher temp for creativity
-    options.withTopP(0.95);
+    try options.withMaxTokens(500);
+    try options.withTemperature(0.9); // Higher temp for creativity
+    try options.withTopP(0.95);
 
     std.debug.print("Request: {s}\n", .{user.content.text});
     std.debug.print("Temperature: 0.9 (creative)\n", .{});

--- a/agenkit-zig/examples/adapters/anthropic_streaming.zig
+++ b/agenkit-zig/examples/adapters/anthropic_streaming.zig
@@ -14,7 +14,7 @@ const Message = agenkit.Message;
 const CallOptions = agenkit.adapter.llm.CallOptions;
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/agenkit-zig/examples/adapters/anthropic_streaming.zig
+++ b/agenkit-zig/examples/adapters/anthropic_streaming.zig
@@ -42,11 +42,11 @@ pub fn main() !void {
     // Set up options
     var options = CallOptions.init(allocator);
     defer options.deinit();
-    options.withTemperature(1.0);
-    options.withMaxTokens(1024);
+    try options.withTemperature(1.0);
+    try options.withMaxTokens(1024);
 
     // Stream response
-    var full_response = std.ArrayList(u8).init(allocator);
+    var full_response = std.ArrayList(u8).empty;
     defer full_response.deinit();
 
     var stream_iter = try llm.stream(allocator, &messages, &options);

--- a/agenkit-zig/examples/adapters/bedrock_basic.zig
+++ b/agenkit-zig/examples/adapters/bedrock_basic.zig
@@ -31,7 +31,7 @@ const Role = agenkit.Role;
 const llm_mod = agenkit.adapter;
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/agenkit-zig/examples/adapters/gemini_basic.zig
+++ b/agenkit-zig/examples/adapters/gemini_basic.zig
@@ -19,7 +19,7 @@ const Role = agenkit.Role;
 const llm_mod = agenkit.adapter;
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/agenkit-zig/examples/adapters/gemini_basic.zig
+++ b/agenkit-zig/examples/adapters/gemini_basic.zig
@@ -106,7 +106,7 @@ fn creativeWriting(allocator: std.mem.Allocator, llm: llm_mod.LLM) !void {
 
     var options = llm_mod.CallOptions.init(allocator);
     defer options.deinit();
-    options.withTemperature(0.9); // Higher temp for creativity
+    try options.withTemperature(0.9); // Higher temp for creativity
 
     std.debug.print("Request: {s}\n", .{user.content.text});
     std.debug.print("Temperature: 0.9 (creative)\n", .{});
@@ -140,8 +140,8 @@ fn codeGeneration(allocator: std.mem.Allocator, llm: llm_mod.LLM) !void {
 
     var options = llm_mod.CallOptions.init(allocator);
     defer options.deinit();
-    options.withTemperature(0.2); // Low temp for accuracy
-    options.withMaxTokens(500); // Limit response length
+    try options.withTemperature(0.2); // Low temp for accuracy
+    try options.withMaxTokens(500); // Limit response length
 
     std.debug.print("Request: {s}\n", .{user.content.text});
     std.debug.print("Temperature: 0.2 (precise)\n", .{});

--- a/agenkit-zig/examples/adapters/gemini_streaming.zig
+++ b/agenkit-zig/examples/adapters/gemini_streaming.zig
@@ -14,7 +14,7 @@ const Message = agenkit.Message;
 const CallOptions = agenkit.adapter.llm.CallOptions;
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/agenkit-zig/examples/adapters/gemini_streaming.zig
+++ b/agenkit-zig/examples/adapters/gemini_streaming.zig
@@ -42,11 +42,11 @@ pub fn main() !void {
     // Set up options
     var options = CallOptions.init(allocator);
     defer options.deinit();
-    options.withTemperature(1.0);
-    options.withMaxTokens(1024);
+    try options.withTemperature(1.0);
+    try options.withMaxTokens(1024);
 
     // Stream response
-    var full_response = std.ArrayList(u8).init(allocator);
+    var full_response = std.ArrayList(u8).empty;
     defer full_response.deinit();
 
     var stream_iter = try llm.stream(allocator, &messages, &options);

--- a/agenkit-zig/examples/adapters/litellm_basic.zig
+++ b/agenkit-zig/examples/adapters/litellm_basic.zig
@@ -126,7 +126,7 @@ fn modelRouting(allocator: std.mem.Allocator) !void {
 
     var options = llm_mod.CallOptions.init(allocator);
     defer options.deinit();
-    options.withMaxTokens(50);
+    try options.withMaxTokens(50);
 
     const response = fast_llm.complete(allocator, &messages, &options) catch |err| {
         std.debug.print("Error: {}\n", .{err});
@@ -174,7 +174,7 @@ fn costAwareRouting(allocator: std.mem.Allocator) !void {
 
     var options1 = llm_mod.CallOptions.init(allocator);
     defer options1.deinit();
-    options1.withMaxTokens(100);
+    try options1.withMaxTokens(100);
 
     const response1 = cheap_llm.complete(allocator, &messages1, &options1) catch |err| {
         std.debug.print("Error: {}\n", .{err});

--- a/agenkit-zig/examples/adapters/litellm_basic.zig
+++ b/agenkit-zig/examples/adapters/litellm_basic.zig
@@ -20,7 +20,7 @@ const Role = agenkit.Role;
 const llm_mod = agenkit.adapter;
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/agenkit-zig/examples/adapters/ollama_basic.zig
+++ b/agenkit-zig/examples/adapters/ollama_basic.zig
@@ -19,7 +19,7 @@ const Role = agenkit.Role;
 const llm_mod = agenkit.adapter;
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/agenkit-zig/examples/adapters/ollama_basic.zig
+++ b/agenkit-zig/examples/adapters/ollama_basic.zig
@@ -106,7 +106,7 @@ fn creativeWriting(allocator: std.mem.Allocator, llm: llm_mod.LLM) !void {
 
     var options = llm_mod.CallOptions.init(allocator);
     defer options.deinit();
-    options.withTemperature(0.9); // Higher temp for creativity
+    try options.withTemperature(0.9); // Higher temp for creativity
 
     std.debug.print("Request: {s}\n", .{user.content.text});
     std.debug.print("Temperature: 0.9 (creative)\n", .{});
@@ -140,7 +140,7 @@ fn codeGeneration(allocator: std.mem.Allocator, llm: llm_mod.LLM) !void {
 
     var options = llm_mod.CallOptions.init(allocator);
     defer options.deinit();
-    options.withTemperature(0.2); // Low temp for accuracy
+    try options.withTemperature(0.2); // Low temp for accuracy
 
     std.debug.print("Request: {s}\n", .{user.content.text});
     std.debug.print("Temperature: 0.2 (precise)\n", .{});

--- a/agenkit-zig/examples/adapters/openai_basic.zig
+++ b/agenkit-zig/examples/adapters/openai_basic.zig
@@ -101,8 +101,8 @@ fn completionWithOptions(allocator: std.mem.Allocator, llm: llm_mod.LLM) !void {
 
     var options = llm_mod.CallOptions.init(allocator);
     defer options.deinit();
-    options.withTemperature(0.9); // Higher temp for creative output
-    options.withMaxTokens(100);
+    try options.withTemperature(0.9); // Higher temp for creative output
+    try options.withMaxTokens(100);
 
     std.debug.print("Request: {s}\n", .{msg.content.text});
     std.debug.print("Options: temperature=0.9, max_tokens=100\n", .{});
@@ -134,7 +134,7 @@ fn multiTurnConversation(allocator: std.mem.Allocator, llm: llm_mod.LLM) !void {
 
     var options = llm_mod.CallOptions.init(allocator);
     defer options.deinit();
-    options.withTemperature(0.2); // Low temp for factual responses
+    try options.withTemperature(0.2); // Low temp for factual responses
 
     std.debug.print("Conversation:\n", .{});
     std.debug.print("System: {s}\n", .{system.content.text});
@@ -171,8 +171,8 @@ fn codeGeneration(allocator: std.mem.Allocator, llm: llm_mod.LLM) !void {
 
     var options = llm_mod.CallOptions.init(allocator);
     defer options.deinit();
-    options.withTemperature(0.2); // Low temp for code
-    options.withMaxTokens(500);
+    try options.withTemperature(0.2); // Low temp for code
+    try options.withMaxTokens(500);
 
     std.debug.print("Request: {s}\n", .{user.content.text});
 

--- a/agenkit-zig/examples/adapters/openai_basic.zig
+++ b/agenkit-zig/examples/adapters/openai_basic.zig
@@ -21,7 +21,7 @@ const Role = agenkit.Role;
 const llm_mod = agenkit.adapter;
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/agenkit-zig/examples/adapters/openai_streaming.zig
+++ b/agenkit-zig/examples/adapters/openai_streaming.zig
@@ -14,7 +14,7 @@ const Message = agenkit.Message;
 const CallOptions = agenkit.adapter.llm.CallOptions;
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/agenkit-zig/examples/adapters/openai_streaming.zig
+++ b/agenkit-zig/examples/adapters/openai_streaming.zig
@@ -42,11 +42,11 @@ pub fn main() !void {
     // Set up options
     var options = CallOptions.init(allocator);
     defer options.deinit();
-    options.withTemperature(1.0);
-    options.withMaxTokens(1024);
+    try options.withTemperature(1.0);
+    try options.withMaxTokens(1024);
 
     // Stream response
-    var full_response = std.ArrayList(u8).init(allocator);
+    var full_response = std.ArrayList(u8).empty;
     defer full_response.deinit();
 
     var stream_iter = try llm.stream(allocator, &messages, &options);

--- a/agenkit-zig/examples/basic/echo.zig
+++ b/agenkit-zig/examples/basic/echo.zig
@@ -14,7 +14,7 @@ const agenkit = @import("agenkit");
 
 pub fn main() !void {
     // Initialize allocator
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/agenkit-zig/examples/basic/error_handling.zig
+++ b/agenkit-zig/examples/basic/error_handling.zig
@@ -109,7 +109,7 @@ fn processStreamImpl(ptr: *anyopaque, message: Message, callbacks: StreamCallbac
 }
 pub fn main() !void {
     // Initialize allocator
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/agenkit-zig/examples/basic/memory_management.zig
+++ b/agenkit-zig/examples/basic/memory_management.zig
@@ -2,7 +2,7 @@
 //!
 //! This example demonstrates:
 //! - Different allocator types in Zig
-//! - GeneralPurposeAllocator for leak detection
+//! - DebugAllocator for leak detection
 //! - ArenaAllocator for bulk cleanup
 //! - Proper defer patterns for cleanup
 //! - Memory ownership in agent processing
@@ -16,10 +16,10 @@ const agenkit = @import("agenkit");
 pub fn main() !void {
     std.debug.print("\n=== AgentKit Memory Management Example ===\n\n", .{});
 
-    // Example 1: GeneralPurposeAllocator with leak detection
-    std.debug.print("--- Example 1: GeneralPurposeAllocator with Leak Detection ---\n", .{});
+    // Example 1: DebugAllocator with leak detection
+    std.debug.print("--- Example 1: DebugAllocator with Leak Detection ---\n", .{});
     {
-        var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+        var gpa = std.heap.DebugAllocator(.{}){};
         defer {
             const leaked = gpa.deinit();
             if (leaked == .leak) {
@@ -51,7 +51,7 @@ pub fn main() !void {
     // Example 2: ArenaAllocator for bulk cleanup
     std.debug.print("--- Example 2: ArenaAllocator for Bulk Cleanup ---\n", .{});
     {
-        var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+        var gpa = std.heap.DebugAllocator(.{}){};
         defer _ = gpa.deinit();
         const backing_allocator = gpa.allocator();
 
@@ -81,7 +81,7 @@ pub fn main() !void {
     // Example 3: Memory ownership patterns
     std.debug.print("--- Example 3: Memory Ownership Patterns ---\n", .{});
     {
-        var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+        var gpa = std.heap.DebugAllocator(.{}){};
         defer _ = gpa.deinit();
         const allocator = gpa.allocator();
 
@@ -125,7 +125,7 @@ pub fn main() !void {
     // Example 4: Memory-efficient agent chains
     std.debug.print("--- Example 4: Memory-Efficient Agent Chains ---\n", .{});
     {
-        var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+        var gpa = std.heap.DebugAllocator(.{}){};
         defer _ = gpa.deinit();
         const allocator = gpa.allocator();
 
@@ -172,7 +172,7 @@ pub fn main() !void {
     // Example 5: Detecting memory leaks intentionally
     std.debug.print("--- Example 5: Memory Leak Detection ---\n", .{});
     {
-        var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+        var gpa = std.heap.DebugAllocator(.{}){};
         const allocator = gpa.allocator();
 
         // Create a message but DON'T clean it up (intentional leak for demo)
@@ -194,7 +194,7 @@ pub fn main() !void {
 
     std.debug.print("=== Memory Management Best Practices ===\n", .{});
     std.debug.print("1. Always use defer for cleanup\n", .{});
-    std.debug.print("2. Use GeneralPurposeAllocator during development\n", .{});
+    std.debug.print("2. Use DebugAllocator during development\n", .{});
     std.debug.print("3. Consider ArenaAllocator for short-lived operations\n", .{});
     std.debug.print("4. Clear ownership: who allocates, who frees?\n", .{});
     std.debug.print("5. Clean up intermediate results in chains\n", .{});

--- a/agenkit-zig/examples/basic/memory_management.zig
+++ b/agenkit-zig/examples/basic/memory_management.zig
@@ -2,7 +2,7 @@
 //!
 //! This example demonstrates:
 //! - Different allocator types in Zig
-//! - DebugAllocator for leak detection
+//! - GeneralPurposeAllocator for leak detection
 //! - ArenaAllocator for bulk cleanup
 //! - Proper defer patterns for cleanup
 //! - Memory ownership in agent processing
@@ -16,8 +16,8 @@ const agenkit = @import("agenkit");
 pub fn main() !void {
     std.debug.print("\n=== AgentKit Memory Management Example ===\n\n", .{});
 
-    // Example 1: DebugAllocator with leak detection
-    std.debug.print("--- Example 1: DebugAllocator with Leak Detection ---\n", .{});
+    // Example 1: GeneralPurposeAllocator with leak detection
+    std.debug.print("--- Example 1: GeneralPurposeAllocator with Leak Detection ---\n", .{});
     {
         var gpa = std.heap.DebugAllocator(.{}){};
         defer {
@@ -194,7 +194,7 @@ pub fn main() !void {
 
     std.debug.print("=== Memory Management Best Practices ===\n", .{});
     std.debug.print("1. Always use defer for cleanup\n", .{});
-    std.debug.print("2. Use DebugAllocator during development\n", .{});
+    std.debug.print("2. Use GeneralPurposeAllocator during development\n", .{});
     std.debug.print("3. Consider ArenaAllocator for short-lived operations\n", .{});
     std.debug.print("4. Clear ownership: who allocates, who frees?\n", .{});
     std.debug.print("5. Clean up intermediate results in chains\n", .{});

--- a/agenkit-zig/examples/basic/testing_patterns.zig
+++ b/agenkit-zig/examples/basic/testing_patterns.zig
@@ -120,7 +120,7 @@ fn processStreamImpl(ptr: *anyopaque, message: Message, callbacks: StreamCallbac
     callbacks.onError(AgentError.NotImplemented);
 }
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/agenkit-zig/examples/basic/workflow.zig
+++ b/agenkit-zig/examples/basic/workflow.zig
@@ -14,7 +14,7 @@ const agenkit = @import("agenkit");
 
 pub fn main() !void {
     // Initialize allocator
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/agenkit-zig/examples/budget/cost_tracking_example.zig
+++ b/agenkit-zig/examples/budget/cost_tracking_example.zig
@@ -11,7 +11,7 @@ const std = @import("std");
 const budget = @import("../../src/infrastructure/budget/mod.zig");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/agenkit-zig/examples/checkpointing/durable_agent.zig
+++ b/agenkit-zig/examples/checkpointing/durable_agent.zig
@@ -18,7 +18,7 @@ const DurableAgent = agenkit.infrastructure.checkpointing.DurableAgent;
 const InMemoryStorage = agenkit.infrastructure.checkpointing.InMemoryStorage;
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/agenkit-zig/examples/checkpointing/durable_agent.zig
+++ b/agenkit-zig/examples/checkpointing/durable_agent.zig
@@ -134,7 +134,7 @@ pub fn main() !void {
     // Step 10: Get statistics
     std.debug.print("10. Session statistics:\n", .{});
     var stats = try durable.getSessionStats(session_id);
-    defer stats.object.deinit();
+    defer stats.object.deinit(allocator);
 
     if (stats.object.get("total_checkpoints")) |total| {
         std.debug.print("   Total checkpoints: {d}\n", .{total.integer});

--- a/agenkit-zig/examples/checkpointing/file_storage.zig
+++ b/agenkit-zig/examples/checkpointing/file_storage.zig
@@ -98,11 +98,11 @@ pub fn main() !void {
         );
         defer allocator.free(file_path);
 
-        const file = std.fs.cwd().openFile(file_path, .{}) catch |err| {
+        const file = std.Io.Dir.cwd().openFile(agenkit.io_compat.io(), file_path, .{}) catch |err| {
             std.debug.print("       ⚠️  File not found: {}\n", .{err});
             continue;
         };
-        file.close();
+        file.close(agenkit.io_compat.io());
         std.debug.print("       ✅ File exists: {s}\n", .{file_path});
     }
     std.debug.print("\n", .{});
@@ -110,7 +110,7 @@ pub fn main() !void {
     // Step 6: Get session statistics
     std.debug.print("6. Session statistics:\n", .{});
     var stats = try durable.getSessionStats(session_id);
-    defer stats.object.deinit();
+    defer stats.object.deinit(allocator);
 
     if (stats.object.get("total_checkpoints")) |total| {
         std.debug.print("   Total checkpoints: {d}\n", .{total.integer});

--- a/agenkit-zig/examples/checkpointing/file_storage.zig
+++ b/agenkit-zig/examples/checkpointing/file_storage.zig
@@ -18,7 +18,7 @@ const DurableAgent = agenkit.infrastructure.checkpointing.DurableAgent;
 const FileStorage = agenkit.infrastructure.checkpointing.FileStorage;
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/agenkit-zig/examples/echo_example.zig
+++ b/agenkit-zig/examples/echo_example.zig
@@ -10,7 +10,7 @@ const agenkit = @import("agenkit");
 
 pub fn main() !void {
     // Setup allocator
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/agenkit-zig/examples/echo_example.zig
+++ b/agenkit-zig/examples/echo_example.zig
@@ -6,6 +6,7 @@
 /// - Processing messages through the agent
 /// - Handling results and cleanup
 const std = @import("std");
+const agktime = @import("../src/time_compat.zig");
 const agenkit = @import("agenkit");
 
 pub fn main() !void {
@@ -28,7 +29,7 @@ pub fn main() !void {
 
     // Add metadata to the message
     try user_msg.setMetadata("session_id", std.json.Value{ .string = "zig-example-001" });
-    try user_msg.setMetadata("timestamp", std.json.Value{ .integer = std.time.timestamp() });
+    try user_msg.setMetadata("timestamp", std.json.Value{ .integer = agktime.timestamp() });
 
     // Create an echo agent
     std.debug.print("Creating echo agent...\n", .{});

--- a/agenkit-zig/examples/evaluation/basic_evaluation_example.zig
+++ b/agenkit-zig/examples/evaluation/basic_evaluation_example.zig
@@ -26,7 +26,7 @@ pub fn main() !void {
     // ========================================================================
     std.debug.print("Step 1: Creating test cases...\n", .{});
 
-    var test_cases = std.ArrayList(*evaluation.TestCase){};
+    var test_cases = std.ArrayList(*evaluation.TestCase).empty;
     defer {
         for (test_cases.items) |tc| tc.deinit();
         test_cases.deinit(allocator);

--- a/agenkit-zig/examples/evaluation/basic_evaluation_example.zig
+++ b/agenkit-zig/examples/evaluation/basic_evaluation_example.zig
@@ -13,7 +13,7 @@ const agenkit = @import("agenkit");
 const evaluation = agenkit.evaluation;
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/agenkit-zig/examples/evaluation/regression_detection_example.zig
+++ b/agenkit-zig/examples/evaluation/regression_detection_example.zig
@@ -13,7 +13,7 @@ const agenkit = @import("agenkit");
 const evaluation = agenkit.evaluation;
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/agenkit-zig/examples/evaluation/session_recording_example.zig
+++ b/agenkit-zig/examples/evaluation/session_recording_example.zig
@@ -159,17 +159,14 @@ pub fn main() !void {
     std.debug.print("  ✓ Exported to: {s}\n\n", .{export_path});
 
     // Read and display
-    const file = try std.fs.cwd().openFile(export_path, .{});
-    defer file.close();
-
-    const content = try file.readToEndAlloc(allocator, 10000);
+    const content = try std.Io.Dir.cwd().readFileAlloc(agenkit.io_compat.io(), export_path, allocator, .limited(10000));
     defer allocator.free(content);
 
     std.debug.print("  JSON Content:\n", .{});
     std.debug.print("  {s}\n\n", .{content});
 
     // Clean up
-    try std.fs.cwd().deleteFile(export_path);
+    try std.Io.Dir.cwd().deleteFile(agenkit.io_compat.io(), export_path);
 
     // ========================================================================
     // Summary

--- a/agenkit-zig/examples/evaluation/session_recording_example.zig
+++ b/agenkit-zig/examples/evaluation/session_recording_example.zig
@@ -13,7 +13,7 @@ const agenkit = @import("agenkit");
 const evaluation = agenkit.evaluation;
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/agenkit-zig/examples/infrastructure/basic_memory.zig
+++ b/agenkit-zig/examples/infrastructure/basic_memory.zig
@@ -16,7 +16,7 @@ const InMemoryMemory = agenkit.infrastructure.memory.InMemoryMemory;
 const Role = agenkit.infrastructure.memory.Role;
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/agenkit-zig/examples/infrastructure/conversational_with_memory.zig
+++ b/agenkit-zig/examples/infrastructure/conversational_with_memory.zig
@@ -140,7 +140,7 @@ const MemoryAwareAgent = struct {
 };
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/agenkit-zig/examples/infrastructure/hierarchical_memory.zig
+++ b/agenkit-zig/examples/infrastructure/hierarchical_memory.zig
@@ -15,7 +15,7 @@ const MemoryEntry = agenkit.infrastructure.memory.MemoryEntry;
 const HierarchyMemory = agenkit.infrastructure.memory.HierarchyMemory;
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/agenkit-zig/examples/infrastructure/memory_strategies.zig
+++ b/agenkit-zig/examples/infrastructure/memory_strategies.zig
@@ -16,7 +16,7 @@ const strategies = agenkit.infrastructure.memory.strategies;
 const StrategyContext = strategies.StrategyContext;
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/agenkit-zig/examples/integration/evaluation_pipeline.zig
+++ b/agenkit-zig/examples/integration/evaluation_pipeline.zig
@@ -187,7 +187,7 @@ fn processStreamImpl(ptr: *anyopaque, message: Message, callbacks: StreamCallbac
     callbacks.onError(AgentError.NotImplemented);
 }
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/agenkit-zig/examples/integration/evaluation_pipeline.zig
+++ b/agenkit-zig/examples/integration/evaluation_pipeline.zig
@@ -14,6 +14,7 @@
 //! Run with: zig build run-evaluation
 
 const std = @import("std");
+const agktime = agenkit.time_compat;
 const agenkit = @import("agenkit");
 const Message = agenkit.Message;
 const AgentError = agenkit.AgentError;
@@ -29,7 +30,7 @@ const BenchmarkAgent = struct {
 
     pub fn init(allocator: std.mem.Allocator, name: []const u8, delay_ms: u64, success_rate: f32) !*BenchmarkAgent {
         var seed: u64 = undefined;
-        try std.posix.getrandom(std.mem.asBytes(&seed));
+        agenkit.io_compat.randomBytes(std.mem.asBytes(&seed));
 
         const self = try allocator.create(BenchmarkAgent);
         self.* = .{
@@ -80,7 +81,7 @@ const BenchmarkAgent = struct {
         };
 
         // Simulate processing delay
-        std.Thread.sleep(self.delay_ms * std.time.ns_per_ms);
+        agktime.sleep(self.delay_ms * std.time.ns_per_ms);
 
         // Simulate success/failure based on success_rate
         const rand_val = self.prng.random().float(f32);
@@ -203,15 +204,15 @@ pub fn main() !void {
         var metrics = EvaluationMetrics.init();
         const num_requests = 10;
 
-        const start = std.time.nanoTimestamp();
+        const start = agktime.nanoTimestamp();
 
         for (0..num_requests) |_| {
             var msg = try agenkit.Message.withText(allocator, .user, "test");
             defer msg.deinit();
 
-            const req_start = std.time.nanoTimestamp();
+            const req_start = agktime.nanoTimestamp();
             const result = try agent.agent().process(msg);
-            const req_end = std.time.nanoTimestamp();
+            const req_end = agktime.nanoTimestamp();
             const duration = @as(u64, @intCast(req_end - req_start));
 
             if (result.isOk()) {
@@ -223,7 +224,7 @@ pub fn main() !void {
             }
         }
 
-        const end = std.time.nanoTimestamp();
+        const end = agktime.nanoTimestamp();
         const total_duration_s = @as(f64, @floatFromInt(end - start)) / @as(f64, @floatFromInt(std.time.ns_per_s));
 
         metrics.print();
@@ -240,15 +241,15 @@ pub fn main() !void {
         var metrics = EvaluationMetrics.init();
         const num_requests = 5;
 
-        const start = std.time.nanoTimestamp();
+        const start = agktime.nanoTimestamp();
 
         for (0..num_requests) |_| {
             var msg = try agenkit.Message.withText(allocator, .user, "test");
             defer msg.deinit();
 
-            const req_start = std.time.nanoTimestamp();
+            const req_start = agktime.nanoTimestamp();
             const result = try agent.agent().process(msg);
-            const req_end = std.time.nanoTimestamp();
+            const req_end = agktime.nanoTimestamp();
             const duration = @as(u64, @intCast(req_end - req_start));
 
             if (result.isOk()) {
@@ -260,7 +261,7 @@ pub fn main() !void {
             }
         }
 
-        const end = std.time.nanoTimestamp();
+        const end = agktime.nanoTimestamp();
         const total_duration_s = @as(f64, @floatFromInt(end - start)) / @as(f64, @floatFromInt(std.time.ns_per_s));
 
         metrics.print();
@@ -277,15 +278,15 @@ pub fn main() !void {
         var metrics = EvaluationMetrics.init();
         const num_requests = 20;
 
-        const start = std.time.nanoTimestamp();
+        const start = agktime.nanoTimestamp();
 
         for (0..num_requests) |_| {
             var msg = try agenkit.Message.withText(allocator, .user, "test");
             defer msg.deinit();
 
-            const req_start = std.time.nanoTimestamp();
+            const req_start = agktime.nanoTimestamp();
             const result = try agent.agent().process(msg);
-            const req_end = std.time.nanoTimestamp();
+            const req_end = agktime.nanoTimestamp();
             const duration = @as(u64, @intCast(req_end - req_start));
 
             if (result.isOk()) {
@@ -297,7 +298,7 @@ pub fn main() !void {
             }
         }
 
-        const end = std.time.nanoTimestamp();
+        const end = agktime.nanoTimestamp();
         const total_duration_s = @as(f64, @floatFromInt(end - start)) / @as(f64, @floatFromInt(std.time.ns_per_s));
 
         metrics.print();

--- a/agenkit-zig/examples/integration/long_running_agent.zig
+++ b/agenkit-zig/examples/integration/long_running_agent.zig
@@ -136,7 +136,7 @@ fn processStreamImpl(ptr: *anyopaque, message: Message, callbacks: StreamCallbac
     callbacks.onError(AgentError.NotImplemented);
 }
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/agenkit-zig/examples/integration/long_running_agent.zig
+++ b/agenkit-zig/examples/integration/long_running_agent.zig
@@ -31,7 +31,7 @@ const AssistantAgent = struct {
             .allocator = allocator,
             .name = try allocator.dupe(u8, name),
             .interaction_count = 0,
-            .memory = std.ArrayList([]const u8){},
+            .memory = std.ArrayList([]const u8).empty,
         };
         return self;
     }
@@ -65,7 +65,7 @@ const AssistantAgent = struct {
     }
 
     pub fn recallMemories(self: *AssistantAgent, query: []const u8, allocator: std.mem.Allocator) ![][]const u8 {
-        var results = std.ArrayList([]const u8){};
+        var results = std.ArrayList([]const u8).empty;
         errdefer results.deinit(allocator);
 
         // Simple substring search

--- a/agenkit-zig/examples/integration/multi_pattern_workflow.zig
+++ b/agenkit-zig/examples/integration/multi_pattern_workflow.zig
@@ -104,7 +104,7 @@ fn processStreamImpl(ptr: *anyopaque, message: Message, callbacks: StreamCallbac
     callbacks.onError(AgentError.NotImplemented);
 }
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/agenkit-zig/examples/middleware/batching_example.zig
+++ b/agenkit-zig/examples/middleware/batching_example.zig
@@ -7,6 +7,7 @@
 /// 4. Observe batch size and wait time
 
 const std = @import("std");
+const agktime = @import("../../src/time_compat.zig");
 const agenkit = @import("agenkit");
 
 // Slow agent that simulates processing time
@@ -58,7 +59,7 @@ const SlowAgent = struct {
         std.debug.print("  [Slow Agent] Processing request #{d}\\n", .{count + 1});
 
         // Simulate slow processing
-        std.time.sleep(self.delay_ms * std.time.ns_per_ms);
+        agktime.sleep(self.delay_ms * std.time.ns_per_ms);
 
         return agenkit.Result{ .ok = message };
     }
@@ -147,7 +148,7 @@ fn basicBatchingExample(allocator: std.mem.Allocator) !void {
     defer batching_agent.stop();
 
     std.debug.print("  Sending 10 requests concurrently...\n", .{});
-    const start_time = std.time.milliTimestamp();
+    const start_time = agktime.milliTimestamp();
 
     // Spawn 10 concurrent threads
     var threads: [10]std.Thread = undefined;
@@ -165,7 +166,7 @@ fn basicBatchingExample(allocator: std.mem.Allocator) !void {
         thread.join();
     }
 
-    const elapsed_ms = std.time.milliTimestamp() - start_time;
+    const elapsed_ms = agktime.milliTimestamp() - start_time;
     std.debug.print("\n  Completed in {d}ms\n", .{elapsed_ms});
 
     const metrics = batching_agent.metrics();
@@ -195,7 +196,7 @@ fn waitTimeBatchingExample(allocator: std.mem.Allocator) !void {
     defer batching_agent.stop();
 
     std.debug.print("  Sending 3 requests with delays...\n", .{});
-    const start_time = std.time.milliTimestamp();
+    const start_time = agktime.milliTimestamp();
 
     // Send 3 requests with 50ms delays between them
     var i: u32 = 0;
@@ -208,14 +209,14 @@ fn waitTimeBatchingExample(allocator: std.mem.Allocator) !void {
         thread.detach();
 
         if (i < 2) {
-            std.time.sleep(50 * std.time.ns_per_ms);
+            agktime.sleep(50 * std.time.ns_per_ms);
         }
     }
 
     // Wait for processing
-    std.time.sleep(300 * std.time.ns_per_ms);
+    agktime.sleep(300 * std.time.ns_per_ms);
 
-    const elapsed_ms = std.time.milliTimestamp() - start_time;
+    const elapsed_ms = agktime.milliTimestamp() - start_time;
     std.debug.print("\n  Completed in {d}ms\n", .{elapsed_ms});
 
     const metrics = batching_agent.metrics();
@@ -245,7 +246,7 @@ fn metricsExample(allocator: std.mem.Allocator) !void {
     defer batching_agent.stop();
 
     std.debug.print("  Sending 25 requests in 5 waves...\n", .{});
-    const start_time = std.time.milliTimestamp();
+    const start_time = agktime.milliTimestamp();
 
     // Send 5 waves of 5 requests
     var wave: u32 = 0;
@@ -263,14 +264,14 @@ fn metricsExample(allocator: std.mem.Allocator) !void {
 
         // Wait between waves
         if (wave < 4) {
-            std.time.sleep(100 * std.time.ns_per_ms);
+            agktime.sleep(100 * std.time.ns_per_ms);
         }
     }
 
     // Wait for all processing
-    std.time.sleep(500 * std.time.ns_per_ms);
+    agktime.sleep(500 * std.time.ns_per_ms);
 
-    const elapsed_ms = std.time.milliTimestamp() - start_time;
+    const elapsed_ms = agktime.milliTimestamp() - start_time;
     const metrics = batching_agent.metrics();
 
     std.debug.print("\n  Final Metrics:\n", .{});

--- a/agenkit-zig/examples/middleware/batching_example.zig
+++ b/agenkit-zig/examples/middleware/batching_example.zig
@@ -103,7 +103,7 @@ fn processStreamImpl(ptr: *anyopaque, message: Message, callbacks: StreamCallbac
     callbacks.onError(AgentError.NotImplemented);
 }
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/agenkit-zig/examples/middleware/caching_example.zig
+++ b/agenkit-zig/examples/middleware/caching_example.zig
@@ -77,7 +77,7 @@ fn processStreamImpl(ptr: *anyopaque, message: Message, callbacks: StreamCallbac
     callbacks.onError(AgentError.NotImplemented);
 }
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/agenkit-zig/examples/middleware/caching_example.zig
+++ b/agenkit-zig/examples/middleware/caching_example.zig
@@ -7,6 +7,7 @@
 /// 4. Test cache invalidation
 
 const std = @import("std");
+const agktime = @import("../../src/time_compat.zig");
 const agenkit = @import("agenkit");
 
 // Counter agent that tracks how many times it's actually called
@@ -191,7 +192,7 @@ fn cacheExpirationExample(allocator: std.mem.Allocator) !void {
 
     // Wait for TTL expiration
     std.debug.print("  Waiting 600ms for cache expiration...\\n", .{});
-    std.time.sleep(600 * std.time.ns_per_ms);
+    agktime.sleep(600 * std.time.ns_per_ms);
 
     // Third request - cache miss (expired)
     std.debug.print("  Request 3 (cache miss - expired)...\\n", .{});

--- a/agenkit-zig/examples/middleware/circuit_breaker_example.zig
+++ b/agenkit-zig/examples/middleware/circuit_breaker_example.zig
@@ -7,6 +7,7 @@
 /// 4. Handle rejected requests when circuit is open
 
 const std = @import("std");
+const agktime = @import("../../src/time_compat.zig");
 const agenkit = @import("agenkit");
 
 // Unreliable agent that fails based on configuration
@@ -195,7 +196,7 @@ fn circuitRecoveryExample(allocator: std.mem.Allocator) !void {
 
     // Step 2: Wait for recovery timeout
     std.debug.print("  Step 2: Waiting for recovery timeout (100ms)...\n", .{});
-    std.time.sleep(150 * std.time.ns_per_ms);
+    agktime.sleep(150 * std.time.ns_per_ms);
 
     // Step 3: Service recovers
     unreliable.setFailure(false);
@@ -247,7 +248,7 @@ fn halfOpenFailureExample(allocator: std.mem.Allocator) !void {
 
     // Step 2: Wait for recovery
     std.debug.print("  Step 2: Waiting for recovery timeout...\n", .{});
-    std.time.sleep(150 * std.time.ns_per_ms);
+    agktime.sleep(150 * std.time.ns_per_ms);
 
     // Step 3: Service still failing - fails in HALF_OPEN
     std.debug.print("  Step 3: Service still failing...\n", .{});
@@ -296,7 +297,7 @@ fn metricsExample(allocator: std.mem.Allocator) !void {
 
         // Add small delay to avoid opening circuit too fast
         if (i % 3 == 2) {
-            std.time.sleep(50 * std.time.ns_per_ms);
+            agktime.sleep(50 * std.time.ns_per_ms);
         }
     }
 
@@ -309,6 +310,6 @@ fn metricsExample(allocator: std.mem.Allocator) !void {
     std.debug.print("    Rejected:            {d}\n", .{metrics.rejected_requests});
     std.debug.print("    Current state:       {s}\n", .{metrics.current_state.toString()});
     if (metrics.last_state_change_ms) |timestamp| {
-        std.debug.print("    Last state change:   {d}ms ago\n", .{std.time.milliTimestamp() - timestamp});
+        std.debug.print("    Last state change:   {d}ms ago\n", .{agktime.milliTimestamp() - timestamp});
     }
 }

--- a/agenkit-zig/examples/middleware/circuit_breaker_example.zig
+++ b/agenkit-zig/examples/middleware/circuit_breaker_example.zig
@@ -88,7 +88,7 @@ fn processStreamImpl(ptr: *anyopaque, message: Message, callbacks: StreamCallbac
     callbacks.onError(AgentError.NotImplemented);
 }
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/agenkit-zig/examples/middleware/rate_limiter_example.zig
+++ b/agenkit-zig/examples/middleware/rate_limiter_example.zig
@@ -7,6 +7,7 @@
 /// 4. Observe token refill behavior
 
 const std = @import("std");
+const agktime = @import("../../src/time_compat.zig");
 const agenkit = @import("agenkit");
 
 // Echo agent that simply returns the message
@@ -126,7 +127,7 @@ fn basicRateLimitingExample(allocator: std.mem.Allocator) !void {
     defer message.deinit();
 
     std.debug.print("  Sending 5 requests (should succeed immediately)...\\n", .{});
-    const start_time = std.time.milliTimestamp();
+    const start_time = agktime.milliTimestamp();
 
     var i: u32 = 0;
     while (i < 5) : (i += 1) {
@@ -136,7 +137,7 @@ fn basicRateLimitingExample(allocator: std.mem.Allocator) !void {
         std.debug.print("    Request {d}: SUCCESS\\n", .{i + 1});
     }
 
-    const elapsed_ms = std.time.milliTimestamp() - start_time;
+    const elapsed_ms = agktime.milliTimestamp() - start_time;
     std.debug.print("  Completed in {d}ms\\n", .{elapsed_ms});
 
     const metrics = limiter.metrics();
@@ -166,7 +167,7 @@ fn burstCapacityExample(allocator: std.mem.Allocator) !void {
     defer message.deinit();
 
     std.debug.print("  Sending 30 requests in burst...\\n", .{});
-    const start_time = std.time.milliTimestamp();
+    const start_time = agktime.milliTimestamp();
 
     var i: u32 = 0;
     while (i < 30) : (i += 1) {
@@ -181,7 +182,7 @@ fn burstCapacityExample(allocator: std.mem.Allocator) !void {
         }
     }
 
-    const elapsed_ms = std.time.milliTimestamp() - start_time;
+    const elapsed_ms = agktime.milliTimestamp() - start_time;
     std.debug.print("  Completed in {d}ms\\n", .{elapsed_ms});
 
     const metrics = limiter.metrics();
@@ -223,13 +224,13 @@ fn tokenRefillExample(allocator: std.mem.Allocator) !void {
 
     // Wait for refill
     std.debug.print("  Waiting 1 second for refill...\\n", .{});
-    std.time.sleep(1000 * std.time.ns_per_ms);
+    agktime.sleep(1000 * std.time.ns_per_ms);
 
     // Send one more request (should wait for tokens)
     std.debug.print("  Sending request (will wait for tokens)...\\n", .{});
-    const start_time = std.time.milliTimestamp();
+    const start_time = agktime.milliTimestamp();
     const result = try limiter.agent().process(message);
-    const elapsed_ms = std.time.milliTimestamp() - start_time;
+    const elapsed_ms = agktime.milliTimestamp() - start_time;
     var response = try result.unwrap();
     response.deinit();
 
@@ -259,7 +260,7 @@ fn metricsExample(allocator: std.mem.Allocator) !void {
 
     // Send 150 requests
     std.debug.print("  Sending 150 requests...\\n", .{});
-    const start_time = std.time.milliTimestamp();
+    const start_time = agktime.milliTimestamp();
 
     var i: u32 = 0;
     while (i < 150) : (i += 1) {
@@ -269,12 +270,12 @@ fn metricsExample(allocator: std.mem.Allocator) !void {
 
         // Print progress every 50 requests
         if ((i + 1) % 50 == 0) {
-            const elapsed_ms = std.time.milliTimestamp() - start_time;
+            const elapsed_ms = agktime.milliTimestamp() - start_time;
             std.debug.print("    Completed {d} requests in {d}ms\\n", .{ i + 1, elapsed_ms });
         }
     }
 
-    const total_time = std.time.milliTimestamp() - start_time;
+    const total_time = agktime.milliTimestamp() - start_time;
     const metrics = limiter.metrics();
 
     std.debug.print("\\n  Final Metrics:\\n", .{});

--- a/agenkit-zig/examples/middleware/rate_limiter_example.zig
+++ b/agenkit-zig/examples/middleware/rate_limiter_example.zig
@@ -77,7 +77,7 @@ fn processStreamImpl(ptr: *anyopaque, message: Message, callbacks: StreamCallbac
     callbacks.onError(AgentError.NotImplemented);
 }
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/agenkit-zig/examples/middleware/retry_example.zig
+++ b/agenkit-zig/examples/middleware/retry_example.zig
@@ -88,7 +88,7 @@ fn processStreamImpl(ptr: *anyopaque, message: Message, callbacks: StreamCallbac
     callbacks.onError(AgentError.NotImplemented);
 }
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/agenkit-zig/examples/middleware/timeout_example.zig
+++ b/agenkit-zig/examples/middleware/timeout_example.zig
@@ -87,7 +87,7 @@ fn processStreamImpl(ptr: *anyopaque, message: Message, callbacks: StreamCallbac
     callbacks.onError(AgentError.NotImplemented);
 }
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/agenkit-zig/examples/middleware/timeout_example.zig
+++ b/agenkit-zig/examples/middleware/timeout_example.zig
@@ -7,6 +7,7 @@
 /// 4. Handle timeout errors
 
 const std = @import("std");
+const agktime = @import("../../src/time_compat.zig");
 const agenkit = @import("agenkit");
 
 // Slow agent that takes variable time to respond
@@ -61,7 +62,7 @@ const SlowAgent = struct {
         std.debug.print("  [Slow Agent] Processing (will take {d}ms)...\n", .{delay_ms});
 
         // Simulate slow processing
-        std.time.sleep(delay_ms * std.time.ns_per_ms);
+        agktime.sleep(delay_ms * std.time.ns_per_ms);
 
         std.debug.print("  [Slow Agent] Done!\n", .{});
 

--- a/agenkit-zig/examples/observability/full_stack_example.zig
+++ b/agenkit-zig/examples/observability/full_stack_example.zig
@@ -53,7 +53,7 @@ fn completeSetup(allocator: std.mem.Allocator) !void {
     // 2. Create audit logger
     var audit_logger = try audit.AuditLogger.init(allocator, "example_audit.log");
     defer audit_logger.deinit();
-    defer std.fs.cwd().deleteFile("example_audit.log") catch {};
+    defer std.Io.Dir.cwd().deleteFile(agenkit.io_compat.io(), "example_audit.log") catch {};
     std.debug.print("✅ Audit logger initialized\n", .{});
 
     // 3. Create agent with tracing and metrics
@@ -195,7 +195,7 @@ fn productionAgent(allocator: std.mem.Allocator) !void {
     // Create audit logger with descriptive name
     var audit_logger = try audit.AuditLogger.init(allocator, "production_audit.log");
     defer audit_logger.deinit();
-    defer std.fs.cwd().deleteFile("production_audit.log") catch {};
+    defer std.Io.Dir.cwd().deleteFile(agenkit.io_compat.io(), "production_audit.log") catch {};
 
     // Create fully instrumented agent
     var echo = try EchoAgent.init(allocator);

--- a/agenkit-zig/examples/observability/full_stack_example.zig
+++ b/agenkit-zig/examples/observability/full_stack_example.zig
@@ -23,7 +23,7 @@ const logging = observability.logging;
 const audit = observability.audit;
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/agenkit-zig/examples/observability/metrics_example.zig
+++ b/agenkit-zig/examples/observability/metrics_example.zig
@@ -22,7 +22,7 @@ const Counter = agenkit.observability.Counter;
 const Histogram = agenkit.observability.Histogram;
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/agenkit-zig/examples/observability/tracing_example.zig
+++ b/agenkit-zig/examples/observability/tracing_example.zig
@@ -21,7 +21,7 @@ const TracingMiddleware = agenkit.observability.TracingMiddleware;
 const SpanContext = agenkit.observability.SpanContext;
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/agenkit-zig/examples/patterns/agents_as_tools.zig
+++ b/agenkit-zig/examples/patterns/agents_as_tools.zig
@@ -107,7 +107,7 @@ fn processStreamImpl(ptr: *anyopaque, message: Message, callbacks: StreamCallbac
     callbacks.onError(AgentError.NotImplemented);
 }
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/agenkit-zig/examples/patterns/autonomous.zig
+++ b/agenkit-zig/examples/patterns/autonomous.zig
@@ -30,7 +30,7 @@ fn researchWorker(allocator: std.mem.Allocator, goal: *agenkit.patterns.Goal) ag
 }
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/agenkit-zig/examples/patterns/collaborative_example.zig
+++ b/agenkit-zig/examples/patterns/collaborative_example.zig
@@ -109,7 +109,7 @@ fn processStreamImpl(ptr: *anyopaque, message: Message, callbacks: StreamCallbac
     callbacks.onError(AgentError.NotImplemented);
 }
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/agenkit-zig/examples/patterns/conversational.zig
+++ b/agenkit-zig/examples/patterns/conversational.zig
@@ -15,7 +15,7 @@ const std = @import("std");
 const agenkit = @import("agenkit");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/agenkit-zig/examples/patterns/fallback_example.zig
+++ b/agenkit-zig/examples/patterns/fallback_example.zig
@@ -111,7 +111,7 @@ fn processStreamImpl(ptr: *anyopaque, message: Message, callbacks: StreamCallbac
     callbacks.onError(AgentError.NotImplemented);
 }
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/agenkit-zig/examples/patterns/human_in_loop_example.zig
+++ b/agenkit-zig/examples/patterns/human_in_loop_example.zig
@@ -142,7 +142,7 @@ fn processStreamImpl(ptr: *anyopaque, message: Message, callbacks: StreamCallbac
     callbacks.onError(AgentError.NotImplemented);
 }
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/agenkit-zig/examples/patterns/memory_hierarchy.zig
+++ b/agenkit-zig/examples/patterns/memory_hierarchy.zig
@@ -15,7 +15,7 @@ const std = @import("std");
 const agenkit = @import("agenkit");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/agenkit-zig/examples/patterns/multiagent.zig
+++ b/agenkit-zig/examples/patterns/multiagent.zig
@@ -14,7 +14,7 @@ const std = @import("std");
 const agenkit = @import("agenkit");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/agenkit-zig/examples/patterns/parallel.zig
+++ b/agenkit-zig/examples/patterns/parallel.zig
@@ -199,7 +199,7 @@ fn processStreamImpl(ptr: *anyopaque, message: Message, callbacks: StreamCallbac
     callbacks.onError(AgentError.NotImplemented);
 }
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/agenkit-zig/examples/patterns/planning.zig
+++ b/agenkit-zig/examples/patterns/planning.zig
@@ -24,7 +24,7 @@ fn customStepExecutor(allocator: std.mem.Allocator, step: *const agenkit.pattern
 }
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/agenkit-zig/examples/patterns/react.zig
+++ b/agenkit-zig/examples/patterns/react.zig
@@ -48,7 +48,7 @@ fn databaseTool(allocator: std.mem.Allocator, input: []const u8) agenkit.AgentEr
 }
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/agenkit-zig/examples/patterns/reasoning_with_tools_example.zig
+++ b/agenkit-zig/examples/patterns/reasoning_with_tools_example.zig
@@ -114,7 +114,7 @@ fn processStreamImpl(ptr: *anyopaque, message: Message, callbacks: StreamCallbac
     callbacks.onError(AgentError.NotImplemented);
 }
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/agenkit-zig/examples/patterns/reflection.zig
+++ b/agenkit-zig/examples/patterns/reflection.zig
@@ -219,7 +219,7 @@ fn processStreamImpl(ptr: *anyopaque, message: agenkit.Message, callbacks: agenk
     callbacks.onError(agenkit.AgentError.NotImplemented);
 }
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/agenkit-zig/examples/patterns/router_example.zig
+++ b/agenkit-zig/examples/patterns/router_example.zig
@@ -101,7 +101,7 @@ fn processStreamImpl(ptr: *anyopaque, message: Message, callbacks: StreamCallbac
     callbacks.onError(AgentError.NotImplemented);
 }
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/agenkit-zig/examples/patterns/sequential.zig
+++ b/agenkit-zig/examples/patterns/sequential.zig
@@ -115,7 +115,7 @@ fn processStreamImpl(ptr: *anyopaque, message: Message, callbacks: StreamCallbac
     callbacks.onError(AgentError.NotImplemented);
 }
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/agenkit-zig/examples/patterns/supervisor_example.zig
+++ b/agenkit-zig/examples/patterns/supervisor_example.zig
@@ -169,7 +169,7 @@ fn processStreamImpl(ptr: *anyopaque, message: Message, callbacks: StreamCallbac
     callbacks.onError(AgentError.NotImplemented);
 }
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/agenkit-zig/examples/patterns/task.zig
+++ b/agenkit-zig/examples/patterns/task.zig
@@ -14,7 +14,7 @@ const std = @import("std");
 const agenkit = @import("agenkit");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/agenkit-zig/examples/patterns_example.zig
+++ b/agenkit-zig/examples/patterns_example.zig
@@ -26,7 +26,7 @@ const Message = agenkit.Message;
 const EchoAgent = agenkit.EchoAgent;
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/agenkit-zig/examples/safety/basic_safety.zig
+++ b/agenkit-zig/examples/safety/basic_safety.zig
@@ -155,7 +155,7 @@ pub fn main() !void {
     std.debug.print("----------------\n", .{});
 
     const log_path = "agenkit_safety_demo.log";
-    defer std.fs.cwd().deleteFile(log_path) catch {};
+    defer std.Io.Dir.cwd().deleteFile(agenkit.io_compat.io(), log_path) catch {};
 
     var logger = try agenkit.safety.audit.SecurityAuditLogger.init(allocator, .{
         .log_file_path = log_path,

--- a/agenkit-zig/examples/safety/basic_safety.zig
+++ b/agenkit-zig/examples/safety/basic_safety.zig
@@ -12,7 +12,7 @@ const std = @import("std");
 const agenkit = @import("agenkit");
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/agenkit-zig/src/adapter/anthropic.zig
+++ b/agenkit-zig/src/adapter/anthropic.zig
@@ -17,8 +17,9 @@
 /// const response = try llm.complete(allocator, &messages, &options);
 /// defer response.deinit();
 /// ```
-
 const std = @import("std");
+const ioc = @import("../io_compat.zig");
+const agkenv = @import("../env_compat.zig");
 const llm = @import("llm.zig");
 const Message = @import("../message.zig").Message;
 const Role = @import("../message.zig").Role;
@@ -35,7 +36,7 @@ const AnthropicStream = struct {
 
     /// Make streaming HTTP request to Anthropic API
     fn makeStreamRequest(self: *AnthropicStream, body: []const u8) !void {
-        var client = std.http.Client{ .allocator = self.allocator };
+        var client = std.http.Client{ .allocator = self.allocator, .io = ioc.io() };
         defer client.deinit();
 
         const uri_str = try std.fmt.allocPrint(
@@ -51,7 +52,7 @@ const AnthropicStream = struct {
             .{ .name = "anthropic-version", .value = self.self.api_version },
         };
 
-        var response_buffer: std.io.Writer.Allocating = .init(self.allocator);
+        var response_buffer: std.Io.Writer.Allocating = .init(self.allocator);
         defer response_buffer.deinit();
 
         const result = try client.fetch(.{
@@ -183,7 +184,7 @@ pub const AnthropicLLM = struct {
         const key = if (api_key.len > 0)
             try allocator.dupe(u8, api_key)
         else blk: {
-            const env_key = std.process.getEnvVarOwned(allocator, "ANTHROPIC_API_KEY") catch {
+            const env_key = agkenv.getEnvVarOwned(allocator, "ANTHROPIC_API_KEY") catch {
                 return error.MissingAPIKey;
             };
             break :blk env_key;
@@ -265,8 +266,8 @@ pub const AnthropicLLM = struct {
         stream_impl.* = AnthropicStream{
             .allocator = allocator,
             .self = self,
-            .buffer = std.ArrayList(u8){},
-            .chunks = std.ArrayList([]const u8){},
+            .buffer = std.ArrayList(u8).empty,
+            .chunks = std.ArrayList([]const u8).empty,
             .current_index = 0,
             .completed = false,
         };
@@ -302,7 +303,7 @@ pub const AnthropicLLM = struct {
         messages: []const *Message,
         options: *const llm.CallOptions,
     ) ![]const u8 {
-        var json = std.ArrayList(u8){};
+        var json = std.ArrayList(u8).empty;
         defer json.deinit(allocator);
 
         try json.appendSlice(allocator, "{\"model\":\"");
@@ -417,7 +418,7 @@ pub const AnthropicLLM = struct {
         messages: []const *Message,
         options: *const llm.CallOptions,
     ) ![]const u8 {
-        var json = std.ArrayList(u8){};
+        var json = std.ArrayList(u8).empty;
         defer json.deinit(allocator);
 
         try json.appendSlice(allocator, "{\"model\":\"");
@@ -536,7 +537,7 @@ pub const AnthropicLLM = struct {
 
     /// Make HTTP request to Anthropic API
     fn makeRequest(self: *AnthropicLLM, allocator: Allocator, body: []const u8) ![]const u8 {
-        var client = std.http.Client{ .allocator = allocator };
+        var client = std.http.Client{ .allocator = allocator, .io = ioc.io() };
         defer client.deinit();
 
         const uri_str = try std.fmt.allocPrint(
@@ -553,7 +554,7 @@ pub const AnthropicLLM = struct {
             .{ .name = "anthropic-version", .value = self.api_version },
         };
 
-        var response_body: std.io.Writer.Allocating = .init(allocator);
+        var response_body: std.Io.Writer.Allocating = .init(allocator);
         defer response_body.deinit();
 
         const result = try client.fetch(.{

--- a/agenkit-zig/src/adapter/bedrock.zig
+++ b/agenkit-zig/src/adapter/bedrock.zig
@@ -26,8 +26,10 @@
 /// const response = try llm.complete(allocator, &messages, &options);
 /// defer response.deinit();
 /// ```
-
 const std = @import("std");
+const ioc = @import("../io_compat.zig");
+const agkenv = @import("../env_compat.zig");
+const agktime = @import("../time_compat.zig");
 const llm = @import("llm.zig");
 const Message = @import("../message.zig").Message;
 const Role = @import("../message.zig").Role;
@@ -67,7 +69,7 @@ pub const BedrockLLM = struct {
         const key_id = if (access_key_id.len > 0)
             try allocator.dupe(u8, access_key_id)
         else blk: {
-            const env_key = std.process.getEnvVarOwned(allocator, "AWS_ACCESS_KEY_ID") catch {
+            const env_key = agkenv.getEnvVarOwned(allocator, "AWS_ACCESS_KEY_ID") catch {
                 return error.MissingAccessKeyID;
             };
             break :blk env_key;
@@ -77,14 +79,14 @@ pub const BedrockLLM = struct {
         const secret = if (secret_access_key.len > 0)
             try allocator.dupe(u8, secret_access_key)
         else blk: {
-            const env_secret = std.process.getEnvVarOwned(allocator, "AWS_SECRET_ACCESS_KEY") catch {
+            const env_secret = agkenv.getEnvVarOwned(allocator, "AWS_SECRET_ACCESS_KEY") catch {
                 return error.MissingSecretAccessKey;
             };
             break :blk env_secret;
         };
 
         // Session Token (optional)
-        const token = std.process.getEnvVarOwned(allocator, "AWS_SESSION_TOKEN") catch null;
+        const token = agkenv.getEnvVarOwned(allocator, "AWS_SESSION_TOKEN") catch null;
 
         // Model ID
         const model_copy = if (model_id.len > 0)
@@ -96,7 +98,7 @@ pub const BedrockLLM = struct {
         const region_copy = if (region.len > 0)
             try allocator.dupe(u8, region)
         else blk: {
-            const env_region = std.process.getEnvVarOwned(allocator, "AWS_REGION") catch {
+            const env_region = agkenv.getEnvVarOwned(allocator, "AWS_REGION") catch {
                 // Default to us-east-1
                 break :blk try allocator.dupe(u8, "us-east-1");
             };
@@ -193,7 +195,7 @@ pub const BedrockLLM = struct {
     ) ![]const u8 {
         _ = self;
 
-        var json = std.ArrayList(u8){};
+        var json = std.ArrayList(u8).empty;
         defer json.deinit(allocator);
 
         // Anthropic format on Bedrock
@@ -333,7 +335,7 @@ pub const BedrockLLM = struct {
         defer allocator.free(uri_path);
 
         // Get current timestamp for signing
-        const timestamp_secs = std.time.timestamp();
+        const timestamp_secs = agktime.timestamp();
         const timestamp = try formatTimestamp(allocator, timestamp_secs);
         defer allocator.free(timestamp);
 
@@ -433,7 +435,7 @@ pub const BedrockLLM = struct {
         defer allocator.free(auth_header);
 
         // Make the HTTP request
-        var client = std.http.Client{ .allocator = allocator };
+        var client = std.http.Client{ .allocator = allocator, .io = ioc.io() };
         defer client.deinit();
 
         const full_url = try std.fmt.allocPrint(
@@ -444,7 +446,7 @@ pub const BedrockLLM = struct {
         defer allocator.free(full_url);
 
         // Build headers slice (unmanaged ArrayList, Zig 0.15 pattern)
-        var headers_list = std.ArrayList(std.http.Header){};
+        var headers_list = std.ArrayList(std.http.Header).empty;
         defer headers_list.deinit(allocator);
 
         try headers_list.append(allocator, .{ .name = "Content-Type", .value = "application/json" });
@@ -454,7 +456,7 @@ pub const BedrockLLM = struct {
             try headers_list.append(allocator, .{ .name = "x-amz-security-token", .value = token });
         }
 
-        var response_body: std.io.Writer.Allocating = .init(allocator);
+        var response_body: std.Io.Writer.Allocating = .init(allocator);
         defer response_body.deinit();
 
         const result = try client.fetch(.{

--- a/agenkit-zig/src/adapter/gemini.zig
+++ b/agenkit-zig/src/adapter/gemini.zig
@@ -16,8 +16,9 @@
 /// const response = try llm.complete(allocator, &messages, &options);
 /// defer response.deinit();
 /// ```
-
 const std = @import("std");
+const ioc = @import("../io_compat.zig");
+const agkenv = @import("../env_compat.zig");
 const llm = @import("llm.zig");
 const Message = @import("../message.zig").Message;
 const Role = @import("../message.zig").Role;
@@ -31,7 +32,7 @@ const GeminiStream = struct {
     current_index: usize,
 
     fn makeStreamRequest(self: *GeminiStream, body: []const u8) !void {
-        var client = std.http.Client{ .allocator = self.allocator };
+        var client = std.http.Client{ .allocator = self.allocator, .io = ioc.io() };
         defer client.deinit();
 
         // Use streamGenerateContent endpoint
@@ -46,7 +47,7 @@ const GeminiStream = struct {
             .{ .name = "Content-Type", .value = "application/json" },
         };
 
-        var response_buffer: std.io.Writer.Allocating = .init(self.allocator);
+        var response_buffer: std.Io.Writer.Allocating = .init(self.allocator);
         defer response_buffer.deinit();
 
         const result = try client.fetch(.{
@@ -160,7 +161,7 @@ pub const GeminiLLM = struct {
         const key = if (api_key.len > 0)
             try allocator.dupe(u8, api_key)
         else blk: {
-            const env_key = std.process.getEnvVarOwned(allocator, "GEMINI_API_KEY") catch {
+            const env_key = agkenv.getEnvVarOwned(allocator, "GEMINI_API_KEY") catch {
                 return error.MissingAPIKey;
             };
             break :blk env_key;
@@ -240,7 +241,7 @@ pub const GeminiLLM = struct {
         stream_impl.* = GeminiStream{
             .allocator = allocator,
             .self = self,
-            .chunks = std.ArrayList([]const u8){},
+            .chunks = std.ArrayList([]const u8).empty,
             .current_index = 0,
         };
 
@@ -276,7 +277,7 @@ pub const GeminiLLM = struct {
         options: *const llm.CallOptions,
     ) ![]const u8 {
         _ = self;
-        var json = std.ArrayList(u8){};
+        var json = std.ArrayList(u8).empty;
         defer json.deinit(allocator);
 
         try json.appendSlice(allocator, "{\"contents\":[");
@@ -362,7 +363,7 @@ pub const GeminiLLM = struct {
 
     /// Make HTTP request to Gemini API
     fn makeRequest(self: *GeminiLLM, allocator: Allocator, body: []const u8) ![]const u8 {
-        var client = std.http.Client{ .allocator = allocator };
+        var client = std.http.Client{ .allocator = allocator, .io = ioc.io() };
         defer client.deinit();
 
         // Gemini uses query parameter for API key
@@ -377,7 +378,7 @@ pub const GeminiLLM = struct {
             .{ .name = "Content-Type", .value = "application/json" },
         };
 
-        var response_body: std.io.Writer.Allocating = .init(allocator);
+        var response_body: std.Io.Writer.Allocating = .init(allocator);
         defer response_body.deinit();
 
         const result = try client.fetch(.{

--- a/agenkit-zig/src/adapter/litellm.zig
+++ b/agenkit-zig/src/adapter/litellm.zig
@@ -26,8 +26,9 @@
 /// const response = try llm.complete(allocator, &messages, &options);
 /// defer response.deinit();
 /// ```
-
 const std = @import("std");
+const ioc = @import("../io_compat.zig");
+const agkenv = @import("../env_compat.zig");
 const llm = @import("llm.zig");
 const Message = @import("../message.zig").Message;
 const Role = @import("../message.zig").Role;
@@ -38,11 +39,11 @@ const LiteLLMStream = struct {
     chunks: std.ArrayList([]const u8),
     current_index: usize,
     fn makeStreamRequest(self: *LiteLLMStream, body: []const u8) !void {
-        var client = std.http.Client{ .allocator = self.allocator };
+        var client = std.http.Client{ .allocator = self.allocator, .io = ioc.io() };
         defer client.deinit();
         const uri_str = try std.fmt.allocPrint(self.allocator, "{s}/chat/completions", .{self.self.base_url});
         defer self.allocator.free(uri_str);
-        var headers = std.ArrayList(std.http.Header){};
+        var headers = std.ArrayList(std.http.Header).empty;
         defer headers.deinit(self.allocator);
         try headers.append(self.allocator, .{ .name = "Content-Type", .value = "application/json" });
 
@@ -52,7 +53,7 @@ const LiteLLMStream = struct {
             try headers.append(self.allocator, .{ .name = "Authorization", .value = auth_value });
         }
 
-        var response_buffer: std.io.Writer.Allocating = .init(self.allocator);
+        var response_buffer: std.Io.Writer.Allocating = .init(self.allocator);
         defer response_buffer.deinit();
 
         const result = try client.fetch(.{
@@ -90,10 +91,26 @@ const LiteLLMStream = struct {
             }
         }
     }
-    fn deinit(self: *LiteLLMStream) void { for (self.chunks.items) |chunk| self.allocator.free(chunk); self.chunks.deinit(self.allocator); self.allocator.destroy(self); }
+    fn deinit(self: *LiteLLMStream) void {
+        for (self.chunks.items) |chunk| self.allocator.free(chunk);
+        self.chunks.deinit(self.allocator);
+        self.allocator.destroy(self);
+    }
 };
-fn litellmStreamNext(ptr: *anyopaque, allocator: Allocator) !?*Message { const self: *LiteLLMStream = @ptrCast(@alignCast(ptr)); if (self.current_index >= self.chunks.items.len) return null; const text = self.chunks.items[self.current_index]; self.current_index += 1; const msg = try allocator.create(Message); msg.* = try Message.withText(allocator, .assistant, text); try msg.setMetadata("streaming", std.json.Value{ .bool = true }); return msg; }
-fn litellmStreamDeinit(ptr: *anyopaque) void { const self: *LiteLLMStream = @ptrCast(@alignCast(ptr)); self.deinit(); }
+fn litellmStreamNext(ptr: *anyopaque, allocator: Allocator) !?*Message {
+    const self: *LiteLLMStream = @ptrCast(@alignCast(ptr));
+    if (self.current_index >= self.chunks.items.len) return null;
+    const text = self.chunks.items[self.current_index];
+    self.current_index += 1;
+    const msg = try allocator.create(Message);
+    msg.* = try Message.withText(allocator, .assistant, text);
+    try msg.setMetadata("streaming", std.json.Value{ .bool = true });
+    return msg;
+}
+fn litellmStreamDeinit(ptr: *anyopaque) void {
+    const self: *LiteLLMStream = @ptrCast(@alignCast(ptr));
+    self.deinit();
+}
 
 const Allocator = std.mem.Allocator;
 
@@ -127,7 +144,7 @@ pub const LiteLLMLLM = struct {
             try allocator.dupe(u8, api_key)
         else blk: {
             // Try LITELLM_API_KEY, fallback to empty (for local deployments)
-            const env_key = std.process.getEnvVarOwned(allocator, "LITELLM_API_KEY") catch {
+            const env_key = agkenv.getEnvVarOwned(allocator, "LITELLM_API_KEY") catch {
                 break :blk try allocator.dupe(u8, "");
             };
             break :blk env_key;
@@ -208,7 +225,7 @@ pub const LiteLLMLLM = struct {
         stream_impl.* = LiteLLMStream{
             .allocator = allocator,
             .self = self,
-            .chunks = std.ArrayList([]const u8){},
+            .chunks = std.ArrayList([]const u8).empty,
             .current_index = 0,
         };
 
@@ -253,7 +270,7 @@ pub const LiteLLMLLM = struct {
         options: *const llm.CallOptions,
         is_stream: bool,
     ) ![]const u8 {
-        var json = std.ArrayList(u8){};
+        var json = std.ArrayList(u8).empty;
         defer json.deinit(allocator);
 
         try json.appendSlice(allocator, "{\"model\":\"");
@@ -325,7 +342,7 @@ pub const LiteLLMLLM = struct {
 
     /// Make HTTP request to LiteLLM API
     fn makeRequest(self: *LiteLLMLLM, allocator: Allocator, body: []const u8) ![]const u8 {
-        var client = std.http.Client{ .allocator = allocator };
+        var client = std.http.Client{ .allocator = allocator, .io = ioc.io() };
         defer client.deinit();
 
         const uri_str = try std.fmt.allocPrint(
@@ -353,7 +370,7 @@ pub const LiteLLMLLM = struct {
 
         const headers = headers_buf[0..headers_count];
 
-        var response_body: std.io.Writer.Allocating = .init(allocator);
+        var response_body: std.Io.Writer.Allocating = .init(allocator);
         defer response_body.deinit();
 
         const result = try client.fetch(.{

--- a/agenkit-zig/src/adapter/llm.zig
+++ b/agenkit-zig/src/adapter/llm.zig
@@ -26,7 +26,6 @@
 /// const response = try llm.complete(allocator, &messages, &options);
 /// defer response.deinit();
 /// ```
-
 const std = @import("std");
 const Message = @import("../message.zig").Message;
 const Allocator = std.mem.Allocator;

--- a/agenkit-zig/src/adapter/ollama.zig
+++ b/agenkit-zig/src/adapter/ollama.zig
@@ -16,8 +16,8 @@
 /// const response = try llm.complete(allocator, &messages, &options);
 /// defer response.deinit();
 /// ```
-
 const std = @import("std");
+const ioc = @import("../io_compat.zig");
 const llm = @import("llm.zig");
 const Message = @import("../message.zig").Message;
 const Role = @import("../message.zig").Role;
@@ -31,7 +31,7 @@ const OllamaStream = struct {
     current_index: usize,
 
     fn makeStreamRequest(self: *OllamaStream, body: []const u8) !void {
-        var client = std.http.Client{ .allocator = self.allocator };
+        var client = std.http.Client{ .allocator = self.allocator, .io = ioc.io() };
         defer client.deinit();
 
         const uri_str = try std.fmt.allocPrint(self.allocator, "{s}/api/chat", .{self.self.base_url});
@@ -39,7 +39,7 @@ const OllamaStream = struct {
 
         const headers = [_]std.http.Header{.{ .name = "Content-Type", .value = "application/json" }};
 
-        var response_buffer: std.io.Writer.Allocating = .init(self.allocator);
+        var response_buffer: std.Io.Writer.Allocating = .init(self.allocator);
         defer response_buffer.deinit();
 
         const result = try client.fetch(.{
@@ -195,7 +195,7 @@ pub const OllamaLLM = struct {
         stream_impl.* = OllamaStream{
             .allocator = allocator,
             .self = self,
-            .chunks = std.ArrayList([]const u8){},
+            .chunks = std.ArrayList([]const u8).empty,
             .current_index = 0,
         };
 
@@ -230,7 +230,7 @@ pub const OllamaLLM = struct {
         options: *const llm.CallOptions,
         is_stream: bool,
     ) ![]const u8 {
-        var json = std.ArrayList(u8){};
+        var json = std.ArrayList(u8).empty;
         defer json.deinit(allocator);
 
         try json.appendSlice(allocator, "{\"model\":\"");
@@ -300,7 +300,7 @@ pub const OllamaLLM = struct {
 
     /// Make HTTP request to Ollama API
     fn makeRequest(self: *OllamaLLM, allocator: Allocator, body: []const u8) ![]const u8 {
-        var client = std.http.Client{ .allocator = allocator };
+        var client = std.http.Client{ .allocator = allocator, .io = ioc.io() };
         defer client.deinit();
 
         const uri_str = try std.fmt.allocPrint(
@@ -314,7 +314,7 @@ pub const OllamaLLM = struct {
             .{ .name = "Content-Type", .value = "application/json" },
         };
 
-        var response_body: std.io.Writer.Allocating = .init(allocator);
+        var response_body: std.Io.Writer.Allocating = .init(allocator);
         defer response_body.deinit();
 
         const result = try client.fetch(.{

--- a/agenkit-zig/src/adapter/openai.zig
+++ b/agenkit-zig/src/adapter/openai.zig
@@ -17,8 +17,9 @@
 /// const response = try llm.complete(allocator, &messages, &options);
 /// defer response.deinit();
 /// ```
-
 const std = @import("std");
+const ioc = @import("../io_compat.zig");
+const agkenv = @import("../env_compat.zig");
 const llm = @import("llm.zig");
 const Message = @import("../message.zig").Message;
 const Role = @import("../message.zig").Role;
@@ -32,7 +33,7 @@ const OpenAIStream = struct {
     current_index: usize,
 
     fn makeStreamRequest(self: *OpenAIStream, body: []const u8) !void {
-        var client = std.http.Client{ .allocator = self.allocator };
+        var client = std.http.Client{ .allocator = self.allocator, .io = ioc.io() };
         defer client.deinit();
 
         const uri_str = try std.fmt.allocPrint(
@@ -54,7 +55,7 @@ const OpenAIStream = struct {
             .{ .name = "Authorization", .value = auth_value },
         };
 
-        var response_buffer: std.io.Writer.Allocating = .init(self.allocator);
+        var response_buffer: std.Io.Writer.Allocating = .init(self.allocator);
         defer response_buffer.deinit();
 
         const result = try client.fetch(.{
@@ -172,7 +173,7 @@ pub const OpenAILLM = struct {
             try allocator.dupe(u8, api_key)
         else blk: {
             // Try environment variable
-            const env_key = std.process.getEnvVarOwned(allocator, "OPENAI_API_KEY") catch {
+            const env_key = agkenv.getEnvVarOwned(allocator, "OPENAI_API_KEY") catch {
                 return error.MissingAPIKey;
             };
             break :blk env_key;
@@ -255,7 +256,7 @@ pub const OpenAILLM = struct {
         stream_impl.* = OpenAIStream{
             .allocator = allocator,
             .self = self,
-            .chunks = std.ArrayList([]const u8){},
+            .chunks = std.ArrayList([]const u8).empty,
             .current_index = 0,
         };
 
@@ -293,7 +294,7 @@ pub const OpenAILLM = struct {
     ) ![]const u8 {
         // Build JSON manually for now (simpler than using std.json API)
         // In Zig 0.15.2, ArrayList is unmanaged and requires allocator parameter
-        var json = std.ArrayList(u8){};
+        var json = std.ArrayList(u8).empty;
         defer json.deinit(allocator);
 
         try json.appendSlice(allocator, "{\"model\":\"");
@@ -372,7 +373,7 @@ pub const OpenAILLM = struct {
 
     /// Make HTTP request to OpenAI API
     fn makeRequest(self: *OpenAILLM, allocator: Allocator, body: []const u8) ![]const u8 {
-        var client = std.http.Client{ .allocator = allocator };
+        var client = std.http.Client{ .allocator = allocator, .io = ioc.io() };
         defer client.deinit();
 
         // Build URI
@@ -397,8 +398,8 @@ pub const OpenAILLM = struct {
             .{ .name = "Content-Type", .value = "application/json" },
         };
 
-        // Use std.io.Writer.Allocating for response body (Zig 0.15 pattern)
-        var response_body: std.io.Writer.Allocating = .init(allocator);
+        // Use std.Io.Writer.Allocating for response body (Zig 0.15 pattern)
+        var response_body: std.Io.Writer.Allocating = .init(allocator);
         defer response_body.deinit();
 
         // Make request using fetch API

--- a/agenkit-zig/src/adapter/openai_compatible.zig
+++ b/agenkit-zig/src/adapter/openai_compatible.zig
@@ -34,8 +34,8 @@
 /// const response = try llm.complete(allocator, &messages, &options);
 /// defer response.deinit();
 /// ```
-
 const std = @import("std");
+const ioc = @import("../io_compat.zig");
 const llm = @import("llm.zig");
 const Message = @import("../message.zig").Message;
 const Role = @import("../message.zig").Role;
@@ -218,7 +218,7 @@ pub const OpenAICompatibleLLM = struct {
         is_stream: bool,
     ) ![]const u8 {
         // Build JSON manually for now (simpler than using std.json API)
-        var json = std.ArrayList(u8){};
+        var json = std.ArrayList(u8).empty;
         defer json.deinit(allocator);
 
         try json.appendSlice(allocator, "{\"model\":\"");
@@ -292,7 +292,7 @@ pub const OpenAICompatibleLLM = struct {
 
     /// Make HTTP request to OpenAI-compatible API
     fn makeRequest(self: *OpenAICompatibleLLM, allocator: Allocator, body: []const u8) ![]const u8 {
-        var client = std.http.Client{ .allocator = allocator };
+        var client = std.http.Client{ .allocator = allocator, .io = ioc.io() };
         defer client.deinit();
 
         // Build URI
@@ -318,8 +318,8 @@ pub const OpenAICompatibleLLM = struct {
             .{ .name = "Content-Type", .value = "application/json" },
         };
 
-        // Use std.io.Writer.Allocating for response body (Zig 0.15 pattern)
-        var response_body: std.io.Writer.Allocating = .init(allocator);
+        // Use std.Io.Writer.Allocating for response body (Zig 0.15 pattern)
+        var response_body: std.Io.Writer.Allocating = .init(allocator);
         defer response_body.deinit();
 
         // Make request using fetch API

--- a/agenkit-zig/src/agent.zig
+++ b/agenkit-zig/src/agent.zig
@@ -244,10 +244,10 @@ pub const EchoAgent = struct {
     fn introspectImpl(ptr: *anyopaque, allocator: Allocator) Allocator.Error!IntrospectionResult {
         const self: *EchoAgent = @ptrCast(@alignCast(ptr));
         const caps = try capabilitiesImpl(ptr, allocator);
-        defer {
-            for (caps) |cap| allocator.free(cap);
-            allocator.free(caps);
-        }
+        // Capability strings are borrowed (see SequentialAgent/ParallelAgent:
+        // they pass inner cap strings through by reference). Only the array is
+        // owned here; `createDefaultIntrospectionResult` duplicates the strings.
+        defer allocator.free(caps);
         return createDefaultIntrospectionResult(allocator, self.agent_name, caps);
     }
 

--- a/agenkit-zig/src/composition.zig
+++ b/agenkit-zig/src/composition.zig
@@ -8,7 +8,6 @@
 ///
 /// These are minimal composition primitives. For richer agent patterns
 /// with advanced features, see the patterns module.
-
 const std = @import("std");
 const Agent = @import("agent.zig").Agent;
 const AgentError = @import("agent.zig").AgentError;
@@ -72,7 +71,7 @@ pub const SequentialAgent = struct {
             }
         }
 
-        var caps = std.ArrayList([]const u8).init(allocator);
+        var caps = std.ArrayList([]const u8).empty;
         var it = cap_set.keyIterator();
         while (it.next()) |key| {
             try caps.append(try allocator.dupe(u8, key.*));
@@ -173,7 +172,7 @@ pub const FallbackAgent = struct {
             }
         }
 
-        var caps = std.ArrayList([]const u8).init(allocator);
+        var caps = std.ArrayList([]const u8).empty;
         var it = cap_set.keyIterator();
         while (it.next()) |key| {
             try caps.append(try allocator.dupe(u8, key.*));

--- a/agenkit-zig/src/env_compat.zig
+++ b/agenkit-zig/src/env_compat.zig
@@ -1,0 +1,44 @@
+//! Environment-variable access compatible with the pre-0.16 API.
+//!
+//! Zig 0.16 reworked `std.process` around the `Io`/`Environ` model and removed
+//! the free function `std.process.getEnvVarOwned`. This shim restores it with
+//! the same signature and ownership contract (caller owns the returned slice),
+//! so adapter credential lookups keep working without threading an `Io`
+//! through their constructors.
+
+const std = @import("std");
+const builtin = @import("builtin");
+
+pub const GetEnvVarError = error{
+    EnvironmentVariableNotFound,
+    OutOfMemory,
+    InvalidWtf8,
+};
+
+/// Returns an allocator-owned copy of the value of the environment variable
+/// `key`, or `error.EnvironmentVariableNotFound` if it is unset.
+pub fn getEnvVarOwned(allocator: std.mem.Allocator, key: []const u8) GetEnvVarError![]u8 {
+    if (builtin.link_libc) {
+        const key_z = try allocator.dupeZ(u8, key);
+        defer allocator.free(key_z);
+        const val = std.c.getenv(key_z.ptr) orelse return error.EnvironmentVariableNotFound;
+        return allocator.dupe(u8, std.mem.sliceTo(val, 0));
+    }
+    // Fallback for non-libc targets: scan the POSIX environ block.
+    for (std.os.environ) |entry| {
+        const pair = std.mem.sliceTo(entry, 0);
+        const eq = std.mem.indexOfScalar(u8, pair, '=') orelse continue;
+        if (std.mem.eql(u8, pair[0..eq], key)) {
+            return allocator.dupe(u8, pair[eq + 1 ..]);
+        }
+    }
+    return error.EnvironmentVariableNotFound;
+}
+
+test "missing variable returns error" {
+    const a = std.testing.allocator;
+    try std.testing.expectError(
+        error.EnvironmentVariableNotFound,
+        getEnvVarOwned(a, "AGENKIT_DEFINITELY_UNSET_VAR_XYZ"),
+    );
+}

--- a/agenkit-zig/src/env_compat.zig
+++ b/agenkit-zig/src/env_compat.zig
@@ -24,8 +24,11 @@ pub fn getEnvVarOwned(allocator: std.mem.Allocator, key: []const u8) GetEnvVarEr
         const val = std.c.getenv(key_z.ptr) orelse return error.EnvironmentVariableNotFound;
         return allocator.dupe(u8, std.mem.sliceTo(val, 0));
     }
-    // Fallback for non-libc targets: scan the POSIX environ block.
-    for (std.os.environ) |entry| {
+    // Non-libc fallback: scan the C `environ` block directly. 0.16 exposes it
+    // as `std.c.environ` (a null-terminated array of optional NUL-terminated
+    // strings); there is no portable std.posix/std.os `environ` in 0.16.
+    var i: usize = 0;
+    while (std.c.environ[i]) |entry| : (i += 1) {
         const pair = std.mem.sliceTo(entry, 0);
         const eq = std.mem.indexOfScalar(u8, pair, '=') orelse continue;
         if (std.mem.eql(u8, pair[0..eq], key)) {

--- a/agenkit-zig/src/evaluation/ab_testing.zig
+++ b/agenkit-zig/src/evaluation/ab_testing.zig
@@ -9,7 +9,6 @@
 /// - Effect size calculation (Cohen's d)
 /// - Confidence intervals
 /// - Sample size calculation
-
 const std = @import("std");
 const core = @import("core.zig");
 const Allocator = std.mem.Allocator;
@@ -63,7 +62,7 @@ pub const ABVariant = struct {
         const self = try allocator.create(ABVariant);
         self.* = ABVariant{
             .name = try allocator.dupe(u8, name),
-            .samples = std.ArrayList(f64){},
+            .samples = std.ArrayList(f64).empty,
             .mean = 0.0,
             .std_dev = 0.0,
             .sample_size = 0,

--- a/agenkit-zig/src/evaluation/bayesian_optimizer.zig
+++ b/agenkit-zig/src/evaluation/bayesian_optimizer.zig
@@ -8,8 +8,8 @@
 /// - Multiple acquisition functions (EI, UCB, PI)
 /// - Exploration/exploitation balance
 /// - Integration with SearchSpace
-
 const std = @import("std");
+const agktime = @import("../time_compat.zig");
 const optimizer = @import("optimizer.zig");
 const Allocator = std.mem.Allocator;
 const SearchSpace = optimizer.SearchSpace;
@@ -129,7 +129,7 @@ pub const BayesianOptimizer = struct {
             try result.history.append(self.allocator, step);
         }
 
-        result.end_time = std.time.timestamp();
+        result.end_time = agktime.timestamp();
         return result;
     }
 
@@ -224,7 +224,7 @@ pub const BayesianOptimizer = struct {
         // Simplified GP: weighted average based on similarity
         var weighted_sum: f64 = 0.0;
         var weight_sum: f64 = 0.0;
-        var scores = std.ArrayList(f64){};
+        var scores = std.ArrayList(f64).empty;
         defer scores.deinit(self.allocator);
 
         for (result.history.items) |step| {

--- a/agenkit-zig/src/evaluation/benchmarks.zig
+++ b/agenkit-zig/src/evaluation/benchmarks.zig
@@ -8,7 +8,6 @@
 /// - Configurable difficulty levels
 /// - Extreme-scale testing support
 /// - Domain-specific test suites
-
 const std = @import("std");
 const core = @import("core.zig");
 const Allocator = std.mem.Allocator;
@@ -87,7 +86,7 @@ pub const SimpleQABenchmark = struct {
         allocator: Allocator,
     ) anyerror!std.ArrayList(*core.TestCase) {
         _ = ptr;
-        var cases = std.ArrayList(*core.TestCase){};
+        var cases = std.ArrayList(*core.TestCase).empty;
 
         // Math questions
         const tc1 = try core.TestCase.initExact(allocator, "What is 15 + 27?", "42");
@@ -192,7 +191,7 @@ pub const NeedleInHaystackBenchmark = struct {
         allocator: Allocator,
     ) anyerror!std.ArrayList(*core.TestCase) {
         const self: *NeedleInHaystackBenchmark = @ptrCast(@alignCast(ptr));
-        var cases = std.ArrayList(*core.TestCase){};
+        var cases = std.ArrayList(*core.TestCase).empty;
 
         // Generate needles (facts to hide in haystack)
         const needles = [_][]const u8{
@@ -202,7 +201,7 @@ pub const NeedleInHaystackBenchmark = struct {
         };
 
         // Generate haystack (filler content)
-        var haystack = std.ArrayList(u8){};
+        var haystack = std.ArrayList(u8).empty;
         defer haystack.deinit();
 
         const filler = "This is irrelevant information that serves as distraction. ";
@@ -300,7 +299,7 @@ pub const ExtremeScaleBenchmark = struct {
         allocator: Allocator,
     ) anyerror!std.ArrayList(*core.TestCase) {
         const self: *ExtremeScaleBenchmark = @ptrCast(@alignCast(ptr));
-        var cases = std.ArrayList(*core.TestCase){};
+        var cases = std.ArrayList(*core.TestCase).empty;
 
         // Generate massive context
         const tokens_per_char = 4; // Approximate
@@ -392,7 +391,7 @@ pub const InformationRetentionBenchmark = struct {
         allocator: Allocator,
     ) anyerror!std.ArrayList(*core.TestCase) {
         const self: *InformationRetentionBenchmark = @ptrCast(@alignCast(ptr));
-        var cases = std.ArrayList(*core.TestCase){};
+        var cases = std.ArrayList(*core.TestCase).empty;
 
         const facts = [_][]const u8{
             "The Eiffel Tower is 330 meters tall",
@@ -449,7 +448,7 @@ pub const BenchmarkSuite = struct {
         const self = try allocator.create(BenchmarkSuite);
         self.* = BenchmarkSuite{
             .name_str = try allocator.dupe(u8, name_str),
-            .benchmarks = std.ArrayList(Benchmark){},
+            .benchmarks = std.ArrayList(Benchmark).empty,
             .allocator = allocator,
         };
         return self;
@@ -463,7 +462,7 @@ pub const BenchmarkSuite = struct {
         self: *const BenchmarkSuite,
         allocator: Allocator,
     ) !std.ArrayList(*core.TestCase) {
-        var all_cases = std.ArrayList(*core.TestCase){};
+        var all_cases = std.ArrayList(*core.TestCase).empty;
 
         for (self.benchmarks.items) |benchmark| {
             var cases = try benchmark.generateTestCases(allocator);

--- a/agenkit-zig/src/evaluation/context_metrics.zig
+++ b/agenkit-zig/src/evaluation/context_metrics.zig
@@ -8,7 +8,6 @@
 /// - Compression effectiveness tracking
 /// - Percentile-based latency analysis
 /// - Memory-efficient streaming measurement
-
 const std = @import("std");
 const core = @import("core.zig");
 const Allocator = std.mem.Allocator;
@@ -26,7 +25,7 @@ pub const ContextMetric = struct {
         self.* = ContextMetric{
             .name_str = "context_length",
             .allocator = allocator,
-            .measurements = std.ArrayList(f64){},
+            .measurements = std.ArrayList(f64).empty,
         };
         return self;
     }
@@ -197,7 +196,7 @@ pub const CompressionMetric = struct {
     ) !std.ArrayList(CompressionStats) {
         _ = agent;
         _ = session_id;
-        var stats = std.ArrayList(CompressionStats){};
+        var stats = std.ArrayList(CompressionStats).empty;
 
         // For each test length, simulate compression evaluation
         for (self.test_lengths) |length| {
@@ -304,7 +303,7 @@ pub const LatencyMetric = struct {
         self.* = LatencyMetric{
             .name_str = "latency",
             .allocator = allocator,
-            .measurements = std.ArrayList(f64){},
+            .measurements = std.ArrayList(f64).empty,
         };
         return self;
     }
@@ -452,9 +451,9 @@ test "ContextMetric tracking" {
     }
 
     // Simulate multiple measurements
-    try metric.measurements.append(allocator,100.0);
-    try metric.measurements.append(allocator,150.0);
-    try metric.measurements.append(allocator,200.0);
+    try metric.measurements.append(allocator, 100.0);
+    try metric.measurements.append(allocator, 150.0);
+    try metric.measurements.append(allocator, 200.0);
 
     const measurements = metric.measurements.items;
     var aggregated = try metric.asMetric().aggregate(measurements, allocator);

--- a/agenkit-zig/src/evaluation/core.zig
+++ b/agenkit-zig/src/evaluation/core.zig
@@ -7,7 +7,6 @@
 /// - Explicit memory management with allocators
 /// - Type-safe metric definitions
 /// - Composable evaluation components
-
 const std = @import("std");
 const Agent = @import("../agent.zig").Agent;
 const Message = @import("../message.zig").Message;
@@ -165,7 +164,7 @@ pub const EvaluationResult = struct {
             .n_cases = 0,
             .n_passed = 0,
             .metrics = std.StringHashMap(f64).init(allocator),
-            .errors = std.ArrayList(*ErrorRecord){},
+            .errors = std.ArrayList(*ErrorRecord).empty,
             .allocator = allocator,
         };
         return self;

--- a/agenkit-zig/src/evaluation/metrics.zig
+++ b/agenkit-zig/src/evaluation/metrics.zig
@@ -9,8 +9,9 @@
 /// - Time-based session tracking
 /// - Flexible metric aggregation
 /// - JSON serialization support
-
 const std = @import("std");
+const agksync = @import("../sync_compat.zig");
+const agktime = @import("../time_compat.zig");
 const Allocator = std.mem.Allocator;
 
 /// Session execution status
@@ -108,7 +109,7 @@ pub const MetricMeasurement = struct {
         self.* = MetricMeasurement{
             .metric_type = metric_type,
             .value = value,
-            .timestamp = std.time.timestamp(),
+            .timestamp = agktime.timestamp(),
             .session_id = try allocator.dupe(u8, session_id),
             .allocator = allocator,
         };
@@ -143,7 +144,7 @@ pub const SessionResult = struct {
             .agent_name = try allocator.dupe(u8, agent_name),
             .status = .running,
             .metrics = std.StringHashMap(f64).init(allocator),
-            .start_time = std.time.timestamp(),
+            .start_time = agktime.timestamp(),
             .end_time = 0,
             .error_message = null,
             .allocator = allocator,
@@ -155,7 +156,7 @@ pub const SessionResult = struct {
     pub fn duration(self: *const SessionResult) f64 {
         if (self.end_time == 0) {
             // Session still running, use current time
-            const now = std.time.timestamp();
+            const now = agktime.timestamp();
             return @as(f64, @floatFromInt(now - self.start_time));
         }
         return @as(f64, @floatFromInt(self.end_time - self.start_time));
@@ -164,13 +165,13 @@ pub const SessionResult = struct {
     /// Mark session as completed
     pub fn complete(self: *SessionResult) void {
         self.status = .completed;
-        self.end_time = std.time.timestamp();
+        self.end_time = agktime.timestamp();
     }
 
     /// Mark session as failed with error message
     pub fn fail(self: *SessionResult, error_msg: []const u8) !void {
         self.status = .failed;
-        self.end_time = std.time.timestamp();
+        self.end_time = agktime.timestamp();
         self.error_message = try self.allocator.dupe(u8, error_msg);
     }
 
@@ -230,12 +231,12 @@ pub const Statistics = struct {
 pub const MetricsCollector = struct {
     sessions: std.ArrayList(*SessionResult),
     allocator: Allocator,
-    mutex: std.Thread.Mutex,
+    mutex: agksync.Mutex,
 
     pub fn init(allocator: Allocator) !*MetricsCollector {
         const self = try allocator.create(MetricsCollector);
         self.* = .{
-            .sessions = std.ArrayList(*SessionResult){},
+            .sessions = std.ArrayList(*SessionResult).empty,
             .allocator = allocator,
             .mutex = .{},
         };
@@ -334,7 +335,7 @@ pub const MetricsCollector = struct {
         self.mutex.lock();
         defer self.mutex.unlock();
 
-        var filtered = std.ArrayList(*SessionResult){};
+        var filtered = std.ArrayList(*SessionResult).empty;
 
         for (self.sessions.items) |session| {
             if (std.mem.eql(u8, session.agent_name, agent_name)) {
@@ -354,7 +355,7 @@ pub const MetricsCollector = struct {
         self.mutex.lock();
         defer self.mutex.unlock();
 
-        var filtered = std.ArrayList(*SessionResult){};
+        var filtered = std.ArrayList(*SessionResult).empty;
 
         for (self.sessions.items) |session| {
             if (session.status == status) {
@@ -375,7 +376,7 @@ pub const MetricsCollector = struct {
         self.mutex.lock();
         defer self.mutex.unlock();
 
-        var filtered = std.ArrayList(*SessionResult){};
+        var filtered = std.ArrayList(*SessionResult).empty;
 
         for (self.sessions.items) |session| {
             if (session.start_time >= start and session.start_time <= end) {

--- a/agenkit-zig/src/evaluation/mod.zig
+++ b/agenkit-zig/src/evaluation/mod.zig
@@ -19,7 +19,6 @@
 /// const evaluator = try evaluation.Evaluator.init(allocator, agent, &metrics);
 /// const result = try evaluator.evaluate(&test_cases, "session-1");
 /// ```
-
 const std = @import("std");
 
 // Core evaluation types

--- a/agenkit-zig/src/evaluation/optimizer.zig
+++ b/agenkit-zig/src/evaluation/optimizer.zig
@@ -8,8 +8,8 @@
 /// - Pluggable optimization algorithms
 /// - History tracking for analysis
 /// - Support for maximization and minimization
-
 const std = @import("std");
+const agktime = @import("../time_compat.zig");
 const Allocator = std.mem.Allocator;
 
 /// Parameter type in search space
@@ -85,9 +85,9 @@ pub const SearchSpace = struct {
 
     pub fn init(allocator: Allocator) !*SearchSpace {
         const self = try allocator.create(SearchSpace);
-        const seed = @as(u64, @intCast(std.time.timestamp()));
+        const seed = @as(u64, @intCast(agktime.timestamp()));
         self.* = SearchSpace{
-            .parameters = std.ArrayList(Parameter){},
+            .parameters = std.ArrayList(Parameter).empty,
             .allocator = allocator,
             .rng = std.Random.DefaultPrng.init(seed),
         };
@@ -265,8 +265,8 @@ pub const OptimizationResult = struct {
             .best_config = std.StringHashMap(ConfigValue).init(allocator),
             .best_score = -std.math.inf(f64), // Start with worst possible
             .n_iterations = 0,
-            .history = std.ArrayList(OptimizationStep){},
-            .start_time = std.time.timestamp(),
+            .history = std.ArrayList(OptimizationStep).empty,
+            .start_time = agktime.timestamp(),
             .end_time = 0,
             .allocator = allocator,
         };
@@ -372,7 +372,7 @@ pub const RandomSearchOptimizer = struct {
             try result.history.append(self.allocator, step);
         }
 
-        result.end_time = std.time.timestamp();
+        result.end_time = agktime.timestamp();
         return result;
     }
 

--- a/agenkit-zig/src/evaluation/prompt_optimizer.zig
+++ b/agenkit-zig/src/evaluation/prompt_optimizer.zig
@@ -8,8 +8,8 @@
 /// - Multiple optimization strategies
 /// - Multi-metric evaluation
 /// - AgentFactory pattern for creating agents from prompts
-
 const std = @import("std");
+const agktime = @import("../time_compat.zig");
 const core = @import("core.zig");
 const Allocator = std.mem.Allocator;
 
@@ -114,7 +114,7 @@ pub const PromptOptimizer = struct {
         evaluation_fn: EvaluationFn,
     ) !*PromptOptimizer {
         const self = try allocator.create(PromptOptimizer);
-        const seed = @as(u64, @intCast(std.time.timestamp()));
+        const seed = @as(u64, @intCast(agktime.timestamp()));
         self.* = PromptOptimizer{
             .prompt_template = try allocator.dupe(u8, prompt_template),
             .variations = variations,
@@ -131,14 +131,14 @@ pub const PromptOptimizer = struct {
         self: *PromptOptimizer,
         test_cases: []const core.TestCase,
     ) !*PromptOptimizationResult {
-        const start_time = std.time.timestamp();
+        const start_time = agktime.timestamp();
 
         const result = try self.allocator.create(PromptOptimizationResult);
         result.* = PromptOptimizationResult{
             .best_prompt = try self.allocator.dupe(u8, ""),
             .best_config = PromptConfig.init(self.allocator),
             .best_scores = PromptScores.init(self.allocator),
-            .history = std.ArrayList(OptimizationEntry).init(self.allocator),
+            .history = std.ArrayList(OptimizationEntry).empty,
             .strategy_used = .grid,
             .total_time_seconds = 0.0,
             .allocator = self.allocator,
@@ -241,7 +241,7 @@ pub const PromptOptimizer = struct {
             scores.deinit();
         }
 
-        const end_time = std.time.timestamp();
+        const end_time = agktime.timestamp();
         result.total_time_seconds = @as(f64, @floatFromInt(end_time - start_time));
 
         return result;
@@ -253,14 +253,14 @@ pub const PromptOptimizer = struct {
         test_cases: []const core.TestCase,
         n_samples: usize,
     ) !*PromptOptimizationResult {
-        const start_time = std.time.timestamp();
+        const start_time = agktime.timestamp();
 
         const result = try self.allocator.create(PromptOptimizationResult);
         result.* = PromptOptimizationResult{
             .best_prompt = try self.allocator.dupe(u8, ""),
             .best_config = PromptConfig.init(self.allocator),
             .best_scores = PromptScores.init(self.allocator),
-            .history = std.ArrayList(OptimizationEntry).init(self.allocator),
+            .history = std.ArrayList(OptimizationEntry).empty,
             .strategy_used = .random,
             .total_time_seconds = 0.0,
             .allocator = self.allocator,
@@ -353,7 +353,7 @@ pub const PromptOptimizer = struct {
             scores.deinit();
         }
 
-        const end_time = std.time.timestamp();
+        const end_time = agktime.timestamp();
         result.total_time_seconds = @as(f64, @floatFromInt(end_time - start_time));
 
         return result;
@@ -367,14 +367,14 @@ pub const PromptOptimizer = struct {
         n_generations: usize,
         mutation_rate: f64,
     ) !*PromptOptimizationResult {
-        const start_time = std.time.timestamp();
+        const start_time = agktime.timestamp();
 
         const result = try self.allocator.create(PromptOptimizationResult);
         result.* = PromptOptimizationResult{
             .best_prompt = try self.allocator.dupe(u8, ""),
             .best_config = PromptConfig.init(self.allocator),
             .best_scores = PromptScores.init(self.allocator),
-            .history = std.ArrayList(OptimizationEntry).init(self.allocator),
+            .history = std.ArrayList(OptimizationEntry).empty,
             .strategy_used = .genetic,
             .total_time_seconds = 0.0,
             .allocator = self.allocator,
@@ -383,7 +383,7 @@ pub const PromptOptimizer = struct {
         var best_avg_score: f64 = -std.math.inf(f64);
 
         // Initialize population
-        var population = std.ArrayList(PromptConfig).init(self.allocator);
+        var population = std.ArrayList(PromptConfig).empty;
         defer {
             for (population.items) |*config| {
                 var it = config.iterator();
@@ -403,7 +403,7 @@ pub const PromptOptimizer = struct {
         // Evolutionary loop
         for (0..n_generations) |_| {
             // Evaluate population
-            var fitness = std.ArrayList(f64).init(self.allocator);
+            var fitness = std.ArrayList(f64).empty;
             defer fitness.deinit();
 
             for (population.items) |*config| {
@@ -454,7 +454,7 @@ pub const PromptOptimizer = struct {
             }
 
             // Selection and crossover
-            var new_population = std.ArrayList(PromptConfig).init(self.allocator);
+            var new_population = std.ArrayList(PromptConfig).empty;
             defer {
                 for (new_population.items) |*config| {
                     var it = config.iterator();
@@ -501,7 +501,7 @@ pub const PromptOptimizer = struct {
             }
         }
 
-        const end_time = std.time.timestamp();
+        const end_time = agktime.timestamp();
         result.total_time_seconds = @as(f64, @floatFromInt(end_time - start_time));
 
         return result;
@@ -509,7 +509,7 @@ pub const PromptOptimizer = struct {
 
     /// Format prompt from configuration
     fn formatPrompt(self: *PromptOptimizer, config: *const PromptConfig) ![]const u8 {
-        var result = std.ArrayList(u8){};
+        var result = std.ArrayList(u8).empty;
         defer result.deinit(self.allocator);
 
         var template_it = std.mem.tokenizeScalar(u8, self.prompt_template, '{');
@@ -519,15 +519,15 @@ pub const PromptOptimizer = struct {
                 const rest = part[close_idx + 1 ..];
 
                 if (config.get(var_name)) |value| {
-                    try result.appendSlice(self.allocator,value);
+                    try result.appendSlice(self.allocator, value);
                 } else {
-                    try result.append(self.allocator,'{');
-                    try result.appendSlice(self.allocator,var_name);
-                    try result.append(self.allocator,'}');
+                    try result.append(self.allocator, '{');
+                    try result.appendSlice(self.allocator, var_name);
+                    try result.append(self.allocator, '}');
                 }
-                try result.appendSlice(self.allocator,rest);
+                try result.appendSlice(self.allocator, rest);
             } else {
-                try result.appendSlice(self.allocator,part);
+                try result.appendSlice(self.allocator, part);
             }
         }
 
@@ -557,12 +557,12 @@ pub const PromptOptimizer = struct {
 
     /// Generate all possible configurations
     fn generateAllConfigs(self: *PromptOptimizer) !std.ArrayList(PromptConfig) {
-        var result = std.ArrayList(PromptConfig).init(self.allocator);
+        var result = std.ArrayList(PromptConfig).empty;
 
-        var var_names = std.ArrayList([]const u8).init(self.allocator);
+        var var_names = std.ArrayList([]const u8).empty;
         defer var_names.deinit();
 
-        var var_options = std.ArrayList(std.ArrayList([]const u8)).init(self.allocator);
+        var var_options = std.ArrayList(std.ArrayList([]const u8)).empty;
         defer var_options.deinit();
 
         var it = self.variations.iterator();
@@ -652,7 +652,7 @@ pub const PromptOptimizer = struct {
         const random = self.rng.random();
 
         // Pick random variable to mutate
-        var var_names = std.ArrayList([]const u8).init(self.allocator);
+        var var_names = std.ArrayList([]const u8).empty;
         defer var_names.deinit();
 
         var it = config.iterator();
@@ -781,7 +781,7 @@ test "PromptOptimizer sampleRandomConfig" {
 
     var variations = std.StringHashMap(std.ArrayList([]const u8)).init(allocator);
 
-    var roles = std.ArrayList([]const u8){};
+    var roles = std.ArrayList([]const u8).empty;
     try roles.append(allocator, try allocator.dupe(u8, "assistant"));
     try roles.append(allocator, try allocator.dupe(u8, "expert"));
     try variations.put(try allocator.dupe(u8, "role"), roles);

--- a/agenkit-zig/src/evaluation/quality_metrics.zig
+++ b/agenkit-zig/src/evaluation/quality_metrics.zig
@@ -8,7 +8,6 @@
 /// - LLM-as-judge pattern support
 /// - Classification metrics (precision/recall/F1)
 /// - Configurable thresholds
-
 const std = @import("std");
 const json = std.json;
 const core = @import("core.zig");
@@ -373,7 +372,7 @@ pub const PrecisionRecallMetric = struct {
             .name_str = "precision_recall",
             .allocator = allocator,
             .positive_threshold = positive_threshold,
-            .classifications = std.ArrayList(bool){},
+            .classifications = std.ArrayList(bool).empty,
         };
         return self;
     }
@@ -493,7 +492,7 @@ test "AccuracyMetric case sensitive" {
     // Test exact match
     var output1 = try Message.withText(allocator, .assistant, "Hello");
     defer output1.deinit();
-    try output1.metadata.object.put("expected", json.Value{ .string = "Hello" });
+    try output1.metadata.object.put(allocator, "expected", json.Value{ .string = "Hello" });
 
     // Mock agent and input (not used in accuracy measurement)
     const agent = Agent{ .ptr = undefined, .vtable = undefined };
@@ -506,7 +505,7 @@ test "AccuracyMetric case sensitive" {
     // Test mismatch
     var output2 = try Message.withText(allocator, .assistant, "hello");
     defer output2.deinit();
-    try output2.metadata.object.put("expected", json.Value{ .string = "Hello" });
+    try output2.metadata.object.put(allocator, "expected", json.Value{ .string = "Hello" });
 
     const score2 = try metric.asMetric().measure(agent, input, output2, allocator);
     try std.testing.expectEqual(@as(f64, 0.0), score2);
@@ -520,7 +519,7 @@ test "AccuracyMetric case insensitive" {
 
     var output = try Message.withText(allocator, .assistant, "hello");
     defer output.deinit();
-    try output.metadata.object.put("expected", json.Value{ .string = "HELLO" });
+    try output.metadata.object.put(allocator, "expected", json.Value{ .string = "HELLO" });
 
     const agent = Agent{ .ptr = undefined, .vtable = undefined };
     var input = try Message.withText(allocator, .user, "test");

--- a/agenkit-zig/src/evaluation/recorder.zig
+++ b/agenkit-zig/src/evaluation/recorder.zig
@@ -8,8 +8,10 @@
 /// - Efficient serialization (JSON)
 /// - Replay with fidelity
 /// - Memory and file storage options
-
 const std = @import("std");
+const ioc = @import("../io_compat.zig");
+const agksync = @import("../sync_compat.zig");
+const agktime = @import("../time_compat.zig");
 const Allocator = std.mem.Allocator;
 const Agent = @import("../agent.zig").Agent;
 const Message = @import("../message.zig").Message;
@@ -33,7 +35,7 @@ pub const Interaction = struct {
         self.* = Interaction{
             .input = try allocator.dupe(u8, input),
             .output = try allocator.dupe(u8, output),
-            .timestamp = std.time.timestamp(),
+            .timestamp = agktime.timestamp(),
             .duration_ms = duration_ms,
             .metadata = std.StringHashMap([]const u8).init(allocator),
             .allocator = allocator,
@@ -76,9 +78,9 @@ pub const SessionTrace = struct {
         const self = try allocator.create(SessionTrace);
         self.* = SessionTrace{
             .session_id = try allocator.dupe(u8, session_id),
-            .interactions = std.ArrayList(*Interaction){},
+            .interactions = std.ArrayList(*Interaction).empty,
             .metadata = std.StringHashMap([]const u8).init(allocator),
-            .start_time = std.time.timestamp(),
+            .start_time = agktime.timestamp(),
             .end_time = 0,
             .allocator = allocator,
         };
@@ -99,13 +101,13 @@ pub const SessionTrace = struct {
 
     /// Mark trace as complete
     pub fn complete(self: *SessionTrace) void {
-        self.end_time = std.time.timestamp();
+        self.end_time = agktime.timestamp();
     }
 
     /// Get total duration in seconds
     pub fn duration(self: *const SessionTrace) f64 {
         if (self.end_time == 0) {
-            const now = std.time.timestamp();
+            const now = agktime.timestamp();
             return @as(f64, @floatFromInt(now - self.start_time));
         }
         return @as(f64, @floatFromInt(self.end_time - self.start_time));
@@ -153,7 +155,7 @@ pub const SessionRecorder = struct {
     traces: std.StringHashMap(*SessionTrace),
     active_sessions: std.StringHashMap(bool),
     allocator: Allocator,
-    mutex: std.Thread.Mutex,
+    mutex: agksync.Mutex,
 
     pub fn init(allocator: Allocator) !*SessionRecorder {
         const self = try allocator.create(SessionRecorder);
@@ -241,7 +243,7 @@ pub const SessionRecorder = struct {
         self.mutex.lock();
         defer self.mutex.unlock();
 
-        var result = std.ArrayList(*SessionTrace){};
+        var result = std.ArrayList(*SessionTrace).empty;
 
         var it = self.traces.iterator();
         while (it.next()) |entry| {
@@ -308,16 +310,16 @@ pub const SessionRecorder = struct {
         self.mutex.lock();
         defer self.mutex.unlock();
 
-        const file = try std.fs.cwd().createFile(path, .{});
-        defer file.close();
+        const file = try std.Io.Dir.cwd().createFile(ioc.io(), path, .{});
+        defer file.close(ioc.io());
 
         // Simple JSON format: array of traces
-        try file.writeAll("[");
+        try file.writeStreamingAll(ioc.io(), "[");
 
         var first = true;
         var it = self.traces.iterator();
         while (it.next()) |entry| {
-            if (!first) try file.writeAll(",");
+            if (!first) try file.writeStreamingAll(ioc.io(), ",");
             first = false;
 
             const trace = entry.value_ptr.*;
@@ -327,10 +329,10 @@ pub const SessionRecorder = struct {
                 .{ trace.session_id, trace.interactionCount() },
             );
             defer self.allocator.free(json);
-            try file.writeAll(json);
+            try file.writeStreamingAll(ioc.io(), json);
         }
 
-        try file.writeAll("]");
+        try file.writeStreamingAll(ioc.io(), "]");
     }
 
     pub fn deinit(self: *SessionRecorder) void {
@@ -574,5 +576,5 @@ test "SessionRecorder save to file" {
     try recorder.saveToFile(temp_path);
 
     // Clean up
-    std.fs.cwd().deleteFile(temp_path) catch {};
+    std.Io.Dir.cwd().deleteFile(ioc.io(), temp_path) catch {};
 }

--- a/agenkit-zig/src/evaluation/regression.zig
+++ b/agenkit-zig/src/evaluation/regression.zig
@@ -9,8 +9,8 @@
 /// - Configurable thresholds per metric
 /// - Severity classification
 /// - Actionable regression reports
-
 const std = @import("std");
+const agksync = @import("../sync_compat.zig");
 const Allocator = std.mem.Allocator;
 
 /// Severity level of a detected regression
@@ -130,7 +130,7 @@ pub const BaselineMeasurement = struct {
     pub fn init(allocator: Allocator) !*BaselineMeasurement {
         const self = try allocator.create(BaselineMeasurement);
         self.* = BaselineMeasurement{
-            .samples = std.ArrayList(f64){},
+            .samples = std.ArrayList(f64).empty,
             .mean = 0.0,
             .std_dev = 0.0,
             .allocator = allocator,
@@ -183,7 +183,7 @@ pub const RegressionDetector = struct {
     thresholds: std.StringHashMap(f64),
     config: RegressionConfig,
     allocator: Allocator,
-    mutex: std.Thread.Mutex,
+    mutex: agksync.Mutex,
 
     pub fn init(allocator: Allocator, config: RegressionConfig) !*RegressionDetector {
         const self = try allocator.create(RegressionDetector);
@@ -260,7 +260,7 @@ pub const RegressionDetector = struct {
         self.mutex.lock();
         defer self.mutex.unlock();
 
-        var regressions = std.ArrayList(*Regression){};
+        var regressions = std.ArrayList(*Regression).empty;
 
         // Check each metric in current against baseline
         var current_it = current.iterator();

--- a/agenkit-zig/src/infrastructure/budget/limiter.zig
+++ b/agenkit-zig/src/infrastructure/budget/limiter.zig
@@ -29,6 +29,7 @@
 /// const result = try limiter.agent().process(message);
 /// ```
 const std = @import("std");
+const agksync = @import("../../sync_compat.zig");
 const Agent = @import("../../agent.zig").Agent;
 const AgentError = @import("../../agent.zig").AgentError;
 const StreamCallbacks = @import("../../agent.zig").StreamCallbacks;
@@ -125,7 +126,7 @@ pub const BudgetLimiterDecorator = struct {
     cost_tracker: *CostTracker,
     config: BudgetLimiterConfig,
     metrics_data: BudgetLimiterMetrics,
-    mutex: std.Thread.Mutex,
+    mutex: agksync.Mutex,
 
     pub fn init(
         allocator: Allocator,
@@ -143,7 +144,7 @@ pub const BudgetLimiterDecorator = struct {
             .cost_tracker = cost_tracker,
             .config = config,
             .metrics_data = BudgetLimiterMetrics{},
-            .mutex = std.Thread.Mutex{},
+            .mutex = agksync.Mutex{},
         };
         return self;
     }

--- a/agenkit-zig/src/infrastructure/budget/models.zig
+++ b/agenkit-zig/src/infrastructure/budget/models.zig
@@ -12,6 +12,8 @@
 ///   const cost = try pricing.calculate("claude-sonnet-4", 10000, .input);
 ///   std.debug.print("Cost: ${d:.4}\n", .{cost});
 const std = @import("std");
+const agksync = @import("../../sync_compat.zig");
+const agktime = @import("../../time_compat.zig");
 const Allocator = std.mem.Allocator;
 
 /// Direction for cost calculation (input or output tokens).
@@ -39,7 +41,7 @@ pub const Direction = enum {
 ///   const cost = try pricing.calculate("gpt-4o", 100000, .input);
 pub const ModelPricing = struct {
     allocator: Allocator,
-    mutex: std.Thread.Mutex,
+    mutex: agksync.Mutex,
     pricing: std.StringHashMap(PricingData),
 
     pub const PricingData = struct {
@@ -170,7 +172,7 @@ pub const ModelPricing = struct {
         self.mutex.lock();
         defer self.mutex.unlock();
 
-        var models = std.ArrayList([]const u8).init(self.allocator);
+        var models = std.ArrayList([]const u8).empty;
         var iter = self.pricing.keyIterator();
         while (iter.next()) |key| {
             if (!std.mem.eql(u8, key.*, "default")) {
@@ -372,8 +374,8 @@ pub const Cost = struct {
             .output_cost = output_cost,
             .thinking_cost = thinking_cost,
             .total_cost = total_cost,
-            .timestamp = std.time.milliTimestamp(),
-            .metadata = std.json.Value{ .object = std.json.ObjectMap.init(allocator) },
+            .timestamp = agktime.milliTimestamp(),
+            .metadata = std.json.Value{ .object = std.json.ObjectMap.empty },
             .allocator = allocator,
         };
     }
@@ -397,7 +399,7 @@ pub const Cost = struct {
     ///   const json_value = try cost.toJson();
     ///   defer json_value.object.deinit();
     pub fn toJson(self: *const Cost) !std.json.Value {
-        var obj = std.json.ObjectMap.init(self.allocator);
+        var obj = std.json.ObjectMap.empty;
 
         try obj.put("session_id", .{ .string = self.session_id });
         try obj.put("agent_name", .{ .string = self.agent_name });

--- a/agenkit-zig/src/infrastructure/budget/optimizer.zig
+++ b/agenkit-zig/src/infrastructure/budget/optimizer.zig
@@ -28,6 +28,7 @@
 /// std.debug.print("Selected model: {s}\n", .{model});
 /// ```
 const std = @import("std");
+const agksync = @import("../../sync_compat.zig");
 const ModelPricing = @import("models.zig").ModelPricing;
 const Allocator = std.mem.Allocator;
 
@@ -51,10 +52,10 @@ pub const ComplexityLevel = enum {
 
 /// Model tier based on capability and cost
 pub const ModelTier = enum {
-    economy,      // gpt-4o-mini, claude-haiku
-    standard,     // gpt-4o, claude-sonnet
-    advanced,     // o1, claude-opus
-    reasoning,    // o3, claude-opus-4 (extended thinking)
+    economy, // gpt-4o-mini, claude-haiku
+    standard, // gpt-4o, claude-sonnet
+    advanced, // o1, claude-opus
+    reasoning, // o3, claude-opus-4 (extended thinking)
 
     /// Get recommended models for this tier
     pub fn models(self: ModelTier) []const []const u8 {
@@ -167,7 +168,7 @@ pub const ModelOptimizer = struct {
     model_pricing: *ModelPricing,
     config: ModelOptimizerConfig,
     metrics_data: ModelOptimizerMetrics,
-    mutex: std.Thread.Mutex,
+    mutex: agksync.Mutex,
 
     pub fn init(
         allocator: Allocator,
@@ -183,7 +184,7 @@ pub const ModelOptimizer = struct {
             .model_pricing = model_pricing,
             .config = config,
             .metrics_data = ModelOptimizerMetrics{},
-            .mutex = std.Thread.Mutex{},
+            .mutex = agksync.Mutex{},
         };
         return self;
     }
@@ -450,9 +451,9 @@ test "ModelOptimizer getFallbackModel" {
 test "ModelOptimizerMetrics avgComplexity" {
     var metrics = ModelOptimizerMetrics{
         .total_decisions = 4,
-        .economy_count = 1,   // 25
-        .standard_count = 1,  // 50
-        .advanced_count = 1,  // 75
+        .economy_count = 1, // 25
+        .standard_count = 1, // 50
+        .advanced_count = 1, // 75
         .reasoning_count = 1, // 100
     };
 

--- a/agenkit-zig/src/infrastructure/budget/tracker.zig
+++ b/agenkit-zig/src/infrastructure/budget/tracker.zig
@@ -19,6 +19,7 @@
 ///
 ///   const total = try tracker.getSessionCost("session-1", null, null);
 const std = @import("std");
+const agksync = @import("../../sync_compat.zig");
 const Allocator = std.mem.Allocator;
 const models = @import("models.zig");
 const Cost = models.Cost;
@@ -83,7 +84,7 @@ pub const Storage = struct {
 ///   try storage.store(&cost);
 pub const InMemoryStorage = struct {
     allocator: Allocator,
-    mutex: std.Thread.Mutex,
+    mutex: agksync.Mutex,
     costs: std.ArrayList(*Cost),
 
     pub fn init(allocator: Allocator) InMemoryStorage {
@@ -170,7 +171,7 @@ pub const InMemoryStorage = struct {
         self.mutex.lock();
         defer self.mutex.unlock();
 
-        var results: std.ArrayList(*Cost) = .{};
+        var results: std.ArrayList(*Cost) = .empty;
 
         for (self.costs.items) |cost| {
             // Filter by session_id
@@ -478,7 +479,7 @@ pub const CostTracker = struct {
         defer self.allocator.free(costs);
 
         if (costs.len == 0) {
-            var obj = std.json.ObjectMap.init(self.allocator);
+            var obj = std.json.ObjectMap.empty;
             try obj.put("total_cost", .{ .float = 0.0 });
             try obj.put("total_requests", .{ .integer = 0 });
             try obj.put("total_input_tokens", .{ .integer = 0 });
@@ -499,7 +500,7 @@ pub const CostTracker = struct {
             total_thinking_tokens += cost.thinking_tokens;
         }
 
-        var obj = std.json.ObjectMap.init(self.allocator);
+        var obj = std.json.ObjectMap.empty;
         try obj.put("total_cost", .{ .float = total_cost });
         try obj.put("total_requests", .{ .integer = @intCast(costs.len) });
         try obj.put("total_input_tokens", .{ .integer = @intCast(total_input_tokens) });

--- a/agenkit-zig/src/infrastructure/checkpointing/checkpoint.zig
+++ b/agenkit-zig/src/infrastructure/checkpointing/checkpoint.zig
@@ -15,6 +15,8 @@
 ///   try checkpoint.setState("counter", .{ .integer = 5 });
 ///   const json_str = try checkpoint.toJson();
 const std = @import("std");
+const ioc = @import("../../io_compat.zig");
+const agktime = @import("../../time_compat.zig");
 const json = std.json;
 const Allocator = std.mem.Allocator;
 const Message = @import("../../message.zig").Message;
@@ -40,7 +42,7 @@ fn freeJsonValue(allocator: Allocator, value: json.Value) void {
                 freeJsonValue(allocator, entry.value_ptr.*);
             }
             var mut_obj = obj;
-            mut_obj.deinit();
+            mut_obj.deinit(allocator);
         },
     }
 }
@@ -62,12 +64,12 @@ fn deepCopyJsonValue(allocator: Allocator, value: json.Value) !json.Value {
             return .{ .array = array_copy };
         },
         .object => |obj| {
-            var object_copy = json.ObjectMap.init(allocator);
+            var object_copy = json.ObjectMap.empty;
             var iter = obj.iterator();
             while (iter.next()) |entry| {
                 const key_copy = try allocator.dupe(u8, entry.key_ptr.*);
                 const value_copy = try deepCopyJsonValue(allocator, entry.value_ptr.*);
-                try object_copy.put(key_copy, value_copy);
+                try object_copy.put(allocator, key_copy, value_copy);
             }
             return .{ .object = object_copy };
         },
@@ -118,7 +120,7 @@ pub const Checkpoint = struct {
         const checkpoint_id = try generateUuid(allocator);
 
         // Get current timestamp in milliseconds
-        const timestamp = std.time.milliTimestamp();
+        const timestamp = agktime.milliTimestamp();
 
         return Checkpoint{
             .checkpoint_id = checkpoint_id,
@@ -126,9 +128,9 @@ pub const Checkpoint = struct {
             .agent_name = try allocator.dupe(u8, agent_name),
             .timestamp = timestamp,
             .step_number = step_number,
-            .state = json.Value{ .object = json.ObjectMap.init(allocator) },
+            .state = json.Value{ .object = json.ObjectMap.empty },
             .messages = try allocator.alloc(Message, 0),
-            .metadata = json.Value{ .object = json.ObjectMap.init(allocator) },
+            .metadata = json.Value{ .object = json.ObjectMap.empty },
             .parent_checkpoint_id = null,
             .allocator = allocator,
         };
@@ -173,7 +175,7 @@ pub const Checkpoint = struct {
             self.allocator.free(entry.key_ptr.*);
             freeJsonValue(self.allocator, entry.value_ptr.*);
         }
-        self.state.object.deinit();
+        self.state.object.deinit(self.allocator);
 
         // Free metadata ObjectMap (including all keys and values recursively)
         var metadata_iter = self.metadata.object.iterator();
@@ -181,7 +183,7 @@ pub const Checkpoint = struct {
             self.allocator.free(entry.key_ptr.*);
             freeJsonValue(self.allocator, entry.value_ptr.*);
         }
-        self.metadata.object.deinit();
+        self.metadata.object.deinit(self.allocator);
 
         // Free messages
         for (self.messages) |*msg| {
@@ -207,7 +209,7 @@ pub const Checkpoint = struct {
         } else {
             // Duplicate key and store
             const key_copy = try self.allocator.dupe(u8, key);
-            try self.state.object.put(key_copy, value);
+            try self.state.object.put(self.allocator, key_copy, value);
         }
     }
 
@@ -253,7 +255,7 @@ pub const Checkpoint = struct {
         } else {
             // Duplicate key and store
             const key_copy = try self.allocator.dupe(u8, key);
-            try self.metadata.object.put(key_copy, value);
+            try self.metadata.object.put(self.allocator, key_copy, value);
         }
     }
 
@@ -273,26 +275,26 @@ pub const Checkpoint = struct {
     /// Returns:
     ///   JSON representation as ObjectMap
     pub fn toJsonObject(self: *const Checkpoint) !json.Value {
-        var obj = json.ObjectMap.init(self.allocator);
+        var obj = json.ObjectMap.empty;
 
         // Add checkpoint_id
-        try obj.put("checkpoint_id", json.Value{ .string = self.checkpoint_id });
+        try obj.put(self.allocator, "checkpoint_id", json.Value{ .string = self.checkpoint_id });
 
         // Add session_id
-        try obj.put("session_id", json.Value{ .string = self.session_id });
+        try obj.put(self.allocator, "session_id", json.Value{ .string = self.session_id });
 
         // Add agent_name
-        try obj.put("agent_name", json.Value{ .string = self.agent_name });
+        try obj.put(self.allocator, "agent_name", json.Value{ .string = self.agent_name });
 
         // Add timestamp as RFC3339 string
         const timestamp_str = try formatTimestamp(self.allocator, self.timestamp);
-        try obj.put("timestamp", json.Value{ .string = timestamp_str });
+        try obj.put(self.allocator, "timestamp", json.Value{ .string = timestamp_str });
 
         // Add step_number
-        try obj.put("step_number", json.Value{ .integer = @intCast(self.step_number) });
+        try obj.put(self.allocator, "step_number", json.Value{ .integer = @intCast(self.step_number) });
 
         // Add state
-        try obj.put("state", self.state);
+        try obj.put(self.allocator, "state", self.state);
 
         // Add messages as JSON array
         const messages_array = try self.allocator.alloc(json.Value, self.messages.len);
@@ -300,14 +302,14 @@ pub const Checkpoint = struct {
             messages_array[i] = try msg.toJson(self.allocator);
         }
         const messages_array_list = json.Array.fromOwnedSlice(self.allocator, messages_array);
-        try obj.put("messages", json.Value{ .array = messages_array_list });
+        try obj.put(self.allocator, "messages", json.Value{ .array = messages_array_list });
 
         // Add metadata
-        try obj.put("metadata", self.metadata);
+        try obj.put(self.allocator, "metadata", self.metadata);
 
         // Add parent_checkpoint_id if present
         if (self.parent_checkpoint_id) |parent_id| {
-            try obj.put("parent_checkpoint_id", json.Value{ .string = parent_id });
+            try obj.put(self.allocator, "parent_checkpoint_id", json.Value{ .string = parent_id });
         }
 
         return json.Value{ .object = obj };
@@ -334,7 +336,7 @@ pub const Checkpoint = struct {
                     for (messages_val.array.items) |msg_val| {
                         if (msg_val == .object) {
                             var mut_obj = msg_val.object;
-                            mut_obj.deinit();
+                            mut_obj.deinit(self.allocator);
                         }
                     }
                     // Free the array backing storage
@@ -342,16 +344,16 @@ pub const Checkpoint = struct {
                     mut_array.deinit();
                 }
             }
-            json_obj.object.deinit();
+            json_obj.object.deinit(self.allocator);
         }
 
         var buffer: [16384]u8 = undefined;
         var fba = std.heap.FixedBufferAllocator.init(&buffer);
         const fba_alloc = fba.allocator();
-        var string_list: std.ArrayList(u8) = .{};
+        var string_list: std.ArrayList(u8) = .empty;
         defer string_list.deinit(fba_alloc);
 
-        try std.fmt.format(string_list.writer(fba_alloc), "{f}", .{json.fmt(json_obj, .{})});
+        try string_list.print(fba_alloc, "{f}", .{json.fmt(json_obj, .{})});
         return try self.allocator.dupe(u8, string_list.items);
     }
 
@@ -387,13 +389,13 @@ pub const Checkpoint = struct {
         const step_number: usize = @intCast(step_number_val.integer);
 
         // Parse state (deep copy to avoid dangling pointers after parsed.deinit())
-        var state = json.Value{ .object = json.ObjectMap.init(allocator) };
+        var state = json.Value{ .object = json.ObjectMap.empty };
         if (obj.get("state")) |state_val| {
             state = try deepCopyJsonValue(allocator, state_val);
         }
 
         // Parse messages
-        var messages: std.ArrayList(Message) = .{};
+        var messages: std.ArrayList(Message) = .empty;
         if (obj.get("messages")) |messages_val| {
             for (messages_val.array.items) |msg_val| {
                 const msg = try Message.fromJson(allocator, msg_val);
@@ -402,7 +404,7 @@ pub const Checkpoint = struct {
         }
 
         // Parse metadata (deep copy to avoid dangling pointers after parsed.deinit())
-        var metadata = json.Value{ .object = json.ObjectMap.init(allocator) };
+        var metadata = json.Value{ .object = json.ObjectMap.empty };
         if (obj.get("metadata")) |metadata_val| {
             metadata = try deepCopyJsonValue(allocator, metadata_val);
         }
@@ -434,7 +436,7 @@ pub const Checkpoint = struct {
 ///   UUID string (caller owns memory)
 fn generateUuid(allocator: Allocator) ![]const u8 {
     var uuid: [16]u8 = undefined;
-    std.crypto.random.bytes(&uuid);
+    ioc.randomBytes(&uuid);
 
     // Set version (4) and variant (10)
     uuid[6] = (uuid[6] & 0x0F) | 0x40;
@@ -510,9 +512,9 @@ fn parseTimestamp(timestamp_str: []const u8) !i64 {
     // This is a simplified calculation - for production use std.time epoch calculations
     const days_since_epoch = daysSinceEpoch(year, month, day);
     const seconds: i64 = @as(i64, days_since_epoch) * 86400 +
-                        @as(i64, hour) * 3600 +
-                        @as(i64, minute) * 60 +
-                        @as(i64, second);
+        @as(i64, hour) * 3600 +
+        @as(i64, minute) * 60 +
+        @as(i64, second);
 
     return seconds * 1000 + @as(i64, milliseconds);
 }

--- a/agenkit-zig/src/infrastructure/checkpointing/durable.zig
+++ b/agenkit-zig/src/infrastructure/checkpointing/durable.zig
@@ -40,16 +40,17 @@ const SessionState = struct {
     resumed: bool,
 
     fn init(allocator: Allocator) SessionState {
+        _ = allocator; // containers start empty (unmanaged); allocator supplied at use sites
         return .{
-            .state = std.json.ObjectMap.init(allocator),
+            .state = std.json.ObjectMap.empty,
             .steps = 0,
-            .messages = .{},
+            .messages = .empty,
             .resumed = false,
         };
     }
 
     fn deinit(self: *SessionState, allocator: Allocator) void {
-        self.state.deinit();
+        self.state.deinit(allocator);
         for (self.messages.items) |*msg| {
             msg.deinit();
         }
@@ -244,13 +245,13 @@ pub const DurableAgent = struct {
         const session = gop.value_ptr;
 
         // Clear old state
-        session.state.deinit();
-        session.state = std.json.ObjectMap.init(self.allocator);
+        session.state.deinit(self.allocator);
+        session.state = std.json.ObjectMap.empty;
 
         // Restore state
         var iter = chkpt.?.state.object.iterator();
         while (iter.next()) |entry| {
-            try session.state.put(entry.key_ptr.*, entry.value_ptr.*);
+            try session.state.put(self.allocator, entry.key_ptr.*, entry.value_ptr.*);
         }
 
         session.steps = chkpt.?.step_number;
@@ -324,13 +325,13 @@ pub const DurableAgent = struct {
         const message_count_val = session.state.get("message_count") orelse std.json.Value{ .integer = 0 };
         const message_count = if (message_count_val == .integer) @as(i64, message_count_val.integer) else 0;
 
-        try session.state.put("message_count", std.json.Value{ .integer = message_count + 1 });
+        try session.state.put(self.allocator, "message_count", std.json.Value{ .integer = message_count + 1 });
 
         const input_text = try input_message.contentAsText();
         const output_text = try output_message.contentAsText();
 
-        try session.state.put("last_input", std.json.Value{ .string = input_text });
-        try session.state.put("last_output", std.json.Value{ .string = output_text });
+        try session.state.put(self.allocator, "last_input", std.json.Value{ .string = input_text });
+        try session.state.put(self.allocator, "last_output", std.json.Value{ .string = output_text });
     }
 
     /// List checkpoints for session.
@@ -351,9 +352,9 @@ pub const DurableAgent = struct {
 
         const session = self.sessions.get(session_id);
         if (session) |s| {
-            try checkpoint_stats.object.put("current_step", std.json.Value{ .integer = @intCast(s.steps) });
-            try checkpoint_stats.object.put("message_count", std.json.Value{ .integer = @intCast(s.messages.items.len) });
-            try checkpoint_stats.object.put("state_size", std.json.Value{ .integer = @intCast(s.state.count()) });
+            try checkpoint_stats.object.put(self.allocator, "current_step", std.json.Value{ .integer = @intCast(s.steps) });
+            try checkpoint_stats.object.put(self.allocator, "message_count", std.json.Value{ .integer = @intCast(s.messages.items.len) });
+            try checkpoint_stats.object.put(self.allocator, "state_size", std.json.Value{ .integer = @intCast(s.state.count()) });
         }
 
         return checkpoint_stats;

--- a/agenkit-zig/src/infrastructure/checkpointing/manager.zig
+++ b/agenkit-zig/src/infrastructure/checkpointing/manager.zig
@@ -74,12 +74,12 @@ pub const CheckpointManager = struct {
                 return .{ .array = array_copy };
             },
             .object => |obj| {
-                var object_copy = std.json.ObjectMap.init(self.allocator);
+                var object_copy = std.json.ObjectMap.empty;
                 var iter = obj.iterator();
                 while (iter.next()) |entry| {
                     const key_copy = try self.allocator.dupe(u8, entry.key_ptr.*);
                     const value_copy = try self.deepCopyJsonValue(entry.value_ptr.*);
-                    try object_copy.put(key_copy, value_copy);
+                    try object_copy.put(self.allocator, key_copy, value_copy);
                 }
                 return .{ .object = object_copy };
             },
@@ -315,33 +315,33 @@ pub const CheckpointManager = struct {
         }
 
         if (checkpoints.len == 0) {
-            var obj = std.json.ObjectMap.init(self.allocator);
-            try obj.put("total_checkpoints", .{ .integer = 0 });
-            try obj.put("first_checkpoint", .null);
-            try obj.put("latest_checkpoint", .null);
-            try obj.put("steps_covered", .{ .integer = 0 });
+            var obj = std.json.ObjectMap.empty;
+            try obj.put(self.allocator, "total_checkpoints", .{ .integer = 0 });
+            try obj.put(self.allocator, "first_checkpoint", .null);
+            try obj.put(self.allocator, "latest_checkpoint", .null);
+            try obj.put(self.allocator, "steps_covered", .{ .integer = 0 });
             return std.json.Value{ .object = obj };
         }
 
         const first_checkpoint = checkpoints[checkpoints.len - 1];
         const latest_checkpoint = checkpoints[0];
 
-        var obj = std.json.ObjectMap.init(self.allocator);
-        try obj.put("total_checkpoints", .{ .integer = @intCast(checkpoints.len) });
-        try obj.put("first_checkpoint", .{ .string = first_checkpoint.checkpoint_id });
-        try obj.put("latest_checkpoint", .{ .string = latest_checkpoint.checkpoint_id });
-        try obj.put("first_step", .{ .integer = @intCast(first_checkpoint.step_number) });
-        try obj.put("latest_step", .{ .integer = @intCast(latest_checkpoint.step_number) });
+        var obj = std.json.ObjectMap.empty;
+        try obj.put(self.allocator, "total_checkpoints", .{ .integer = @intCast(checkpoints.len) });
+        try obj.put(self.allocator, "first_checkpoint", .{ .string = first_checkpoint.checkpoint_id });
+        try obj.put(self.allocator, "latest_checkpoint", .{ .string = latest_checkpoint.checkpoint_id });
+        try obj.put(self.allocator, "first_step", .{ .integer = @intCast(first_checkpoint.step_number) });
+        try obj.put(self.allocator, "latest_step", .{ .integer = @intCast(latest_checkpoint.step_number) });
 
         // Calculate steps_covered safely (handle case where order might be reversed)
         const steps_covered = if (latest_checkpoint.step_number >= first_checkpoint.step_number)
             latest_checkpoint.step_number - first_checkpoint.step_number
         else
             0;
-        try obj.put("steps_covered", .{ .integer = @intCast(steps_covered) });
+        try obj.put(self.allocator, "steps_covered", .{ .integer = @intCast(steps_covered) });
 
         const time_span = @as(f64, @floatFromInt(latest_checkpoint.timestamp - first_checkpoint.timestamp)) / 1000.0;
-        try obj.put("time_span_seconds", .{ .float = time_span });
+        try obj.put(self.allocator, "time_span_seconds", .{ .float = time_span });
 
         return std.json.Value{ .object = obj };
     }
@@ -436,7 +436,7 @@ test "CheckpointManager createCheckpoint and getLatest" {
     defer manager.deinit();
 
     // Create empty state
-    var state = std.json.Value{ .object = std.json.ObjectMap.init(allocator) };
+    var state = std.json.Value{ .object = std.json.ObjectMap.empty };
     defer state.object.deinit();
 
     const messages = try allocator.alloc(Message, 0);
@@ -480,7 +480,7 @@ test "CheckpointManager deleteSession" {
     defer manager.deinit();
 
     // Create empty state
-    var state = std.json.Value{ .object = std.json.ObjectMap.init(allocator) };
+    var state = std.json.Value{ .object = std.json.ObjectMap.empty };
     defer state.object.deinit();
 
     const messages = try allocator.alloc(Message, 0);

--- a/agenkit-zig/src/infrastructure/checkpointing/storage.zig
+++ b/agenkit-zig/src/infrastructure/checkpointing/storage.zig
@@ -11,6 +11,9 @@
 ///   try storage.save(checkpoint);
 ///   const loaded = try storage.load(checkpoint_id);
 const std = @import("std");
+const ioc = @import("../../io_compat.zig");
+const agksync = @import("../../sync_compat.zig");
+const agktime = @import("../../time_compat.zig");
 const fs = std.fs;
 const Allocator = std.mem.Allocator;
 const Checkpoint = @import("checkpoint.zig").Checkpoint;
@@ -90,7 +93,7 @@ pub const CheckpointStorage = struct {
 ///   try storage.save(&checkpoint);
 pub const InMemoryStorage = struct {
     allocator: Allocator,
-    mutex: std.Thread.Mutex,
+    mutex: agksync.Mutex,
     checkpoints: std.StringHashMap(*Checkpoint),
     session_checkpoints: std.StringHashMap(std.ArrayList([]const u8)),
 
@@ -141,7 +144,7 @@ pub const InMemoryStorage = struct {
         const gop = try self.session_checkpoints.getOrPut(session_id);
 
         if (!gop.found_existing) {
-            gop.value_ptr.* = .{};
+            gop.value_ptr.* = .empty;
         }
 
         // Check if already in list
@@ -270,7 +273,7 @@ pub const InMemoryStorage = struct {
     }
 
     pub fn getCheckpointHistory(self: *InMemoryStorage, checkpoint_id: []const u8, max_depth: usize) ![]const *Checkpoint {
-        var history: std.ArrayList(*Checkpoint) = .{};
+        var history: std.ArrayList(*Checkpoint) = .empty;
         defer history.deinit(self.allocator);
 
         var current_id = checkpoint_id;
@@ -362,12 +365,12 @@ pub const InMemoryStorage = struct {
                 return .{ .array = array_copy };
             },
             .object => |obj| {
-                var object_copy = std.json.ObjectMap.init(self.allocator);
+                var object_copy = std.json.ObjectMap.empty;
                 var iter = obj.iterator();
                 while (iter.next()) |entry| {
                     const key_copy = try self.allocator.dupe(u8, entry.key_ptr.*);
                     const value_copy = try self.copyJsonValue(entry.value_ptr.*);
-                    try object_copy.put(key_copy, value_copy);
+                    try object_copy.put(self.allocator, key_copy, value_copy);
                 }
                 return .{ .object = object_copy };
             },
@@ -376,21 +379,21 @@ pub const InMemoryStorage = struct {
 
     fn copyCheckpoint(self: *InMemoryStorage, checkpoint: *const Checkpoint) !Checkpoint {
         // Deep copy state ObjectMap (including keys and values)
-        var state_copy = std.json.ObjectMap.init(self.allocator);
+        var state_copy = std.json.ObjectMap.empty;
         var state_iter = checkpoint.state.object.iterator();
         while (state_iter.next()) |entry| {
             const key_copy = try self.allocator.dupe(u8, entry.key_ptr.*);
             const value_copy = try self.copyJsonValue(entry.value_ptr.*);
-            try state_copy.put(key_copy, value_copy);
+            try state_copy.put(self.allocator, key_copy, value_copy);
         }
 
         // Deep copy metadata ObjectMap (including keys and values)
-        var metadata_copy = std.json.ObjectMap.init(self.allocator);
+        var metadata_copy = std.json.ObjectMap.empty;
         var metadata_iter = checkpoint.metadata.object.iterator();
         while (metadata_iter.next()) |entry| {
             const key_copy = try self.allocator.dupe(u8, entry.key_ptr.*);
             const value_copy = try self.copyJsonValue(entry.value_ptr.*);
-            try metadata_copy.put(key_copy, value_copy);
+            try metadata_copy.put(self.allocator, key_copy, value_copy);
         }
 
         // Create a deep copy of the checkpoint
@@ -446,7 +449,7 @@ pub const FileStorage = struct {
 
     pub fn init(allocator: Allocator, checkpoint_dir: []const u8) !FileStorage {
         // Create directory if it doesn't exist
-        fs.cwd().makePath(checkpoint_dir) catch |err| switch (err) {
+        std.Io.Dir.cwd().createDirPath(ioc.io(), checkpoint_dir) catch |err| switch (err) {
             error.PathAlreadyExists => {},
             else => return err,
         };
@@ -466,7 +469,7 @@ pub const FileStorage = struct {
         const session_dir = try self.getSessionDir(checkpoint.session_id);
         defer self.allocator.free(session_dir);
 
-        fs.cwd().makePath(session_dir) catch |err| switch (err) {
+        std.Io.Dir.cwd().createDirPath(ioc.io(), session_dir) catch |err| switch (err) {
             error.PathAlreadyExists => {},
             else => return err,
         };
@@ -479,19 +482,19 @@ pub const FileStorage = struct {
         const checkpoint_path = try self.getCheckpointPath(checkpoint.session_id, checkpoint.checkpoint_id);
         defer self.allocator.free(checkpoint_path);
 
-        const file = try fs.cwd().createFile(checkpoint_path, .{});
-        defer file.close();
+        const file = try std.Io.Dir.cwd().createFile(ioc.io(), checkpoint_path, .{});
+        defer file.close(ioc.io());
 
-        try file.writeAll(json_data);
+        try file.writeStreamingAll(ioc.io(), json_data);
     }
 
     pub fn load(self: *FileStorage, checkpoint_id: []const u8) !?*Checkpoint {
         // Search through session directories
-        var checkpoint_dir = try fs.cwd().openDir(self.checkpoint_dir, .{ .iterate = true });
-        defer checkpoint_dir.close();
+        var checkpoint_dir = try std.Io.Dir.cwd().openDir(ioc.io(), self.checkpoint_dir, .{ .iterate = true });
+        defer checkpoint_dir.close(ioc.io());
 
         var dir_iter = checkpoint_dir.iterate();
-        while (try dir_iter.next()) |entry| {
+        while (try dir_iter.next(ioc.io())) |entry| {
             if (entry.kind != .directory) continue;
 
             const checkpoint_filename = try std.fmt.allocPrint(self.allocator, "{s}.json", .{checkpoint_id});
@@ -505,13 +508,10 @@ pub const FileStorage = struct {
             defer self.allocator.free(checkpoint_path);
 
             // Check if file exists
-            const file = fs.cwd().openFile(checkpoint_path, .{}) catch |err| switch (err) {
+            const json_data = std.Io.Dir.cwd().readFileAlloc(ioc.io(), checkpoint_path, self.allocator, .limited(10 * 1024 * 1024)) catch |err| switch (err) {
                 error.FileNotFound => continue,
                 else => return err,
             };
-            defer file.close();
-
-            const json_data = try file.readToEndAlloc(self.allocator, 10 * 1024 * 1024); // 10MB max
             defer self.allocator.free(json_data);
 
             const checkpoint = try self.allocator.create(Checkpoint);
@@ -526,17 +526,17 @@ pub const FileStorage = struct {
         const session_dir_path = try self.getSessionDir(session_id);
         defer self.allocator.free(session_dir_path);
 
-        var session_dir = fs.cwd().openDir(session_dir_path, .{ .iterate = true }) catch |err| switch (err) {
+        var session_dir = std.Io.Dir.cwd().openDir(ioc.io(), session_dir_path, .{ .iterate = true }) catch |err| switch (err) {
             error.FileNotFound => return &[_]*Checkpoint{},
             else => return err,
         };
-        defer session_dir.close();
+        defer session_dir.close(ioc.io());
 
-        var checkpoints: std.ArrayList(*Checkpoint) = .{};
+        var checkpoints: std.ArrayList(*Checkpoint) = .empty;
         defer checkpoints.deinit(self.allocator);
 
         var dir_iter = session_dir.iterate();
-        while (try dir_iter.next()) |entry| {
+        while (try dir_iter.next(ioc.io())) |entry| {
             if (entry.kind != .file) continue;
             if (!std.mem.endsWith(u8, entry.name, ".json")) continue;
 
@@ -547,10 +547,7 @@ pub const FileStorage = struct {
             );
             defer self.allocator.free(file_path);
 
-            const file = fs.cwd().openFile(file_path, .{}) catch continue;
-            defer file.close();
-
-            const json_data = file.readToEndAlloc(self.allocator, 10 * 1024 * 1024) catch continue;
+            const json_data = std.Io.Dir.cwd().readFileAlloc(ioc.io(), file_path, self.allocator, .limited(10 * 1024 * 1024)) catch continue;
             defer self.allocator.free(json_data);
 
             const checkpoint = self.allocator.create(Checkpoint) catch continue;
@@ -601,11 +598,11 @@ pub const FileStorage = struct {
 
     pub fn delete(self: *FileStorage, checkpoint_id: []const u8) !bool {
         // Search through session directories
-        var checkpoint_dir = try fs.cwd().openDir(self.checkpoint_dir, .{ .iterate = true });
-        defer checkpoint_dir.close();
+        var checkpoint_dir = try std.Io.Dir.cwd().openDir(ioc.io(), self.checkpoint_dir, .{ .iterate = true });
+        defer checkpoint_dir.close(ioc.io());
 
         var dir_iter = checkpoint_dir.iterate();
-        while (try dir_iter.next()) |entry| {
+        while (try dir_iter.next(ioc.io())) |entry| {
             if (entry.kind != .directory) continue;
 
             const checkpoint_filename = try std.fmt.allocPrint(self.allocator, "{s}.json", .{checkpoint_id});
@@ -618,7 +615,7 @@ pub const FileStorage = struct {
             );
             defer self.allocator.free(checkpoint_path);
 
-            fs.cwd().deleteFile(checkpoint_path) catch |err| switch (err) {
+            std.Io.Dir.cwd().deleteFile(ioc.io(), checkpoint_path) catch |err| switch (err) {
                 error.FileNotFound => continue,
                 else => return err,
             };
@@ -633,15 +630,15 @@ pub const FileStorage = struct {
         const session_dir_path = try self.getSessionDir(session_id);
         defer self.allocator.free(session_dir_path);
 
-        var session_dir = fs.cwd().openDir(session_dir_path, .{ .iterate = true }) catch |err| switch (err) {
+        var session_dir = std.Io.Dir.cwd().openDir(ioc.io(), session_dir_path, .{ .iterate = true }) catch |err| switch (err) {
             error.FileNotFound => return 0,
             else => return err,
         };
-        defer session_dir.close();
+        defer session_dir.close(ioc.io());
 
         var count: usize = 0;
         var dir_iter = session_dir.iterate();
-        while (try dir_iter.next()) |entry| {
+        while (try dir_iter.next(ioc.io())) |entry| {
             if (entry.kind != .file) continue;
             if (!std.mem.endsWith(u8, entry.name, ".json")) continue;
 
@@ -652,18 +649,18 @@ pub const FileStorage = struct {
             );
             defer self.allocator.free(file_path);
 
-            fs.cwd().deleteFile(file_path) catch continue;
+            std.Io.Dir.cwd().deleteFile(ioc.io(), file_path) catch continue;
             count += 1;
         }
 
         // Try to remove session directory
-        fs.cwd().deleteDir(session_dir_path) catch {};
+        std.Io.Dir.cwd().deleteDir(ioc.io(), session_dir_path) catch {};
 
         return count;
     }
 
     pub fn getCheckpointHistory(self: *FileStorage, checkpoint_id: []const u8, max_depth: usize) ![]const *Checkpoint {
-        var history: std.ArrayList(*Checkpoint) = .{};
+        var history: std.ArrayList(*Checkpoint) = .empty;
         defer history.deinit(self.allocator);
 
         var current_id_buf: [256]u8 = undefined;
@@ -842,7 +839,7 @@ test "InMemoryStorage getLatest" {
     defer checkpoint1.deinit();
     try storage.save(&checkpoint1);
 
-    std.time.sleep(1 * std.time.ns_per_ms); // Small delay to ensure different timestamps
+    agktime.sleep(1 * std.time.ns_per_ms); // Small delay to ensure different timestamps
 
     var checkpoint2 = try Checkpoint.init(allocator, "session-1", "assistant", 2);
     defer checkpoint2.deinit();

--- a/agenkit-zig/src/infrastructure/health.zig
+++ b/agenkit-zig/src/infrastructure/health.zig
@@ -5,6 +5,8 @@
 // - Prometheus metrics export
 
 const std = @import("std");
+const agksync = @import("../sync_compat.zig");
+const agktime = @import("../time_compat.zig");
 const Agent = @import("../agent.zig").Agent;
 const Message = @import("../message.zig").Message;
 
@@ -105,7 +107,7 @@ pub const HealthMetrics = struct {
             .last_check_time = std.AutoHashMap(ProbeType, i64).init(allocator),
             .last_check_duration = std.AutoHashMap(ProbeType, f64).init(allocator),
             .consecutive_failures = std.AutoHashMap(ProbeType, usize).init(allocator),
-            .uptime_start = std.time.milliTimestamp(),
+            .uptime_start = agktime.milliTimestamp(),
         };
     }
 
@@ -119,7 +121,7 @@ pub const HealthMetrics = struct {
     }
 
     pub fn getUptime(self: *const HealthMetrics) f64 {
-        const now = std.time.milliTimestamp();
+        const now = agktime.milliTimestamp();
         return @as(f64, @floatFromInt(now - self.uptime_start)) / 1000.0;
     }
 };
@@ -133,7 +135,7 @@ pub const HealthChecker = struct {
     is_alive: bool,
     is_ready: bool,
     startup_complete: bool,
-    mutex: std.Thread.Mutex,
+    mutex: agksync.Mutex,
 
     pub fn init(
         allocator: std.mem.Allocator,
@@ -148,7 +150,7 @@ pub const HealthChecker = struct {
             .is_alive = true,
             .is_ready = false,
             .startup_complete = false,
-            .mutex = std.Thread.Mutex{},
+            .mutex = agksync.Mutex{},
         };
     }
 
@@ -163,7 +165,7 @@ pub const HealthChecker = struct {
     }
 
     pub fn checkLiveness(self: *HealthChecker) !HealthCheckResult {
-        const start_time = std.time.milliTimestamp();
+        const start_time = agktime.milliTimestamp();
         const probe_type = ProbeType.liveness;
 
         try self.trackCheckStarted(probe_type);
@@ -174,33 +176,33 @@ pub const HealthChecker = struct {
         self.allocator.free(caps);
 
         // Success
-        const duration = @as(f64, @floatFromInt(std.time.milliTimestamp() - start_time));
+        const duration = @as(f64, @floatFromInt(agktime.milliTimestamp() - start_time));
         try self.trackCheckSuccess(probe_type, duration);
 
         return HealthCheckResult{
             .status = .healthy,
             .probe_type = probe_type,
             .message = "Agent process is alive",
-            .timestamp = std.time.milliTimestamp(),
+            .timestamp = agktime.milliTimestamp(),
             .duration_ms = duration,
         };
     }
 
     pub fn checkReadiness(self: *HealthChecker) !HealthCheckResult {
-        const start_time = std.time.milliTimestamp();
+        const start_time = agktime.milliTimestamp();
         const probe_type = ProbeType.readiness;
 
         try self.trackCheckStarted(probe_type);
 
         // Check if startup completed
         if (self.config.startup_enabled and !self.startup_complete) {
-            const duration = @as(f64, @floatFromInt(std.time.milliTimestamp() - start_time));
+            const duration = @as(f64, @floatFromInt(agktime.milliTimestamp() - start_time));
             try self.trackCheckFailure(probe_type, duration);
             return HealthCheckResult{
                 .status = .unhealthy,
                 .probe_type = probe_type,
                 .message = "Startup not complete",
-                .timestamp = std.time.milliTimestamp(),
+                .timestamp = agktime.milliTimestamp(),
                 .duration_ms = duration,
             };
         }
@@ -213,7 +215,7 @@ pub const HealthChecker = struct {
         };
 
         const result = self.agent.process(test_msg);
-        const duration = @as(f64, @floatFromInt(std.time.milliTimestamp() - start_time));
+        const duration = @as(f64, @floatFromInt(agktime.milliTimestamp() - start_time));
 
         if (result) |response| {
             if (response.content.len == 0) {
@@ -222,7 +224,7 @@ pub const HealthChecker = struct {
                     .status = .unhealthy,
                     .probe_type = probe_type,
                     .message = "Readiness check failed: empty response",
-                    .timestamp = std.time.milliTimestamp(),
+                    .timestamp = agktime.milliTimestamp(),
                     .duration_ms = duration,
                 };
             }
@@ -233,7 +235,7 @@ pub const HealthChecker = struct {
                 .status = .healthy,
                 .probe_type = probe_type,
                 .message = "Agent is ready to handle requests",
-                .timestamp = std.time.milliTimestamp(),
+                .timestamp = agktime.milliTimestamp(),
                 .duration_ms = duration,
             };
         } else |_| {
@@ -242,14 +244,14 @@ pub const HealthChecker = struct {
                 .status = .unhealthy,
                 .probe_type = probe_type,
                 .message = "Readiness check failed",
-                .timestamp = std.time.milliTimestamp(),
+                .timestamp = agktime.milliTimestamp(),
                 .duration_ms = duration,
             };
         }
     }
 
     pub fn checkStartup(self: *HealthChecker) !HealthCheckResult {
-        const start_time = std.time.milliTimestamp();
+        const start_time = agktime.milliTimestamp();
         const probe_type = ProbeType.startup;
 
         try self.trackCheckStarted(probe_type);
@@ -262,26 +264,26 @@ pub const HealthChecker = struct {
             self.startup_complete = true;
             self.mutex.unlock();
 
-            const duration = @as(f64, @floatFromInt(std.time.milliTimestamp() - start_time));
+            const duration = @as(f64, @floatFromInt(agktime.milliTimestamp() - start_time));
             try self.trackCheckSuccess(probe_type, duration);
 
             return HealthCheckResult{
                 .status = .healthy,
                 .probe_type = probe_type,
                 .message = "Startup complete",
-                .timestamp = std.time.milliTimestamp(),
+                .timestamp = agktime.milliTimestamp(),
                 .duration_ms = duration,
             };
         }
 
-        const duration = @as(f64, @floatFromInt(std.time.milliTimestamp() - start_time));
+        const duration = @as(f64, @floatFromInt(agktime.milliTimestamp() - start_time));
         try self.trackCheckFailure(probe_type, duration);
 
         return HealthCheckResult{
             .status = .unhealthy,
             .probe_type = probe_type,
             .message = "Startup checks not passing yet",
-            .timestamp = std.time.milliTimestamp(),
+            .timestamp = agktime.milliTimestamp(),
             .duration_ms = duration,
         };
     }
@@ -309,7 +311,7 @@ pub const HealthChecker = struct {
             entry.value_ptr.* = 1;
         }
 
-        try self.metrics.last_check_time.put(probe_type, std.time.milliTimestamp());
+        try self.metrics.last_check_time.put(probe_type, agktime.milliTimestamp());
         try self.metrics.last_check_duration.put(probe_type, duration_ms);
         try self.metrics.consecutive_failures.put(probe_type, 0);
     }
@@ -325,7 +327,7 @@ pub const HealthChecker = struct {
             entry.value_ptr.* = 1;
         }
 
-        try self.metrics.last_check_time.put(probe_type, std.time.milliTimestamp());
+        try self.metrics.last_check_time.put(probe_type, agktime.milliTimestamp());
         try self.metrics.last_check_duration.put(probe_type, duration_ms);
 
         const failures_entry = try self.metrics.consecutive_failures.getOrPut(probe_type);
@@ -340,7 +342,7 @@ pub const HealthChecker = struct {
         self.mutex.lock();
         defer self.mutex.unlock();
 
-        var lines = std.ArrayList([]const u8).init(allocator);
+        var lines = std.ArrayList([]const u8).empty;
         defer lines.deinit();
 
         // Total checks

--- a/agenkit-zig/src/infrastructure/load_balancer.zig
+++ b/agenkit-zig/src/infrastructure/load_balancer.zig
@@ -6,6 +6,8 @@
 // - Thread-safe for concurrent requests
 
 const std = @import("std");
+const agksync = @import("../sync_compat.zig");
+const agktime = @import("../time_compat.zig");
 const Agent = @import("../agent.zig").Agent;
 const Message = @import("../message.zig").Message;
 
@@ -36,7 +38,7 @@ pub const AgentBackend = struct {
             .active_connections = 0,
             .total_requests = 0,
             .total_failures = 0,
-            .last_health_check = std.time.milliTimestamp(),
+            .last_health_check = agktime.milliTimestamp(),
             .consecutive_failures = 0,
         };
     }
@@ -103,7 +105,7 @@ pub const LoadBalancer = struct {
     config: LoadBalancerConfig,
     metrics: LoadBalancerMetrics,
     current_index: usize,
-    mutex: std.Thread.Mutex,
+    mutex: agksync.Mutex,
 
     pub fn init(
         allocator: std.mem.Allocator,
@@ -144,7 +146,7 @@ pub const LoadBalancer = struct {
             .config = config,
             .metrics = LoadBalancerMetrics.init(allocator),
             .current_index = 0,
-            .mutex = std.Thread.Mutex{},
+            .mutex = agksync.Mutex{},
         };
     }
 
@@ -204,7 +206,7 @@ pub const LoadBalancer = struct {
         self.mutex.lock();
         defer self.mutex.unlock();
 
-        var healthy_indices = std.ArrayList(usize).init(self.allocator);
+        var healthy_indices = std.ArrayList(usize).empty;
         defer healthy_indices.deinit();
 
         for (self.backends, 0..) |backend, i| {
@@ -222,7 +224,7 @@ pub const LoadBalancer = struct {
             .least_connections => self.selectLeastConnections(healthy_indices.items),
             .weighted_round_robin => self.selectWeightedRoundRobin(healthy_indices.items),
             .random => blk: {
-                var prng = std.rand.DefaultPrng.init(@intCast(std.time.milliTimestamp()));
+                var prng = std.Random.DefaultPrng.init(@intCast(agktime.milliTimestamp()));
                 const rand = prng.random();
                 const index = rand.intRangeAtMost(usize, 0, healthy_indices.items.len - 1);
                 break :blk healthy_indices.items[index];
@@ -266,7 +268,7 @@ pub const LoadBalancer = struct {
 
     fn selectWeightedRoundRobin(self: *LoadBalancer, healthy_indices: []const usize) !usize {
         // Build weighted list
-        var weighted = std.ArrayList(usize).init(self.allocator);
+        var weighted = std.ArrayList(usize).empty;
         defer weighted.deinit();
 
         for (healthy_indices) |index| {

--- a/agenkit-zig/src/infrastructure/memory/base.zig
+++ b/agenkit-zig/src/infrastructure/memory/base.zig
@@ -26,13 +26,15 @@
 /// const entries = try mem_store.retrieve("session-123", 10);
 /// ```
 const std = @import("std");
+const ioc = @import("../../io_compat.zig");
+const agktime = @import("../../time_compat.zig");
 const json = std.json;
 const Allocator = std.mem.Allocator;
 
 /// Generate a UUID v4 string.
 fn generateUuid(allocator: Allocator) ![]const u8 {
     var uuid: [16]u8 = undefined;
-    std.crypto.random.bytes(&uuid);
+    ioc.randomBytes(&uuid);
 
     // Set version (4) and variant bits
     uuid[6] = (uuid[6] & 0x0f) | 0x40;
@@ -132,9 +134,9 @@ pub const MemoryEntry = struct {
             .session_id = try allocator.dupe(u8, session_id),
             .role = role,
             .content = try allocator.dupe(u8, content),
-            .timestamp = std.time.milliTimestamp(),
+            .timestamp = agktime.milliTimestamp(),
             .importance = 0.5, // Default neutral importance
-            .metadata = json.Value{ .object = json.ObjectMap.init(allocator) },
+            .metadata = json.Value{ .object = json.ObjectMap.empty },
             .allocator = allocator,
         };
     }
@@ -150,7 +152,7 @@ pub const MemoryEntry = struct {
         while (iter.next()) |entry| {
             self.allocator.free(entry.key_ptr.*);
         }
-        self.metadata.object.deinit();
+        self.metadata.object.deinit(self.allocator);
     }
 
     /// Set importance score.

--- a/agenkit-zig/src/infrastructure/memory/hierarchy.zig
+++ b/agenkit-zig/src/infrastructure/memory/hierarchy.zig
@@ -29,6 +29,7 @@
 /// const entries = try hierarchy.retrieve("session-1", 20);
 /// ```
 const std = @import("std");
+const agksync = @import("../../sync_compat.zig");
 const Allocator = std.mem.Allocator;
 const MemoryEntry = @import("base.zig").MemoryEntry;
 const Memory = @import("base.zig").Memory;
@@ -72,7 +73,7 @@ pub const Tier = enum {
 pub const HierarchyMemory = struct {
     allocator: Allocator,
     config: HierarchyConfig,
-    mutex: std.Thread.Mutex,
+    mutex: agksync.Mutex,
 
     // Three memory tiers
     working: InMemoryMemory,
@@ -166,7 +167,7 @@ pub const HierarchyMemory = struct {
         self.mutex.lock();
         defer self.mutex.unlock();
 
-        var result = std.ArrayListUnmanaged(*MemoryEntry){};
+        var result = std.ArrayListUnmanaged(*MemoryEntry).empty;
         defer result.deinit(self.allocator);
 
         var seen = std.StringHashMap(void).init(self.allocator);
@@ -308,7 +309,7 @@ pub const HierarchyMemory = struct {
 
         // Clear tier map entries for this session
         var iter = self.tier_map.iterator();
-        var keys_to_remove = std.ArrayListUnmanaged([]const u8){};
+        var keys_to_remove = std.ArrayListUnmanaged([]const u8).empty;
         defer keys_to_remove.deinit(self.allocator);
 
         while (iter.next()) |entry| {

--- a/agenkit-zig/src/infrastructure/memory/in_memory.zig
+++ b/agenkit-zig/src/infrastructure/memory/in_memory.zig
@@ -29,6 +29,7 @@
 /// const entries = try memory.retrieve("session-1", 10);
 /// ```
 const std = @import("std");
+const agksync = @import("../../sync_compat.zig");
 const Allocator = std.mem.Allocator;
 const MemoryEntry = @import("base.zig").MemoryEntry;
 const Memory = @import("base.zig").Memory;
@@ -53,8 +54,8 @@ pub const InMemoryConfig = struct {
 /// LRU node for tracking entry access order.
 const LRUNode = struct {
     entry_id: []const u8,
-    map_key: []const u8,  // The key used in lru_nodes HashMap (for reliable removal)
-    evicted: bool,  // Set to true when node is evicted (for deinit to skip)
+    map_key: []const u8, // The key used in lru_nodes HashMap (for reliable removal)
+    evicted: bool, // Set to true when node is evicted (for deinit to skip)
     prev: ?*LRUNode,
     next: ?*LRUNode,
 };
@@ -63,7 +64,7 @@ const LRUNode = struct {
 pub const InMemoryMemory = struct {
     allocator: Allocator,
     config: InMemoryConfig,
-    mutex: std.Thread.Mutex,
+    mutex: agksync.Mutex,
 
     // Storage: session_id -> list of entries
     entries: std.StringHashMap(std.ArrayList(*MemoryEntry)),
@@ -163,7 +164,7 @@ pub const InMemoryMemory = struct {
         } else {
             // Create new session with duped key
             session_key = try self.allocator.dupe(u8, entry.session_id);
-            const new_list = std.ArrayList(*MemoryEntry){};
+            const new_list = std.ArrayList(*MemoryEntry).empty;
             try self.entries.put(session_key, new_list);
             entry_list = self.entries.getPtr(session_key).?;
         }
@@ -349,8 +350,8 @@ pub const InMemoryMemory = struct {
             const entry_id_copy = try self.allocator.dupe(u8, entry_id);
             node = try self.allocator.create(LRUNode);
             node.* = .{
-                .entry_id = entry_id_copy,  // This IS the HashMap key
-                .map_key = entry_id_copy,   // Same pointer - we'll only free once
+                .entry_id = entry_id_copy, // This IS the HashMap key
+                .map_key = entry_id_copy, // Same pointer - we'll only free once
                 .evicted = false,
                 .prev = null,
                 .next = null,
@@ -412,7 +413,7 @@ pub const InMemoryMemory = struct {
     fn evictOldest(self: *InMemoryMemory, session_id: []const u8) !void {
         const tail = self.lru_tails.get(session_id) orelse return;
         const entry_id_to_find = tail.entry_id;
-        const map_key = tail.map_key;  // The exact key used in lru_nodes
+        const map_key = tail.map_key; // The exact key used in lru_nodes
 
         // Find and remove entry from list
         if (self.entries.getPtr(session_id)) |entry_list| {

--- a/agenkit-zig/src/infrastructure/memory/redis_memory.zig
+++ b/agenkit-zig/src/infrastructure/memory/redis_memory.zig
@@ -133,14 +133,14 @@ pub const RedisMemory = struct {
         content: []const u8,
         metadata: std.StringHashMap(std.json.Value),
     ) ![]u8 {
-        var json_obj = std.json.ObjectMap.init(self.allocator);
+        var json_obj = std.json.ObjectMap.empty;
         defer json_obj.deinit();
 
         try json_obj.put("role", std.json.Value{ .string = role });
         try json_obj.put("content", std.json.Value{ .string = content });
 
         // Convert metadata to JSON object
-        var meta_obj = std.json.ObjectMap.init(self.allocator);
+        var meta_obj = std.json.ObjectMap.empty;
         defer meta_obj.deinit();
 
         var iter = metadata.iterator();
@@ -151,7 +151,7 @@ pub const RedisMemory = struct {
         try json_obj.put("metadata", std.json.Value{ .object = meta_obj });
 
         // Serialize to string
-        var string = std.ArrayList(u8).init(self.allocator);
+        var string = std.ArrayList(u8).empty;
         defer string.deinit();
 
         try std.json.stringify(json_obj, .{}, string.writer());
@@ -185,7 +185,7 @@ pub const RedisMemory = struct {
         // 4. Set TTL if configured
         //
         // Example with hiredis:
-        // const timestamp = @as(f64, @floatFromInt(std.time.timestamp()));
+        // const timestamp = @as(f64, @floatFromInt(agktime.timestamp()));
         // const value = try self.serializeMessage(role, content, metadata);
         // defer self.allocator.free(value);
         //
@@ -283,7 +283,7 @@ pub const RedisMemory = struct {
         }
 
         // Build summary
-        var summary = std.ArrayList(u8).init(self.allocator);
+        var summary = std.ArrayList(u8).empty;
         defer summary.deinit();
 
         try summary.writer().print("Session summary ({d} messages):\n", .{messages.len});

--- a/agenkit-zig/src/infrastructure/memory/strategies/importance_weighting.zig
+++ b/agenkit-zig/src/infrastructure/memory/strategies/importance_weighting.zig
@@ -21,6 +21,7 @@
 /// defer strategy.deinit();
 /// ```
 const std = @import("std");
+const agktime = @import("../../../time_compat.zig");
 const Allocator = std.mem.Allocator;
 const memory_base = @import("../base.zig");
 const MemoryEntry = memory_base.MemoryEntry;
@@ -86,7 +87,7 @@ pub const ImportanceWeightingStrategy = struct {
         var scored = try self.allocator.alloc(ScoredEntry, entries.len);
         defer self.allocator.free(scored);
 
-        const now = std.time.milliTimestamp();
+        const now = agktime.milliTimestamp();
 
         for (entries, 0..) |entry, i| {
             const age_days = @as(f32, @floatFromInt(now - entry.timestamp)) / (1000.0 * 60.0 * 60.0 * 24.0);

--- a/agenkit-zig/src/infrastructure/memory/strategies/mod.zig
+++ b/agenkit-zig/src/infrastructure/memory/strategies/mod.zig
@@ -13,7 +13,6 @@
 /// });
 /// defer sliding.deinit();
 /// ```
-
 pub const base = @import("base.zig");
 pub const MemoryStrategy = base.MemoryStrategy;
 pub const StrategyContext = base.StrategyContext;

--- a/agenkit-zig/src/infrastructure/mod.zig
+++ b/agenkit-zig/src/infrastructure/mod.zig
@@ -7,7 +7,6 @@
 /// - Load balancing: Distribute requests across multiple agents ✅
 /// - Health checks: Kubernetes-style probes with monitoring ✅
 /// - Enhanced retry: Jitter, error classification, budget awareness ✅
-
 pub const checkpointing = struct {
     pub const Checkpoint = @import("checkpointing/checkpoint.zig").Checkpoint;
     pub const CheckpointStorage = @import("checkpointing/storage.zig").CheckpointStorage;

--- a/agenkit-zig/src/infrastructure/retry_enhanced.zig
+++ b/agenkit-zig/src/infrastructure/retry_enhanced.zig
@@ -6,6 +6,8 @@
 // - Detailed metrics
 
 const std = @import("std");
+const agksync = @import("../sync_compat.zig");
+const agktime = @import("../time_compat.zig");
 const Agent = @import("../agent.zig").Agent;
 const Message = @import("../message.zig").Message;
 
@@ -178,7 +180,7 @@ pub const EnhancedRetryMetrics = struct {
             .budget_exceeded_count = 0,
             .backpressure_detected = 0,
             .error_class_counts = std.AutoHashMap(ErrorClass, u64).init(allocator),
-            .recent_results = std.ArrayList(bool).init(allocator),
+            .recent_results = std.ArrayList(bool).empty,
         };
     }
 
@@ -195,7 +197,7 @@ pub const EnhancedRetryDecorator = struct {
     config: EnhancedRetryConfig,
     metrics: EnhancedRetryMetrics,
     budget: RetryBudget,
-    mutex: std.Thread.Mutex,
+    mutex: agksync.Mutex,
 
     pub fn init(
         allocator: std.mem.Allocator,
@@ -212,9 +214,9 @@ pub const EnhancedRetryDecorator = struct {
                 .current_cost = 0.0,
                 .max_retries_per_hour = config.max_retries_per_hour,
                 .retry_count = 0,
-                .window_start = std.time.milliTimestamp(),
+                .window_start = agktime.milliTimestamp(),
             },
-            .mutex = std.Thread.Mutex{},
+            .mutex = agksync.Mutex{},
         };
     }
 
@@ -275,7 +277,7 @@ pub const EnhancedRetryDecorator = struct {
 
     fn calculateBackoff(self: *EnhancedRetryDecorator, base_backoff_ms: u64, attempt: usize) u64 {
         const base_ms = @as(f64, @floatFromInt(base_backoff_ms));
-        var prng = std.rand.DefaultPrng.init(@intCast(std.time.milliTimestamp()));
+        var prng = std.Random.DefaultPrng.init(@intCast(agktime.milliTimestamp()));
         const rand = prng.random();
 
         const jittered_ms: f64 = switch (self.config.jitter_type) {
@@ -313,10 +315,10 @@ pub const EnhancedRetryDecorator = struct {
 
         // Reset window if hour has passed
         const hour_in_ms = 3600000;
-        if (std.time.milliTimestamp() - self.budget.window_start > hour_in_ms) {
+        if (agktime.milliTimestamp() - self.budget.window_start > hour_in_ms) {
             self.budget.current_cost = 0.0;
             self.budget.retry_count = 0;
-            self.budget.window_start = std.time.milliTimestamp();
+            self.budget.window_start = agktime.milliTimestamp();
         }
 
         // Check cost budget
@@ -386,7 +388,7 @@ pub const EnhancedRetryDecorator = struct {
 
             // Check backpressure
             if (self.checkBackpressure()) {
-                std.time.sleep(5000 * std.time.ns_per_ms);
+                agktime.sleep(5000 * std.time.ns_per_ms);
             }
 
             // Process message
@@ -468,7 +470,7 @@ pub const EnhancedRetryDecorator = struct {
                 const backoff_ms = self.calculateBackoff(base_backoff_ms, attempt);
 
                 // Sleep with backoff
-                std.time.sleep(backoff_ms * std.time.ns_per_ms);
+                agktime.sleep(backoff_ms * std.time.ns_per_ms);
             }
         }
 

--- a/agenkit-zig/src/introspection.zig
+++ b/agenkit-zig/src/introspection.zig
@@ -13,6 +13,7 @@
 /// - ArXiv: Introspection of Thought Helps AI Agents (https://arxiv.org/abs/2507.08664)
 /// - Biswas & Talukdar: Building Agentic AI Systems
 const std = @import("std");
+const agktime = @import("time_compat.zig");
 const Allocator = std.mem.Allocator;
 
 /// Result of agent introspection - a snapshot of internal state.
@@ -84,7 +85,7 @@ pub const IntrospectionResult = struct {
             return error.OutOfMemory; // Zig doesn't have custom validation errors in allocator context
         }
 
-        const timestamp = std.time.timestamp();
+        const timestamp = agktime.timestamp();
 
         return IntrospectionResult{
             .allocator = allocator,
@@ -112,16 +113,16 @@ pub const IntrospectionResult = struct {
         if (self.memory_state) |mem| {
             if (mem == .object) {
                 var obj = mem.object;
-                obj.deinit();
+                obj.deinit(self.allocator);
             }
         }
         if (self.internal_state == .object) {
             var obj = self.internal_state.object;
-            obj.deinit();
+            obj.deinit(self.allocator);
         }
         if (self.metadata == .object) {
             var obj = self.metadata.object;
-            obj.deinit();
+            obj.deinit(self.allocator);
         }
     }
 
@@ -165,8 +166,8 @@ pub fn createDefaultIntrospectionResult(
     }
 
     // Create empty JSON objects
-    const internal_state = std.json.Value{ .object = std.json.ObjectMap.init(allocator) };
-    const metadata = std.json.Value{ .object = std.json.ObjectMap.init(allocator) };
+    const internal_state = std.json.Value{ .object = std.json.ObjectMap.empty };
+    const metadata = std.json.Value{ .object = std.json.ObjectMap.empty };
 
     return IntrospectionResult.init(
         allocator,
@@ -189,8 +190,8 @@ test "IntrospectionResult - basic creation" {
     caps[0] = try allocator.dupe(u8, "test");
     caps[1] = try allocator.dupe(u8, "demo");
 
-    const internal_state = std.json.Value{ .object = std.json.ObjectMap.init(allocator) };
-    const metadata = std.json.Value{ .object = std.json.ObjectMap.init(allocator) };
+    const internal_state = std.json.Value{ .object = std.json.ObjectMap.empty };
+    const metadata = std.json.Value{ .object = std.json.ObjectMap.empty };
 
     var result = try IntrospectionResult.init(
         allocator,
@@ -214,13 +215,13 @@ test "IntrospectionResult - with memory state" {
     const caps = try allocator.alloc([]const u8, 1);
     caps[0] = try allocator.dupe(u8, "memory");
 
-    var memory = std.json.ObjectMap.init(allocator);
-    try memory.put("short_term_count", std.json.Value{ .integer = 5 });
-    try memory.put("long_term_count", std.json.Value{ .integer = 10 });
+    var memory = std.json.ObjectMap.empty;
+    try memory.put(allocator, "short_term_count", std.json.Value{ .integer = 5 });
+    try memory.put(allocator, "long_term_count", std.json.Value{ .integer = 10 });
     const memory_state = std.json.Value{ .object = memory };
 
-    const internal_state = std.json.Value{ .object = std.json.ObjectMap.init(allocator) };
-    const metadata = std.json.Value{ .object = std.json.ObjectMap.init(allocator) };
+    const internal_state = std.json.Value{ .object = std.json.ObjectMap.empty };
+    const metadata = std.json.Value{ .object = std.json.ObjectMap.empty };
 
     var result = try IntrospectionResult.init(
         allocator,
@@ -243,8 +244,8 @@ test "IntrospectionResult - validation" {
     const name = try allocator.dupe(u8, "test");
     const caps = try allocator.alloc([]const u8, 0);
 
-    const internal_state = std.json.Value{ .object = std.json.ObjectMap.init(allocator) };
-    const metadata = std.json.Value{ .object = std.json.ObjectMap.init(allocator) };
+    const internal_state = std.json.Value{ .object = std.json.ObjectMap.empty };
+    const metadata = std.json.Value{ .object = std.json.ObjectMap.empty };
 
     var result = try IntrospectionResult.init(
         allocator,
@@ -262,12 +263,12 @@ test "IntrospectionResult - validation" {
 test "IntrospectionResult - timestamp is recent" {
     const allocator = testing.allocator;
 
-    const before = std.time.timestamp();
+    const before = agktime.timestamp();
 
     const name = try allocator.dupe(u8, "test");
     const caps = try allocator.alloc([]const u8, 0);
-    const internal_state = std.json.Value{ .object = std.json.ObjectMap.init(allocator) };
-    const metadata = std.json.Value{ .object = std.json.ObjectMap.init(allocator) };
+    const internal_state = std.json.Value{ .object = std.json.ObjectMap.empty };
+    const metadata = std.json.Value{ .object = std.json.ObjectMap.empty };
 
     var result = try IntrospectionResult.init(
         allocator,
@@ -279,7 +280,7 @@ test "IntrospectionResult - timestamp is recent" {
     );
     defer result.deinit();
 
-    const after = std.time.timestamp();
+    const after = agktime.timestamp();
 
     try testing.expect(result.timestamp >= before);
     try testing.expect(result.timestamp <= after);

--- a/agenkit-zig/src/io_compat.zig
+++ b/agenkit-zig/src/io_compat.zig
@@ -1,0 +1,52 @@
+//! A process-global `std.Io` instance for blocking, synchronous I/O.
+//!
+//! Zig 0.16 routes all filesystem and clock operations through an `Io`
+//! instance (`dir.openFile(io, ...)`, `file.close(io)`, etc.) rather than the
+//! old free-standing `std.fs` API. The agenkit toolkit performs ordinary
+//! blocking file I/O and does not otherwise use the async runtime, so rather
+//! than thread an `Io` through every public signature we expose a single
+//! lazily-initialised `Io.Threaded` here and hand out its `Io` handle.
+//!
+//! This preserves the previous synchronous behaviour: callers obtain the
+//! handle with `io_compat.io()` and pass it to the new `Io`-based methods.
+
+const std = @import("std");
+
+var threaded: std.Io.Threaded = undefined;
+var initialized: bool = false;
+
+/// Returns the process-global blocking `Io` handle, initialising it on first
+/// use. Thread-safe for the first-call race only in the sense that callers in
+/// agenkit reach this from already-serialised setup paths; the underlying
+/// `Threaded` is itself thread-safe once constructed.
+pub fn io() std.Io {
+    if (!initialized) {
+        // `Allocator.failing` is acceptable here: it is only consulted by the
+        // async/group entry points (which agenkit never uses), not by the
+        // synchronous file and clock operations.
+        threaded = std.Io.Threaded.init(std.mem.Allocator.failing, .{});
+        initialized = true;
+    }
+    return threaded.io();
+}
+
+/// Convenience handle to the current working directory as an `Io.Dir`.
+pub fn cwd() std.Io.Dir {
+    return std.Io.Dir.cwd();
+}
+
+/// Fill `buffer` with cryptographically secure random bytes.
+///
+/// Replaces the removed `std.crypto.random.bytes`.
+pub fn randomBytes(buffer: []u8) void {
+    io().random(buffer);
+}
+
+/// Return a random integer of type `T`.
+///
+/// Replaces `std.crypto.random.int(T)` / `.float(T)` call sites.
+pub fn randomInt(comptime T: type) T {
+    var bytes: [@sizeOf(T)]u8 = undefined;
+    randomBytes(&bytes);
+    return std.mem.readInt(T, &bytes, .little);
+}

--- a/agenkit-zig/src/message.zig
+++ b/agenkit-zig/src/message.zig
@@ -171,7 +171,7 @@ pub const Message = struct {
         // Content size validation - max 16MB
         const content_size = switch (self.content) {
             .text => |t| t.len,
-            .structured => |_| blk: {
+            .structured => blk: {
                 // For structured content, we can't easily compute exact size
                 // without serializing. Skip size check for structured content.
                 // In practice, structured content size is validated when

--- a/agenkit-zig/src/message.zig
+++ b/agenkit-zig/src/message.zig
@@ -80,7 +80,7 @@ pub const Message = struct {
         return Message{
             .role = role,
             .content = .{ .text = owned_text },
-            .metadata = json.Value{ .object = json.ObjectMap.init(allocator) },
+            .metadata = json.Value{ .object = json.ObjectMap.empty },
             .allocator = allocator,
         };
     }
@@ -90,7 +90,7 @@ pub const Message = struct {
         return Message{
             .role = role,
             .content = .{ .structured = data },
-            .metadata = json.Value{ .object = json.ObjectMap.init(allocator) },
+            .metadata = json.Value{ .object = json.ObjectMap.empty },
             .allocator = allocator,
         };
     }
@@ -118,7 +118,7 @@ pub const Message = struct {
                     freeJsonValue(allocator, entry.value_ptr.*);
                 }
                 var mut_obj = obj;
-                mut_obj.deinit();
+                mut_obj.deinit(allocator);
             },
             else => {
                 // Don't free top-level strings - they might be static literals
@@ -134,12 +134,12 @@ pub const Message = struct {
             freeJsonValue(self.allocator, entry.value_ptr.*);
         }
         // Free the ObjectMap internal storage
-        self.metadata.object.deinit();
+        self.metadata.object.deinit(self.allocator);
     }
 
     /// Set metadata key-value pair
     pub fn setMetadata(self: *Message, key: []const u8, value: json.Value) !void {
-        try self.metadata.object.put(key, value);
+        try self.metadata.object.put(self.allocator, key, value);
     }
 
     /// Get metadata value by key
@@ -182,7 +182,7 @@ pub const Message = struct {
 
         const max_content_size = 16 * 1024 * 1024; // 16MB
         if (content_size > max_content_size) {
-            std.log.err(
+            std.log.warn(
                 "Message content exceeds maximum size of {d} bytes (got {d} bytes)",
                 .{ max_content_size, content_size },
             );
@@ -195,7 +195,7 @@ pub const Message = struct {
 
             // Max 100 keys
             if (metadata_obj.count() > 100) {
-                std.log.err(
+                std.log.warn(
                     "Message metadata exceeds maximum of 100 keys (got {d})",
                     .{metadata_obj.count()},
                 );
@@ -210,7 +210,7 @@ pub const Message = struct {
             while (it.next()) |entry| {
                 // Key length validation
                 if (entry.key_ptr.*.len > max_key_length) {
-                    std.log.err(
+                    std.log.warn(
                         "Metadata key exceeds maximum length of {d} characters (got {d})",
                         .{ max_key_length, entry.key_ptr.*.len },
                     );
@@ -222,7 +222,7 @@ pub const Message = struct {
                 if (entry.value_ptr.* == .string) {
                     const value_size = entry.value_ptr.*.string.len;
                     if (value_size > max_value_size) {
-                        std.log.err(
+                        std.log.warn(
                             "Metadata value for key '{s}' exceeds maximum size of {d} bytes (got {d} bytes)",
                             .{ entry.key_ptr.*, max_value_size, value_size },
                         );
@@ -235,23 +235,23 @@ pub const Message = struct {
 
     /// Serialize message to JSON
     pub fn toJson(self: *const Message, allocator: Allocator) !json.Value {
-        var obj = json.ObjectMap.init(allocator);
+        var obj = json.ObjectMap.empty;
 
         // Add role
-        try obj.put("role", json.Value{ .string = self.role.toString() });
+        try obj.put(allocator, "role", json.Value{ .string = self.role.toString() });
 
         // Add content
         switch (self.content) {
             .text => |t| {
-                try obj.put("content", json.Value{ .string = t });
+                try obj.put(allocator, "content", json.Value{ .string = t });
             },
             .structured => |s| {
-                try obj.put("content", s);
+                try obj.put(allocator, "content", s);
             },
         }
 
         // Add metadata
-        try obj.put("metadata", self.metadata);
+        try obj.put(allocator, "metadata", self.metadata);
 
         return json.Value{ .object = obj };
     }
@@ -274,7 +274,7 @@ pub const Message = struct {
         };
 
         // Parse metadata (optional)
-        const metadata = if (obj.get("metadata")) |m| m else json.Value{ .object = json.ObjectMap.init(allocator) };
+        const metadata = if (obj.get("metadata")) |m| m else json.Value{ .object = json.ObjectMap.empty };
 
         return Message{
             .role = role,

--- a/agenkit-zig/src/middleware/batching.zig
+++ b/agenkit-zig/src/middleware/batching.zig
@@ -31,6 +31,8 @@
 /// const result = try batching_agent.agent().process(message);
 /// ```
 const std = @import("std");
+const agksync = @import("../sync_compat.zig");
+const agktime = @import("../time_compat.zig");
 const Agent = @import("../agent.zig").Agent;
 const AgentError = @import("../agent.zig").AgentError;
 const StreamCallbacks = @import("../agent.zig").StreamCallbacks;
@@ -127,15 +129,15 @@ const BatchRequest = struct {
     enqueued_at_ms: i64,
     result: ?Result,
     error_value: ?AgentError,
-    completed: std.Thread.Condition,
+    completed: agksync.Condition,
 
     fn init(message: Message) BatchRequest {
         return BatchRequest{
             .message = message,
-            .enqueued_at_ms = std.time.milliTimestamp(),
+            .enqueued_at_ms = agktime.milliTimestamp(),
             .result = null,
             .error_value = null,
-            .completed = std.Thread.Condition{},
+            .completed = agksync.Condition{},
         };
     }
 };
@@ -147,11 +149,11 @@ pub const BatchingDecorator = struct {
     config: BatchingConfig,
     metrics_data: BatchingMetrics,
     queue: std.ArrayList(*BatchRequest),
-    queue_mutex: std.Thread.Mutex,
-    queue_condition: std.Thread.Condition,
+    queue_mutex: agksync.Mutex,
+    queue_condition: agksync.Condition,
     processor_thread: ?std.Thread,
     shutdown: std.atomic.Value(bool),
-    request_mutex: std.Thread.Mutex, // For coordinating individual requests
+    request_mutex: agksync.Mutex, // For coordinating individual requests
 
     pub fn init(allocator: Allocator, inner_agent: Agent, config: BatchingConfig) !*BatchingDecorator {
         // Validate configuration
@@ -163,12 +165,12 @@ pub const BatchingDecorator = struct {
             .inner_agent = inner_agent,
             .config = config,
             .metrics_data = BatchingMetrics{},
-            .queue = std.ArrayList(*BatchRequest).init(allocator),
-            .queue_mutex = std.Thread.Mutex{},
-            .queue_condition = std.Thread.Condition{},
+            .queue = std.ArrayList(*BatchRequest).empty,
+            .queue_mutex = agksync.Mutex{},
+            .queue_condition = agksync.Condition{},
             .processor_thread = null,
             .shutdown = std.atomic.Value(bool).init(false),
-            .request_mutex = std.Thread.Mutex{},
+            .request_mutex = agksync.Mutex{},
         };
         return self;
     }
@@ -230,7 +232,7 @@ pub const BatchingDecorator = struct {
 
     /// Collect a batch and process it
     fn collectAndProcessBatch(self: *BatchingDecorator) !void {
-        var batch = std.ArrayList(*BatchRequest).init(self.allocator);
+        var batch = std.ArrayList(*BatchRequest).empty;
         defer batch.deinit();
 
         // Wait for first request
@@ -251,11 +253,11 @@ pub const BatchingDecorator = struct {
             try batch.append(first_req);
         }
 
-        const deadline_ms = std.time.milliTimestamp() + @as(i64, @intCast(self.config.max_wait_time_ms));
+        const deadline_ms = agktime.milliTimestamp() + @as(i64, @intCast(self.config.max_wait_time_ms));
 
         // Collect more requests until batch full or timeout
         while (batch.items.len < self.config.max_batch_size) {
-            const now_ms = std.time.milliTimestamp();
+            const now_ms = agktime.milliTimestamp();
             if (now_ms >= deadline_ms) break;
 
             // Check if more requests available
@@ -266,7 +268,7 @@ pub const BatchingDecorator = struct {
                 // Wait for more requests with timeout
                 const remaining_ms = @as(u64, @intCast(deadline_ms - now_ms));
                 self.queue_mutex.unlock();
-                std.time.sleep(remaining_ms * std.time.ns_per_ms);
+                agktime.sleep(remaining_ms * std.time.ns_per_ms);
                 self.queue_mutex.lock();
 
                 // Check again after sleep
@@ -305,7 +307,7 @@ pub const BatchingDecorator = struct {
         }
 
         // Calculate wait times
-        const now_ms = std.time.milliTimestamp();
+        const now_ms = agktime.milliTimestamp();
         for (batch) |req| {
             const wait_time_ms = @as(u64, @intCast(now_ms - req.enqueued_at_ms));
             self.metrics_data.total_wait_time_ms += wait_time_ms;
@@ -475,12 +477,11 @@ pub const BatchingDecorator = struct {
 // Tests
 const testing = std.testing;
 
-
-    fn processStreamImpl(ptr: *anyopaque, message: Message, callbacks: StreamCallbacks) AgentError!void {
-        _ = ptr;
-        _ = message;
-        callbacks.onError(AgentError.NotImplemented);
-    }
+fn processStreamImpl(ptr: *anyopaque, message: Message, callbacks: StreamCallbacks) AgentError!void {
+    _ = ptr;
+    _ = message;
+    callbacks.onError(AgentError.NotImplemented);
+}
 
 test "BatchingConfig validation" {
     var config = BatchingConfig{};

--- a/agenkit-zig/src/middleware/caching.zig
+++ b/agenkit-zig/src/middleware/caching.zig
@@ -5,7 +5,7 @@
 /// - LRU (Least Recently Used) eviction when cache is full
 /// - TTL (Time To Live) based expiration with automatic cleanup
 /// - Cache invalidation (specific entries or entire cache)
-/// - Thread-safe operations with std.Thread.RwLock
+/// - Thread-safe operations with agksync.RwLock
 /// - Comprehensive metrics (hits, misses, hit rate, evictions)
 ///
 /// Example:
@@ -22,6 +22,8 @@
 /// const metrics = caching_agent.metrics();
 /// ```
 const std = @import("std");
+const agksync = @import("../sync_compat.zig");
+const agktime = @import("../time_compat.zig");
 const Agent = @import("../agent.zig").Agent;
 const AgentError = @import("../agent.zig").AgentError;
 const StreamCallbacks = @import("../agent.zig").StreamCallbacks;
@@ -60,7 +62,7 @@ const CacheEntry = struct {
     last_access_ms: i64, // For LRU tracking
 
     fn isExpired(self: *const CacheEntry) bool {
-        return std.time.milliTimestamp() >= self.expires_at_ms;
+        return agktime.milliTimestamp() >= self.expires_at_ms;
     }
 };
 
@@ -116,7 +118,7 @@ pub const CachingDecorator = struct {
     config: CachingConfig,
     metrics_data: CachingMetrics,
     cache: std.StringHashMap(CacheEntry),
-    rwlock: std.Thread.RwLock,
+    rwlock: agksync.RwLock,
     cleanup_counter: u64,
 
     pub fn init(allocator: Allocator, inner_agent: Agent, config: CachingConfig) !*CachingDecorator {
@@ -130,7 +132,7 @@ pub const CachingDecorator = struct {
             .config = config,
             .metrics_data = CachingMetrics{},
             .cache = std.StringHashMap(CacheEntry).init(allocator),
-            .rwlock = std.Thread.RwLock{},
+            .rwlock = agksync.RwLock{},
             .cleanup_counter = 0,
         };
         return self;
@@ -200,7 +202,7 @@ pub const CachingDecorator = struct {
 
     /// Cleanup expired entries
     fn cleanupExpired(self: *CachingDecorator) void {
-        var keys_to_remove = std.ArrayList([]const u8).init(self.allocator);
+        var keys_to_remove = std.ArrayList([]const u8).empty;
         defer keys_to_remove.deinit();
 
         // Find expired entries
@@ -347,7 +349,7 @@ pub const CachingDecorator = struct {
         self.evictLRU();
 
         // Add to cache
-        const now_ms = std.time.milliTimestamp();
+        const now_ms = agktime.milliTimestamp();
         const key_owned = try self.allocator.dupe(u8, cache_key);
         const entry = CacheEntry{
             .response = response,
@@ -418,12 +420,11 @@ pub const CachingDecorator = struct {
 // Tests
 const testing = std.testing;
 
-
-    fn processStreamImpl(ptr: *anyopaque, message: Message, callbacks: StreamCallbacks) AgentError!void {
-        _ = ptr;
-        _ = message;
-        callbacks.onError(AgentError.NotImplemented);
-    }
+fn processStreamImpl(ptr: *anyopaque, message: Message, callbacks: StreamCallbacks) AgentError!void {
+    _ = ptr;
+    _ = message;
+    callbacks.onError(AgentError.NotImplemented);
+}
 
 test "CachingConfig validation" {
     var config = CachingConfig{};

--- a/agenkit-zig/src/middleware/circuit_breaker.zig
+++ b/agenkit-zig/src/middleware/circuit_breaker.zig
@@ -32,6 +32,8 @@
 /// const metrics = breaker.metrics();
 /// ```
 const std = @import("std");
+const agksync = @import("../sync_compat.zig");
+const agktime = @import("../time_compat.zig");
 const Agent = @import("../agent.zig").Agent;
 const AgentError = @import("../agent.zig").AgentError;
 const StreamCallbacks = @import("../agent.zig").StreamCallbacks;
@@ -178,7 +180,7 @@ pub const CircuitBreakerDecorator = struct {
     failure_count: u32,
     success_count: u32,
     last_failure_time_ms: ?i64,
-    mutex: std.Thread.Mutex,
+    mutex: agksync.Mutex,
 
     pub fn init(allocator: Allocator, inner_agent: Agent, config: CircuitBreakerConfig) !*CircuitBreakerDecorator {
         // Validate configuration
@@ -194,7 +196,7 @@ pub const CircuitBreakerDecorator = struct {
             .failure_count = 0,
             .success_count = 0,
             .last_failure_time_ms = null,
-            .mutex = std.Thread.Mutex{},
+            .mutex = agksync.Mutex{},
         };
         return self;
     }
@@ -232,7 +234,7 @@ pub const CircuitBreakerDecorator = struct {
         if (self.state != .OPEN) return false;
         if (self.last_failure_time_ms == null) return false;
 
-        const now = std.time.milliTimestamp();
+        const now = agktime.milliTimestamp();
         const elapsed = now - self.last_failure_time_ms.?;
         return elapsed >= @as(i64, @intCast(self.config.recovery_timeout_ms));
     }
@@ -244,7 +246,7 @@ pub const CircuitBreakerDecorator = struct {
 
         self.state = new_state;
         self.metrics_data.current_state = new_state;
-        self.metrics_data.last_state_change_ms = std.time.milliTimestamp();
+        self.metrics_data.last_state_change_ms = agktime.milliTimestamp();
 
         // Record transition
         try self.metrics_data.recordTransition(old_state, new_state, self.allocator);
@@ -276,7 +278,7 @@ pub const CircuitBreakerDecorator = struct {
     /// Record failed request
     fn recordFailure(self: *CircuitBreakerDecorator) !void {
         self.metrics_data.failed_requests += 1;
-        self.last_failure_time_ms = std.time.milliTimestamp();
+        self.last_failure_time_ms = agktime.milliTimestamp();
 
         if (self.state == .HALF_OPEN) {
             // Any failure in HALF_OPEN immediately opens circuit
@@ -355,31 +357,31 @@ pub const CircuitBreakerDecorator = struct {
         var metrics_snapshot = try self.metrics();
         defer metrics_snapshot.state_transitions.deinit();
 
-        var metadata_obj = std.json.ObjectMap.init(allocator);
-        errdefer metadata_obj.deinit();
+        var metadata_obj = std.json.ObjectMap.empty;
+        errdefer metadata_obj.deinit(allocator);
 
-        try metadata_obj.put("total_requests", std.json.Value{ .integer = @intCast(metrics_snapshot.total_requests) });
-        try metadata_obj.put("successful_requests", std.json.Value{ .integer = @intCast(metrics_snapshot.successful_requests) });
-        try metadata_obj.put("failed_requests", std.json.Value{ .integer = @intCast(metrics_snapshot.failed_requests) });
-        try metadata_obj.put("rejected_requests", std.json.Value{ .integer = @intCast(metrics_snapshot.rejected_requests) });
-        try metadata_obj.put("current_state", std.json.Value{ .string = metrics_snapshot.current_state.toString() });
-        try metadata_obj.put("failure_threshold", std.json.Value{ .integer = @intCast(self.config.failure_threshold) });
-        try metadata_obj.put("success_threshold", std.json.Value{ .integer = @intCast(self.config.success_threshold) });
-        try metadata_obj.put("recovery_timeout_ms", std.json.Value{ .integer = @intCast(self.config.recovery_timeout_ms) });
+        try metadata_obj.put(allocator, "total_requests", std.json.Value{ .integer = @intCast(metrics_snapshot.total_requests) });
+        try metadata_obj.put(allocator, "successful_requests", std.json.Value{ .integer = @intCast(metrics_snapshot.successful_requests) });
+        try metadata_obj.put(allocator, "failed_requests", std.json.Value{ .integer = @intCast(metrics_snapshot.failed_requests) });
+        try metadata_obj.put(allocator, "rejected_requests", std.json.Value{ .integer = @intCast(metrics_snapshot.rejected_requests) });
+        try metadata_obj.put(allocator, "current_state", std.json.Value{ .string = metrics_snapshot.current_state.toString() });
+        try metadata_obj.put(allocator, "failure_threshold", std.json.Value{ .integer = @intCast(self.config.failure_threshold) });
+        try metadata_obj.put(allocator, "success_threshold", std.json.Value{ .integer = @intCast(self.config.success_threshold) });
+        try metadata_obj.put(allocator, "recovery_timeout_ms", std.json.Value{ .integer = @intCast(self.config.recovery_timeout_ms) });
 
         // Merge with inner metadata (if it's an object)
         if (inner_result.metadata == .object) {
             var inner_iter = inner_result.metadata.object.iterator();
             while (inner_iter.next()) |entry| {
                 if (!std.mem.startsWith(u8, entry.key_ptr.*, "circuit_")) {
-                    try metadata_obj.put(entry.key_ptr.*, entry.value_ptr.*);
+                    try metadata_obj.put(allocator, entry.key_ptr.*, entry.value_ptr.*);
                 }
             }
         }
 
         return IntrospectionResult{
             .allocator = allocator,
-            .timestamp = std.time.timestamp(),
+            .timestamp = agktime.timestamp(),
             .agent_name = inner_result.agent_name,
             .capabilities = inner_result.capabilities,
             .memory_state = inner_result.memory_state,
@@ -399,12 +401,11 @@ pub const CircuitBreakerDecorator = struct {
 // Tests
 const testing = std.testing;
 
-
-    fn processStreamImpl(ptr: *anyopaque, message: Message, callbacks: StreamCallbacks) AgentError!void {
-        _ = ptr;
-        _ = message;
-        callbacks.onError(AgentError.NotImplemented);
-    }
+fn processStreamImpl(ptr: *anyopaque, message: Message, callbacks: StreamCallbacks) AgentError!void {
+    _ = ptr;
+    _ = message;
+    callbacks.onError(AgentError.NotImplemented);
+}
 
 test "CircuitBreakerConfig validation" {
     var config = CircuitBreakerConfig{};

--- a/agenkit-zig/src/middleware/per_user_rate_limiter.zig
+++ b/agenkit-zig/src/middleware/per_user_rate_limiter.zig
@@ -29,6 +29,8 @@
 /// const metrics = limiter.metrics();
 /// ```
 const std = @import("std");
+const agksync = @import("../sync_compat.zig");
+const agktime = @import("../time_compat.zig");
 const Agent = @import("../agent.zig").Agent;
 const AgentError = @import("../agent.zig").AgentError;
 const StreamCallbacks = @import("../agent.zig").StreamCallbacks;
@@ -109,7 +111,7 @@ const UserBucket = struct {
     fn init(capacity: u32) UserBucket {
         return UserBucket{
             .tokens = @as(f64, @floatFromInt(capacity)),
-            .last_update_ms = std.time.milliTimestamp(),
+            .last_update_ms = agktime.milliTimestamp(),
         };
     }
 };
@@ -162,7 +164,7 @@ pub const PerUserRateLimiterDecorator = struct {
     config: PerUserRateLimiterConfig,
     metrics_data: PerUserRateLimiterMetrics,
     buckets: std.StringHashMap(UserBucket),
-    mutex: std.Thread.Mutex,
+    mutex: agksync.Mutex,
 
     pub fn init(allocator: Allocator, inner_agent: Agent, config: PerUserRateLimiterConfig) !*PerUserRateLimiterDecorator {
         // Validate configuration
@@ -175,7 +177,7 @@ pub const PerUserRateLimiterDecorator = struct {
             .config = config,
             .metrics_data = PerUserRateLimiterMetrics{},
             .buckets = std.StringHashMap(UserBucket).init(allocator),
-            .mutex = std.Thread.Mutex{},
+            .mutex = agksync.Mutex{},
         };
         return self;
     }
@@ -217,7 +219,7 @@ pub const PerUserRateLimiterDecorator = struct {
 
     /// Refill tokens for a user based on elapsed time
     fn refillUserTokens(self: *PerUserRateLimiterDecorator, bucket: *UserBucket) void {
-        const now_ms = std.time.milliTimestamp();
+        const now_ms = agktime.milliTimestamp();
         const elapsed_ms = now_ms - bucket.last_update_ms;
         const elapsed_sec = @as(f64, @floatFromInt(elapsed_ms)) / 1000.0;
 
@@ -265,7 +267,7 @@ pub const PerUserRateLimiterDecorator = struct {
         self.mutex.unlock();
 
         // Wait for tokens to refill
-        std.time.sleep(wait_time_ms * std.time.ns_per_ms);
+        agktime.sleep(wait_time_ms * std.time.ns_per_ms);
 
         // Re-acquire lock and try again
         self.mutex.lock();
@@ -381,12 +383,11 @@ pub const PerUserRateLimiterDecorator = struct {
 // Tests
 const testing = std.testing;
 
-
-    fn processStreamImpl(ptr: *anyopaque, message: Message, callbacks: StreamCallbacks) AgentError!void {
-        _ = ptr;
-        _ = message;
-        callbacks.onError(AgentError.NotImplemented);
-    }
+fn processStreamImpl(ptr: *anyopaque, message: Message, callbacks: StreamCallbacks) AgentError!void {
+    _ = ptr;
+    _ = message;
+    callbacks.onError(AgentError.NotImplemented);
+}
 
 test "PerUserRateLimiterConfig validation" {
     var config = PerUserRateLimiterConfig{};

--- a/agenkit-zig/src/middleware/rate_limiter.zig
+++ b/agenkit-zig/src/middleware/rate_limiter.zig
@@ -27,6 +27,8 @@
 /// const metrics = limiter.metrics();
 /// ```
 const std = @import("std");
+const agksync = @import("../sync_compat.zig");
+const agktime = @import("../time_compat.zig");
 const json = std.json;
 const Agent = @import("../agent.zig").Agent;
 const AgentError = @import("../agent.zig").AgentError;
@@ -132,13 +134,13 @@ pub const RateLimiterDecorator = struct {
     metrics_data: RateLimiterMetrics,
     tokens: f64,
     last_update_ms: i64,
-    mutex: std.Thread.Mutex,
+    mutex: agksync.Mutex,
 
     pub fn init(allocator: Allocator, inner_agent: Agent, config: RateLimiterConfig) !*RateLimiterDecorator {
         // Validate configuration
         try config.validate();
 
-        const now_ms = std.time.milliTimestamp();
+        const now_ms = agktime.milliTimestamp();
         const initial_tokens = @as(f64, @floatFromInt(config.capacity));
 
         const self = try allocator.create(RateLimiterDecorator);
@@ -149,7 +151,7 @@ pub const RateLimiterDecorator = struct {
             .metrics_data = RateLimiterMetrics{ .current_tokens = initial_tokens },
             .tokens = initial_tokens,
             .last_update_ms = now_ms,
-            .mutex = std.Thread.Mutex{},
+            .mutex = agksync.Mutex{},
         };
         return self;
     }
@@ -177,7 +179,7 @@ pub const RateLimiterDecorator = struct {
 
     /// Refill tokens based on elapsed time
     fn refillTokens(self: *RateLimiterDecorator) void {
-        const now_ms = std.time.milliTimestamp();
+        const now_ms = agktime.milliTimestamp();
         const elapsed_ms = now_ms - self.last_update_ms;
         const elapsed_sec = @as(f64, @floatFromInt(elapsed_ms)) / 1000.0;
 
@@ -228,7 +230,7 @@ pub const RateLimiterDecorator = struct {
         self.mutex.unlock();
 
         // Wait outside the lock to allow other operations
-        std.Thread.sleep(wait_time_ms * std.time.ns_per_ms);
+        agktime.sleep(wait_time_ms * std.time.ns_per_ms);
 
         // Re-acquire lock and try again
         self.mutex.lock();
@@ -294,27 +296,27 @@ pub const RateLimiterDecorator = struct {
         // Add rate limiter metrics to metadata
         const metrics_snapshot = self.metrics();
 
-        var metadata_map = json.ObjectMap.init(allocator);
-        errdefer metadata_map.deinit();
+        var metadata_map = json.ObjectMap.empty;
+        errdefer metadata_map.deinit(allocator);
 
         // Add metrics as metadata
-        try metadata_map.put("total_requests", json.Value{ .integer = @intCast(metrics_snapshot.total_requests) });
-        try metadata_map.put("allowed_requests", json.Value{ .integer = @intCast(metrics_snapshot.allowed_requests) });
-        try metadata_map.put("rejected_requests", json.Value{ .integer = @intCast(metrics_snapshot.rejected_requests) });
-        try metadata_map.put("total_wait_time_ms", json.Value{ .integer = @intCast(metrics_snapshot.total_wait_time_ms) });
-        try metadata_map.put("current_tokens", json.Value{ .float = metrics_snapshot.current_tokens });
+        try metadata_map.put(allocator, "total_requests", json.Value{ .integer = @intCast(metrics_snapshot.total_requests) });
+        try metadata_map.put(allocator, "allowed_requests", json.Value{ .integer = @intCast(metrics_snapshot.allowed_requests) });
+        try metadata_map.put(allocator, "rejected_requests", json.Value{ .integer = @intCast(metrics_snapshot.rejected_requests) });
+        try metadata_map.put(allocator, "total_wait_time_ms", json.Value{ .integer = @intCast(metrics_snapshot.total_wait_time_ms) });
+        try metadata_map.put(allocator, "current_tokens", json.Value{ .float = metrics_snapshot.current_tokens });
 
         if (metrics_snapshot.avgWaitTime()) |avg| {
-            try metadata_map.put("avg_wait_time_ms", json.Value{ .float = avg });
+            try metadata_map.put(allocator, "avg_wait_time_ms", json.Value{ .float = avg });
         }
         if (metrics_snapshot.rejectionRate()) |rate| {
-            try metadata_map.put("rejection_rate", json.Value{ .float = rate });
+            try metadata_map.put(allocator, "rejection_rate", json.Value{ .float = rate });
         }
 
         // Add configuration
-        try metadata_map.put("rate", json.Value{ .float = self.config.rate });
-        try metadata_map.put("capacity", json.Value{ .integer = @intCast(self.config.capacity) });
-        try metadata_map.put("tokens_per_request", json.Value{ .integer = @intCast(self.config.tokens_per_request) });
+        try metadata_map.put(allocator, "rate", json.Value{ .float = self.config.rate });
+        try metadata_map.put(allocator, "capacity", json.Value{ .integer = @intCast(self.config.capacity) });
+        try metadata_map.put(allocator, "tokens_per_request", json.Value{ .integer = @intCast(self.config.tokens_per_request) });
 
         // Merge with inner metadata (if it's an object)
         if (inner_result.metadata == .object) {
@@ -322,14 +324,14 @@ pub const RateLimiterDecorator = struct {
             while (inner_iter.next()) |entry| {
                 const key = entry.key_ptr.*;
                 if (!std.mem.startsWith(u8, key, "rate_")) {
-                    try metadata_map.put(key, entry.value_ptr.*);
+                    try metadata_map.put(allocator, key, entry.value_ptr.*);
                 }
             }
         }
 
         return IntrospectionResult{
             .allocator = allocator,
-            .timestamp = std.time.timestamp(),
+            .timestamp = agktime.timestamp(),
             .agent_name = inner_result.agent_name,
             .capabilities = inner_result.capabilities,
             .memory_state = inner_result.memory_state,
@@ -348,12 +350,11 @@ pub const RateLimiterDecorator = struct {
 // Tests
 const testing = std.testing;
 
-
-    fn processStreamImpl(ptr: *anyopaque, message: Message, callbacks: StreamCallbacks) AgentError!void {
-        _ = ptr;
-        _ = message;
-        callbacks.onError(AgentError.NotImplemented);
-    }
+fn processStreamImpl(ptr: *anyopaque, message: Message, callbacks: StreamCallbacks) AgentError!void {
+    _ = ptr;
+    _ = message;
+    callbacks.onError(AgentError.NotImplemented);
+}
 
 test "RateLimiterConfig validation" {
     var config = RateLimiterConfig{};

--- a/agenkit-zig/src/middleware/retry.zig
+++ b/agenkit-zig/src/middleware/retry.zig
@@ -20,6 +20,8 @@
 /// const metrics = retry.metrics();
 /// ```
 const std = @import("std");
+const agksync = @import("../sync_compat.zig");
+const agktime = @import("../time_compat.zig");
 const json = std.json;
 const Agent = @import("../agent.zig").Agent;
 const AgentError = @import("../agent.zig").AgentError;
@@ -104,7 +106,7 @@ pub const RetryDecorator = struct {
     inner_agent: Agent,
     config: RetryConfig,
     metrics_data: RetryMetrics,
-    mutex: std.Thread.Mutex,
+    mutex: agksync.Mutex,
 
     pub fn init(allocator: Allocator, inner_agent: Agent, config: RetryConfig) !*RetryDecorator {
         // Validate configuration
@@ -116,7 +118,7 @@ pub const RetryDecorator = struct {
             .inner_agent = inner_agent,
             .config = config,
             .metrics_data = RetryMetrics{},
-            .mutex = std.Thread.Mutex{},
+            .mutex = agksync.Mutex{},
         };
         return self;
     }
@@ -211,7 +213,7 @@ pub const RetryDecorator = struct {
             self.mutex.unlock();
 
             // Wait before retrying (exponential backoff)
-            std.Thread.sleep(backoff_ms * std.time.ns_per_ms);
+            agktime.sleep(backoff_ms * std.time.ns_per_ms);
 
             // Calculate next backoff
             const next_backoff = @as(f64, @floatFromInt(backoff_ms)) * self.config.multiplier;
@@ -235,18 +237,18 @@ pub const RetryDecorator = struct {
         // Add retry metrics to metadata
         const metrics_snapshot = self.metrics();
 
-        var metadata_map = json.ObjectMap.init(allocator);
-        errdefer metadata_map.deinit();
+        var metadata_map = json.ObjectMap.empty;
+        errdefer metadata_map.deinit(allocator);
 
         // Add metrics as metadata
-        try metadata_map.put("total_attempts", json.Value{ .integer = @intCast(metrics_snapshot.total_attempts) });
-        try metadata_map.put("successful_first_attempt", json.Value{ .integer = @intCast(metrics_snapshot.successful_first_attempt) });
-        try metadata_map.put("successful_on_retry", json.Value{ .integer = @intCast(metrics_snapshot.successful_on_retry) });
-        try metadata_map.put("failed_after_retries", json.Value{ .integer = @intCast(metrics_snapshot.failed_after_retries) });
-        try metadata_map.put("total_retries", json.Value{ .integer = @intCast(metrics_snapshot.total_retries) });
-        try metadata_map.put("max_retries", json.Value{ .integer = @intCast(self.config.max_retries) });
-        try metadata_map.put("initial_delay_ms", json.Value{ .integer = @intCast(self.config.initial_delay_ms) });
-        try metadata_map.put("max_delay_ms", json.Value{ .integer = @intCast(self.config.max_delay_ms) });
+        try metadata_map.put(allocator, "total_attempts", json.Value{ .integer = @intCast(metrics_snapshot.total_attempts) });
+        try metadata_map.put(allocator, "successful_first_attempt", json.Value{ .integer = @intCast(metrics_snapshot.successful_first_attempt) });
+        try metadata_map.put(allocator, "successful_on_retry", json.Value{ .integer = @intCast(metrics_snapshot.successful_on_retry) });
+        try metadata_map.put(allocator, "failed_after_retries", json.Value{ .integer = @intCast(metrics_snapshot.failed_after_retries) });
+        try metadata_map.put(allocator, "total_retries", json.Value{ .integer = @intCast(metrics_snapshot.total_retries) });
+        try metadata_map.put(allocator, "max_retries", json.Value{ .integer = @intCast(self.config.max_retries) });
+        try metadata_map.put(allocator, "initial_delay_ms", json.Value{ .integer = @intCast(self.config.initial_delay_ms) });
+        try metadata_map.put(allocator, "max_delay_ms", json.Value{ .integer = @intCast(self.config.max_delay_ms) });
 
         // Merge with inner metadata (if it's an object)
         if (inner_result.metadata == .object) {
@@ -255,14 +257,14 @@ pub const RetryDecorator = struct {
                 // Inner metadata wins for non-metric keys
                 const key = entry.key_ptr.*;
                 if (!std.mem.startsWith(u8, key, "retry_")) {
-                    try metadata_map.put(key, entry.value_ptr.*);
+                    try metadata_map.put(allocator, key, entry.value_ptr.*);
                 }
             }
         }
 
         return IntrospectionResult{
             .allocator = allocator,
-            .timestamp = std.time.timestamp(),
+            .timestamp = agktime.timestamp(),
             .agent_name = inner_result.agent_name,
             .capabilities = inner_result.capabilities,
             .memory_state = inner_result.memory_state,
@@ -281,12 +283,11 @@ pub const RetryDecorator = struct {
 // Tests
 const testing = std.testing;
 
-
-    fn processStreamImpl(ptr: *anyopaque, message: Message, callbacks: StreamCallbacks) AgentError!void {
-        _ = ptr;
-        _ = message;
-        callbacks.onError(AgentError.NotImplemented);
-    }
+fn processStreamImpl(ptr: *anyopaque, message: Message, callbacks: StreamCallbacks) AgentError!void {
+    _ = ptr;
+    _ = message;
+    callbacks.onError(AgentError.NotImplemented);
+}
 
 test "RetryConfig validation" {
     var config = RetryConfig{};

--- a/agenkit-zig/src/middleware/timeout.zig
+++ b/agenkit-zig/src/middleware/timeout.zig
@@ -20,6 +20,8 @@
 /// const metrics = timeout_agent.metrics();
 /// ```
 const std = @import("std");
+const agksync = @import("../sync_compat.zig");
+const agktime = @import("../time_compat.zig");
 const Agent = @import("../agent.zig").Agent;
 const AgentError = @import("../agent.zig").AgentError;
 const Result = @import("../agent.zig").Result;
@@ -122,7 +124,7 @@ pub const TimeoutDecorator = struct {
     inner_agent: Agent,
     config: TimeoutConfig,
     metrics_data: TimeoutMetrics,
-    mutex: std.Thread.Mutex,
+    mutex: agksync.Mutex,
 
     pub fn init(allocator: Allocator, inner_agent: Agent, config: TimeoutConfig) !*TimeoutDecorator {
         // Validate configuration
@@ -134,7 +136,7 @@ pub const TimeoutDecorator = struct {
             .inner_agent = inner_agent,
             .config = config,
             .metrics_data = TimeoutMetrics{},
-            .mutex = std.Thread.Mutex{},
+            .mutex = agksync.Mutex{},
         };
         return self;
     }
@@ -202,7 +204,7 @@ pub const TimeoutDecorator = struct {
         self.mutex.unlock();
 
         // Record start time
-        const start_time = std.time.milliTimestamp();
+        const start_time = agktime.milliTimestamp();
         const deadline = start_time + @as(i64, @intCast(timeout_ms));
 
         // Create a thread to execute the operation
@@ -236,7 +238,7 @@ pub const TimeoutDecorator = struct {
 
         // Poll for completion or timeout
         while (!context.completed.load(.acquire)) {
-            const now = std.time.milliTimestamp();
+            const now = agktime.milliTimestamp();
             if (now >= deadline) {
                 // Timeout occurred
                 const duration_ms = @as(u64, @intCast(now - start_time));
@@ -250,11 +252,11 @@ pub const TimeoutDecorator = struct {
             }
 
             // Sleep briefly to avoid busy waiting
-            std.time.sleep(10 * std.time.ns_per_ms); // 10ms poll interval
+            agktime.sleep(10 * std.time.ns_per_ms); // 10ms poll interval
         }
 
         // Calculate duration
-        const end_time = std.time.milliTimestamp();
+        const end_time = agktime.milliTimestamp();
         const duration_ms = @as(u64, @intCast(end_time - start_time));
 
         // Check result
@@ -294,7 +296,7 @@ pub const TimeoutDecorator = struct {
         self.mutex.unlock();
 
         // Record start time and deadline
-        const start_time = std.time.milliTimestamp();
+        const start_time = agktime.milliTimestamp();
         const deadline = start_time + @as(i64, @intCast(timeout_ms));
 
         // Create context for wrapped callbacks
@@ -322,7 +324,7 @@ pub const TimeoutDecorator = struct {
             .on_message_fn = struct {
                 fn callback(ctx_ptr: *anyopaque, msg: Message) void {
                     const ctx: *CallbackContext = @ptrCast(@alignCast(ctx_ptr));
-                    const now = std.time.milliTimestamp();
+                    const now = agktime.milliTimestamp();
 
                     if (now >= ctx.deadline) {
                         // Timeout exceeded - call error callback
@@ -344,7 +346,7 @@ pub const TimeoutDecorator = struct {
             .on_error_fn = struct {
                 fn callback(ctx_ptr: *anyopaque, err: AgentError) void {
                     const ctx: *CallbackContext = @ptrCast(@alignCast(ctx_ptr));
-                    const now = std.time.milliTimestamp();
+                    const now = agktime.milliTimestamp();
                     const duration_ms = @as(u64, @intCast(now - ctx.start_time));
 
                     ctx.decorator.mutex.lock();
@@ -362,7 +364,7 @@ pub const TimeoutDecorator = struct {
             .on_complete_fn = struct {
                 fn callback(ctx_ptr: *anyopaque) void {
                     const ctx: *CallbackContext = @ptrCast(@alignCast(ctx_ptr));
-                    const now = std.time.milliTimestamp();
+                    const now = agktime.milliTimestamp();
                     const duration_ms = @as(u64, @intCast(now - ctx.start_time));
 
                     ctx.decorator.mutex.lock();

--- a/agenkit-zig/src/observability/audit.zig
+++ b/agenkit-zig/src/observability/audit.zig
@@ -28,8 +28,9 @@
 /// try logger.log(&event);
 /// try logger.flush();
 /// ```
-
 const std = @import("std");
+const agktime = @import("../time_compat.zig");
+const ioc = @import("../io_compat.zig");
 const Allocator = std.mem.Allocator;
 
 /// Audit event types
@@ -92,7 +93,7 @@ pub const AuditEvent = struct {
     ) !AuditEvent {
         // Generate event ID (simplified UUID)
         var event_id_buf: [36]u8 = undefined;
-        const timestamp = std.time.milliTimestamp();
+        const timestamp = agktime.milliTimestamp();
         _ = try std.fmt.bufPrint(&event_id_buf, "{x:0>16}-{x:0>4}-{x:0>4}", .{
             @as(u64, @intCast(timestamp)),
             @as(u16, @truncate(@as(u64, @intCast(timestamp)) >> 16)),
@@ -135,13 +136,13 @@ pub const AuditEvent = struct {
     }
 
     pub fn toJson(self: *const AuditEvent, allocator: Allocator) ![]const u8 {
-        var buf = std.ArrayList(u8){};
+        var buf = std.ArrayList(u8).empty;
         errdefer buf.deinit(allocator);
 
         try buf.appendSlice(allocator, "{\"event_id\":\"");
         try buf.appendSlice(allocator, self.event_id);
         try buf.appendSlice(allocator, "\",\"timestamp\":");
-        try std.fmt.format(buf.writer(allocator), "{d}", .{self.timestamp});
+        try buf.print(allocator, "{d}", .{self.timestamp});
         try buf.appendSlice(allocator, ",\"event_type\":\"");
         try buf.appendSlice(allocator, self.event_type.toString());
         try buf.appendSlice(allocator, "\",\"agent_name\":\"");
@@ -184,21 +185,23 @@ pub const AuditLogger = struct {
     log_path: []const u8,
     buffer: std.ArrayList(AuditEvent),
     buffer_size: usize,
-    file: ?std.fs.File,
+    file: ?std.Io.File,
+    write_offset: u64,
 
     pub fn init(allocator: Allocator, log_path: []const u8) !AuditLogger {
         return AuditLogger{
             .allocator = allocator,
             .log_path = try allocator.dupe(u8, log_path),
-            .buffer = std.ArrayList(AuditEvent){},
+            .buffer = std.ArrayList(AuditEvent).empty,
             .buffer_size = 100,
             .file = null,
+            .write_offset = 0,
         };
     }
 
     pub fn deinit(self: *AuditLogger) void {
         self.flush() catch {};
-        if (self.file) |f| f.close();
+        if (self.file) |f| f.close(ioc.io());
         for (self.buffer.items) |*event| {
             event.deinit(self.allocator);
         }
@@ -234,13 +237,16 @@ pub const AuditLogger = struct {
     pub fn flush(self: *AuditLogger) !void {
         if (self.buffer.items.len == 0) return;
 
+        const io = ioc.io();
+
         // Open file if not already open
         if (self.file == null) {
-            const file = try std.fs.cwd().createFile(self.log_path, .{
+            const file = try std.Io.Dir.cwd().createFile(io, self.log_path, .{
                 .read = false,
                 .truncate = false,
             });
-            try file.seekFromEnd(0); // Append to end
+            // Append to end: start writing at the current end-of-file offset.
+            self.write_offset = (try file.stat(io)).size;
             self.file = file;
         }
 
@@ -251,8 +257,10 @@ pub const AuditLogger = struct {
             const json = try event.toJson(self.allocator);
             defer self.allocator.free(json);
 
-            try file.writeAll(json);
-            try file.writeAll("\n");
+            try file.writePositionalAll(io, json, self.write_offset);
+            self.write_offset += json.len;
+            try file.writePositionalAll(io, "\n", self.write_offset);
+            self.write_offset += 1;
 
             event.deinit(self.allocator);
         }
@@ -261,7 +269,7 @@ pub const AuditLogger = struct {
     }
 
     pub fn query(self: *AuditLogger, allocator: Allocator, session_id: ?[]const u8) !std.ArrayList(AuditEvent) {
-        var results = std.ArrayList(AuditEvent){};
+        var results = std.ArrayList(AuditEvent).empty;
         errdefer {
             for (results.items) |*event| {
                 event.deinit(allocator);
@@ -285,7 +293,7 @@ pub const AuditLogger = struct {
     }
 
     pub fn queryByType(self: *AuditLogger, event_type: AuditEventType) !std.ArrayList(*const AuditEvent) {
-        var results = std.ArrayList(*const AuditEvent){};
+        var results = std.ArrayList(*const AuditEvent).empty;
         errdefer results.deinit(self.allocator);
 
         for (self.buffer.items) |*event| {
@@ -298,7 +306,7 @@ pub const AuditLogger = struct {
     }
 
     pub fn queryBySeverity(self: *AuditLogger, severity: Severity) !std.ArrayList(*const AuditEvent) {
-        var results = std.ArrayList(*const AuditEvent){};
+        var results = std.ArrayList(*const AuditEvent).empty;
         errdefer results.deinit(self.allocator);
 
         for (self.buffer.items) |*event| {
@@ -401,7 +409,7 @@ test "AuditLogger buffering" {
 
     var logger = try AuditLogger.init(allocator, "test_audit_buffer.log");
     defer logger.deinit();
-    defer std.fs.cwd().deleteFile("test_audit_buffer.log") catch {};
+    defer std.Io.Dir.cwd().deleteFile(ioc.io(), "test_audit_buffer.log") catch {};
 
     var event1 = try AuditEvent.create(allocator, .agent_created, "agent1", null);
     defer event1.deinit(allocator);
@@ -420,7 +428,7 @@ test "AuditLogger flush" {
 
     var logger = try AuditLogger.init(allocator, "test_audit_flush.log");
     defer logger.deinit();
-    defer std.fs.cwd().deleteFile("test_audit_flush.log") catch {};
+    defer std.Io.Dir.cwd().deleteFile(ioc.io(), "test_audit_flush.log") catch {};
 
     var event = try AuditEvent.create(allocator, .message_processed, "agent", "session");
     defer event.deinit(allocator);
@@ -431,9 +439,9 @@ test "AuditLogger flush" {
     try std.testing.expectEqual(@as(usize, 0), logger.buffer.items.len);
 
     // Verify file was written
-    const file = try std.fs.cwd().openFile("test_audit_flush.log", .{});
-    defer file.close();
-    const stat = try file.stat();
+    const file = try std.Io.Dir.cwd().openFile(ioc.io(), "test_audit_flush.log", .{});
+    defer file.close(ioc.io());
+    const stat = try file.stat(ioc.io());
     try std.testing.expect(stat.size > 0);
 }
 
@@ -442,7 +450,7 @@ test "AuditLogger auto-flush on buffer full" {
 
     var logger = try AuditLogger.init(allocator, "test_audit_autoflush.log");
     defer logger.deinit();
-    defer std.fs.cwd().deleteFile("test_audit_autoflush.log") catch {};
+    defer std.Io.Dir.cwd().deleteFile(ioc.io(), "test_audit_autoflush.log") catch {};
 
     logger.buffer_size = 3; // Small buffer for testing
 
@@ -462,7 +470,7 @@ test "AuditLogger query by session" {
 
     var logger = try AuditLogger.init(allocator, "test_audit_query.log");
     defer logger.deinit();
-    defer std.fs.cwd().deleteFile("test_audit_query.log") catch {};
+    defer std.Io.Dir.cwd().deleteFile(ioc.io(), "test_audit_query.log") catch {};
 
     var event1 = try AuditEvent.create(allocator, .message_processed, "agent", "session1");
     defer event1.deinit(allocator);
@@ -539,7 +547,7 @@ test "AuditLogger countEvents" {
 
     var logger = try AuditLogger.init(allocator, "test_count.log");
     defer logger.deinit();
-    defer std.fs.cwd().deleteFile("test_count.log") catch {};
+    defer std.Io.Dir.cwd().deleteFile(ioc.io(), "test_count.log") catch {};
 
     try std.testing.expectEqual(@as(usize, 0), logger.countEvents());
 
@@ -561,7 +569,7 @@ test "AuditLogger queryByType" {
 
     var logger = try AuditLogger.init(allocator, "test_query_type.log");
     defer logger.deinit();
-    defer std.fs.cwd().deleteFile("test_query_type.log") catch {};
+    defer std.Io.Dir.cwd().deleteFile(ioc.io(), "test_query_type.log") catch {};
 
     var event1 = try AuditEvent.create(allocator, .agent_created, "agent1", null);
     defer event1.deinit(allocator);
@@ -589,7 +597,7 @@ test "AuditLogger queryBySeverity" {
 
     var logger = try AuditLogger.init(allocator, "test_query_severity.log");
     defer logger.deinit();
-    defer std.fs.cwd().deleteFile("test_query_severity.log") catch {};
+    defer std.Io.Dir.cwd().deleteFile(ioc.io(), "test_query_severity.log") catch {};
 
     var event1 = try AuditEvent.create(allocator, .message_processed, "agent", null);
     defer event1.deinit(allocator);
@@ -619,7 +627,7 @@ test "AuditLogger clear" {
 
     var logger = try AuditLogger.init(allocator, "test_clear.log");
     defer logger.deinit();
-    defer std.fs.cwd().deleteFile("test_clear.log") catch {};
+    defer std.Io.Dir.cwd().deleteFile(ioc.io(), "test_clear.log") catch {};
 
     var event = try AuditEvent.create(allocator, .agent_created, "agent", null);
     defer event.deinit(allocator);
@@ -660,7 +668,7 @@ test "AuditLogger multiple event types" {
 
     var logger = try AuditLogger.init(allocator, "test_multi_types.log");
     defer logger.deinit();
-    defer std.fs.cwd().deleteFile("test_multi_types.log") catch {};
+    defer std.Io.Dir.cwd().deleteFile(ioc.io(), "test_multi_types.log") catch {};
 
     var event1 = try AuditEvent.create(allocator, .agent_created, "agent1", null);
     defer event1.deinit(allocator);

--- a/agenkit-zig/src/observability/integration_test.zig
+++ b/agenkit-zig/src/observability/integration_test.zig
@@ -4,8 +4,8 @@
 /// - Tracing + Metrics + Logging + Audit
 /// - Middleware composition
 /// - Cross-module data flow
-
 const std = @import("std");
+const ioc = @import("../io_compat.zig");
 const testing = std.testing;
 
 const Agent = @import("../agent.zig").Agent;
@@ -65,7 +65,7 @@ test "Full observability stack" {
     // Create audit logger
     var audit_logger = try audit.AuditLogger.init(allocator, "integration_audit.log");
     defer audit_logger.deinit();
-    defer std.fs.cwd().deleteFile("integration_audit.log") catch {};
+    defer std.Io.Dir.cwd().deleteFile(ioc.io(), "integration_audit.log") catch {};
 
     // Create agent with full observability
     var echo = try EchoAgent.init(allocator);
@@ -201,7 +201,7 @@ test "Audit events with severity filtering" {
 
     var logger = try audit.AuditLogger.init(allocator, "severity_test.log");
     defer logger.deinit();
-    defer std.fs.cwd().deleteFile("severity_test.log") catch {};
+    defer std.Io.Dir.cwd().deleteFile(ioc.io(), "severity_test.log") catch {};
 
     // Create events with different severities
     var info_event = try audit.AuditEvent.create(allocator, .message_processed, "agent", null);
@@ -350,7 +350,7 @@ test "Concurrent audit logging" {
 
     var logger = try audit.AuditLogger.init(allocator, "concurrent_test.log");
     defer logger.deinit();
-    defer std.fs.cwd().deleteFile("concurrent_test.log") catch {};
+    defer std.Io.Dir.cwd().deleteFile(ioc.io(), "concurrent_test.log") catch {};
 
     // Simulate concurrent logging (sequential in tests, but validates thread safety design)
     var i: usize = 0;

--- a/agenkit-zig/src/observability/logging.zig
+++ b/agenkit-zig/src/observability/logging.zig
@@ -20,8 +20,8 @@
 ///     .session_id = "abc123",
 /// });
 /// ```
-
 const std = @import("std");
+const agktime = @import("../time_compat.zig");
 const Allocator = std.mem.Allocator;
 
 /// Log level enumeration
@@ -73,7 +73,7 @@ pub const LogEntry = struct {
 
     pub fn init(allocator: Allocator, level: LogLevel, message: []const u8) !LogEntry {
         return LogEntry{
-            .timestamp = std.time.milliTimestamp(),
+            .timestamp = agktime.milliTimestamp(),
             .level = level,
             .message = try allocator.dupe(u8, message),
             .trace_id = null,
@@ -131,11 +131,11 @@ pub fn shouldLog(level: LogLevel) bool {
 
 /// Format log entry as JSON
 pub fn formatJson(entry: *const LogEntry, allocator: Allocator) ![]const u8 {
-    var buf = std.ArrayList(u8){};
+    var buf = std.ArrayList(u8).empty;
     errdefer buf.deinit(allocator);
 
     try buf.appendSlice(allocator, "{\"timestamp\":");
-    try std.fmt.format(buf.writer(allocator), "{d}", .{entry.timestamp});
+    try buf.print(allocator, "{d}", .{entry.timestamp});
     try buf.appendSlice(allocator, ",\"level\":\"");
     try buf.appendSlice(allocator, entry.level.toString());
     try buf.appendSlice(allocator, "\",\"message\":\"");
@@ -170,17 +170,17 @@ pub fn formatJson(entry: *const LogEntry, allocator: Allocator) ![]const u8 {
 
 /// Format log entry as compact text
 pub fn formatCompact(entry: *const LogEntry, allocator: Allocator) ![]const u8 {
-    var buf = std.ArrayList(u8){};
+    var buf = std.ArrayList(u8).empty;
     errdefer buf.deinit(allocator);
 
-    try std.fmt.format(buf.writer(allocator), "[{d}] {s} {s}", .{
+    try buf.print(allocator, "[{d}] {s} {s}", .{
         entry.timestamp,
         entry.level.toString(),
         entry.message,
     });
 
     if (entry.trace_id) |tid| {
-        try std.fmt.format(buf.writer(allocator), " trace_id={s}", .{tid});
+        try buf.print(allocator, " trace_id={s}", .{tid});
     }
 
     return buf.toOwnedSlice(allocator);
@@ -188,24 +188,24 @@ pub fn formatCompact(entry: *const LogEntry, allocator: Allocator) ![]const u8 {
 
 /// Format log entry as pretty text with indentation
 pub fn formatPretty(entry: *const LogEntry, allocator: Allocator) ![]const u8 {
-    var buf = std.ArrayList(u8){};
+    var buf = std.ArrayList(u8).empty;
     errdefer buf.deinit(allocator);
 
     // Header line
-    try std.fmt.format(buf.writer(allocator), "{s} | {s}\n", .{
+    try buf.print(allocator, "{s} | {s}\n", .{
         entry.level.toString(),
         entry.message,
     });
 
     // Timestamp
-    try std.fmt.format(buf.writer(allocator), "  timestamp: {d}\n", .{entry.timestamp});
+    try buf.print(allocator, "  timestamp: {d}\n", .{entry.timestamp});
 
     // Trace context if present
     if (entry.trace_id) |tid| {
-        try std.fmt.format(buf.writer(allocator), "  trace_id: {s}\n", .{tid});
+        try buf.print(allocator, "  trace_id: {s}\n", .{tid});
     }
     if (entry.span_id) |sid| {
-        try std.fmt.format(buf.writer(allocator), "  span_id: {s}\n", .{sid});
+        try buf.print(allocator, "  span_id: {s}\n", .{sid});
     }
 
     // Fields
@@ -213,7 +213,7 @@ pub fn formatPretty(entry: *const LogEntry, allocator: Allocator) ![]const u8 {
         try buf.appendSlice(allocator, "  fields:\n");
         var iter = entry.fields.iterator();
         while (iter.next()) |field| {
-            try std.fmt.format(buf.writer(allocator), "    {s}: {s}\n", .{
+            try buf.print(allocator, "    {s}: {s}\n", .{
                 field.key_ptr.*,
                 field.value_ptr.*,
             });

--- a/agenkit-zig/src/observability/metrics.zig
+++ b/agenkit-zig/src/observability/metrics.zig
@@ -21,8 +21,8 @@
 /// // Process message - automatically records metrics
 /// const result = try middleware.agent().process(msg);
 /// ```
-
 const std = @import("std");
+const agktime = @import("../time_compat.zig");
 const Agent = @import("../agent.zig").Agent;
 const Message = @import("../message.zig").Message;
 const AgentError = @import("../agent.zig").AgentError;
@@ -80,7 +80,7 @@ pub const Histogram = struct {
         return Histogram{
             .allocator = allocator,
             .name = try allocator.dupe(u8, name),
-            .observations = std.ArrayList(f64){},
+            .observations = std.ArrayList(f64).empty,
         };
     }
 
@@ -177,9 +177,9 @@ pub const MetricsMiddleware = struct {
     fn process(ptr: *anyopaque, message: Message) AgentError!Result {
         const self: *MetricsMiddleware = @ptrCast(@alignCast(ptr));
 
-        const start_time = std.time.milliTimestamp();
+        const start_time = agktime.milliTimestamp();
         const result = self.inner.process(message);
-        const end_time = std.time.milliTimestamp();
+        const end_time = agktime.milliTimestamp();
 
         const duration_ms = @as(f64, @floatFromInt(end_time - start_time));
         const duration_secs = duration_ms / 1000.0;

--- a/agenkit-zig/src/observability/mod.zig
+++ b/agenkit-zig/src/observability/mod.zig
@@ -50,7 +50,6 @@
 /// - Message metadata system
 /// - Evaluation framework
 /// - External systems (Jaeger, Zipkin, Prometheus, Grafana)
-
 const std = @import("std");
 
 // Export all observability modules

--- a/agenkit-zig/src/observability/tracing.zig
+++ b/agenkit-zig/src/observability/tracing.zig
@@ -23,8 +23,8 @@
 /// const result = try traced_agent.agent().process(msg);
 /// // Response will include trace context in metadata
 /// ```
-
 const std = @import("std");
+const agktime = @import("../time_compat.zig");
 const Agent = @import("../agent.zig").Agent;
 const AgentError = @import("../agent.zig").AgentError;
 const StreamCallbacks = @import("../agent.zig").StreamCallbacks;
@@ -50,7 +50,7 @@ pub const SpanContext = struct {
         };
 
         // Generate random trace_id and span_id
-        var prng = std.Random.DefaultPrng.init(@intCast(std.time.timestamp()));
+        var prng = std.Random.DefaultPrng.init(@intCast(agktime.timestamp()));
         const random = prng.random();
         random.bytes(&ctx.trace_id);
         random.bytes(&ctx.span_id);
@@ -68,7 +68,7 @@ pub const SpanContext = struct {
         };
 
         // Generate new span_id
-        var prng = std.Random.DefaultPrng.init(@intCast(std.time.timestamp()));
+        var prng = std.Random.DefaultPrng.init(@intCast(agktime.timestamp()));
         const random = prng.random();
         random.bytes(&ctx.span_id);
 
@@ -110,7 +110,7 @@ pub const SpanContext = struct {
 
     /// Format as W3C traceparent header
     pub fn toTraceparent(self: *const SpanContext, allocator: Allocator) ![]const u8 {
-        var buf = std.ArrayList(u8){};
+        var buf = std.ArrayList(u8).empty;
         defer buf.deinit(allocator);
 
         try buf.appendSlice(allocator, "00-");
@@ -162,7 +162,7 @@ pub const Span = struct {
         self.* = Span{
             .context = context,
             .name = try allocator.dupe(u8, name),
-            .start_time = std.time.nanoTimestamp(),
+            .start_time = agktime.nanoTimestamp(),
             .end_time = null,
             .attributes = std.StringHashMap([]const u8).init(allocator),
             .allocator = allocator,
@@ -172,7 +172,7 @@ pub const Span = struct {
 
     /// End the span
     pub fn end(self: *Span) void {
-        self.end_time = std.time.nanoTimestamp();
+        self.end_time = agktime.nanoTimestamp();
     }
 
     /// Set an attribute
@@ -226,7 +226,6 @@ pub const TracingMiddleware = struct {
     }
 
     /// Convert to Agent interface
-
     fn processStream(ptr: *anyopaque, message: Message, callbacks: StreamCallbacks) AgentError!void {
         _ = ptr;
         _ = message;

--- a/agenkit-zig/src/patterns/agents_as_tools.zig
+++ b/agenkit-zig/src/patterns/agents_as_tools.zig
@@ -32,7 +32,6 @@
 ///
 ///     // Execute tool
 ///     const result = try tool.execute(allocator, "Write a function to reverse a string");
-
 const std = @import("std");
 const Agent = @import("../agent.zig").Agent;
 const AgentError = @import("../agent.zig").AgentError;
@@ -215,7 +214,7 @@ pub const ToolCoordinator = struct {
         self.* = ToolCoordinator{
             .allocator = allocator,
             .agent_name = try allocator.dupe(u8, name),
-            .tools = .{},
+            .tools = .empty,
         };
         return self;
     }
@@ -333,12 +332,11 @@ pub const ToolCoordinator = struct {
 // Tests
 // ============================================================================
 
-
-    fn processStreamImpl(ptr: *anyopaque, message: Message, callbacks: StreamCallbacks) AgentError!void {
-        _ = ptr;
-        _ = message;
-        callbacks.onError(AgentError.NotImplemented);
-    }
+fn processStreamImpl(ptr: *anyopaque, message: Message, callbacks: StreamCallbacks) AgentError!void {
+    _ = ptr;
+    _ = message;
+    callbacks.onError(AgentError.NotImplemented);
+}
 
 test "AgentTool basic functionality" {
     const allocator = std.testing.allocator;

--- a/agenkit-zig/src/patterns/autonomous.zig
+++ b/agenkit-zig/src/patterns/autonomous.zig
@@ -47,7 +47,6 @@
 ///     defer result.deinit();
 /// }
 /// ```
-
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 const Agent = @import("../agent.zig").Agent;
@@ -120,7 +119,7 @@ pub const AutonomousResult = struct {
             .objective = try allocator.dupe(u8, objective),
             .iterations = iterations,
             .goals_completed = goals_completed,
-            .results = std.ArrayList([]const u8){},
+            .results = std.ArrayList([]const u8).empty,
             .allocator = allocator,
         };
     }
@@ -171,7 +170,7 @@ pub const AutonomousAgent = struct {
             .allocator = allocator,
             .objective = try allocator.dupe(u8, objective),
             .max_iterations = max_iter,
-            .goals = std.ArrayList(Goal){},
+            .goals = std.ArrayList(Goal).empty,
             .iteration_count = 0,
             .is_running = false,
             .worker = defaultWorker,

--- a/agenkit-zig/src/patterns/autonomous.zig
+++ b/agenkit-zig/src/patterns/autonomous.zig
@@ -28,7 +28,7 @@
 /// const agenkit = @import("agenkit");
 ///
 /// pub fn main() !void {
-///     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+///     var gpa = std.heap.DebugAllocator(.{}){};
 ///     defer _ = gpa.deinit();
 ///     const allocator = gpa.allocator();
 ///

--- a/agenkit-zig/src/patterns/collaborative.zig
+++ b/agenkit-zig/src/patterns/collaborative.zig
@@ -44,7 +44,6 @@
 /// // Will iterate until consensus or max rounds
 /// const result = try collab.agent().process(input_message);
 /// ```
-
 const std = @import("std");
 const Agent = @import("../agent.zig").Agent;
 const AgentError = @import("../agent.zig").AgentError;
@@ -408,12 +407,11 @@ pub fn firstMerge(allocator: Allocator, messages: []const Message) AgentError!Me
 // Tests
 // ============================================================================
 
-
-    fn processStreamImpl(ptr: *anyopaque, message: Message, callbacks: StreamCallbacks) AgentError!void {
-        _ = ptr;
-        _ = message;
-        callbacks.onError(AgentError.NotImplemented);
-    }
+fn processStreamImpl(ptr: *anyopaque, message: Message, callbacks: StreamCallbacks) AgentError!void {
+    _ = ptr;
+    _ = message;
+    callbacks.onError(AgentError.NotImplemented);
+}
 
 test "CollaborativeAgent: basic collaboration" {
     // Skip test for now - requires mock infrastructure

--- a/agenkit-zig/src/patterns/conversational.zig
+++ b/agenkit-zig/src/patterns/conversational.zig
@@ -50,7 +50,6 @@
 ///     defer response2.deinit();
 /// }
 /// ```
-
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 const Agent = @import("../agent.zig").Agent;
@@ -86,7 +85,7 @@ pub const ConversationalAgent = struct {
             return AgentError.InvalidInput;
         }
 
-        var history = std.ArrayList(Message){};
+        var history = std.ArrayList(Message).empty;
 
         // Add system prompt to history if provided
         const system_prompt_copy = if (system_prompt) |prompt|
@@ -130,10 +129,10 @@ pub const ConversationalAgent = struct {
         }
 
         // Separate system messages from conversation
-        var system_messages = std.ArrayList(Message){};
+        var system_messages = std.ArrayList(Message).empty;
         defer system_messages.deinit(self.allocator);
 
-        var conversation_messages = std.ArrayList(Message){};
+        var conversation_messages = std.ArrayList(Message).empty;
         defer conversation_messages.deinit(self.allocator);
 
         for (self.history.items) |msg| {
@@ -282,7 +281,6 @@ pub const ConversationalAgent = struct {
         return Result{ .ok = response };
     }
 
-
     fn introspectImpl(ptr: *anyopaque, alloc: Allocator) Allocator.Error!IntrospectionResult {
         const caps = try capabilitiesImpl(ptr, alloc);
         defer {
@@ -317,12 +315,11 @@ pub const ConversationalAgent = struct {
 // Tests
 const testing = std.testing;
 
-
-    fn processStreamImpl(ptr: *anyopaque, message: Message, callbacks: StreamCallbacks) AgentError!void {
-        _ = ptr;
-        _ = message;
-        callbacks.onError(AgentError.NotImplemented);
-    }
+fn processStreamImpl(ptr: *anyopaque, message: Message, callbacks: StreamCallbacks) AgentError!void {
+    _ = ptr;
+    _ = message;
+    callbacks.onError(AgentError.NotImplemented);
+}
 
 test "ConversationalAgent creation" {
     const allocator = testing.allocator;

--- a/agenkit-zig/src/patterns/conversational.zig
+++ b/agenkit-zig/src/patterns/conversational.zig
@@ -24,7 +24,7 @@
 /// const agenkit = @import("agenkit");
 ///
 /// pub fn main() !void {
-///     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+///     var gpa = std.heap.DebugAllocator(.{}){};
 ///     defer _ = gpa.deinit();
 ///     const allocator = gpa.allocator();
 ///

--- a/agenkit-zig/src/patterns/fallback.zig
+++ b/agenkit-zig/src/patterns/fallback.zig
@@ -40,7 +40,6 @@
 /// // Will try primary first, then backup if primary fails
 /// const result = try fallback.agent().process(input_message);
 /// ```
-
 const std = @import("std");
 const Agent = @import("../agent.zig").Agent;
 const AgentError = @import("../agent.zig").AgentError;
@@ -193,7 +192,6 @@ pub const FallbackAgent = struct {
         return AgentError.ProcessingFailed;
     }
 
-
     fn introspectImpl(ptr: *anyopaque, alloc: Allocator) Allocator.Error!IntrospectionResult {
         const caps = try capabilitiesImpl(ptr, alloc);
         defer {
@@ -222,12 +220,11 @@ pub const FallbackAgent = struct {
 // Tests
 // ============================================================================
 
-
-    fn processStreamImpl(ptr: *anyopaque, message: Message, callbacks: StreamCallbacks) AgentError!void {
-        _ = ptr;
-        _ = message;
-        callbacks.onError(AgentError.NotImplemented);
-    }
+fn processStreamImpl(ptr: *anyopaque, message: Message, callbacks: StreamCallbacks) AgentError!void {
+    _ = ptr;
+    _ = message;
+    callbacks.onError(AgentError.NotImplemented);
+}
 
 test "FallbackAgent: first agent success" {
     const allocator = std.testing.allocator;
@@ -247,8 +244,8 @@ test "FallbackAgent: first agent success" {
                     .name = nameImpl,
                     .capabilities = capabilitiesImpl,
                     .process = processImpl,
-                .process_stream = processStreamImpl,
-                .introspect = introspectImpl,
+                    .process_stream = processStreamImpl,
+                    .introspect = introspectImpl,
                     .deinit = deinitImpl,
                 },
             };

--- a/agenkit-zig/src/patterns/human_in_loop.zig
+++ b/agenkit-zig/src/patterns/human_in_loop.zig
@@ -49,8 +49,8 @@
 ///
 /// const result = try hitl.agent().process(input_message);
 /// ```
-
 const std = @import("std");
+const agktime = @import("../time_compat.zig");
 const Agent = @import("../agent.zig").Agent;
 const AgentError = @import("../agent.zig").AgentError;
 const StreamCallbacks = @import("../agent.zig").StreamCallbacks;
@@ -227,7 +227,7 @@ pub const HumanInLoopAgent = struct {
                     .message = response,
                     .confidence = confidence,
                     .context = context,
-                    .timestamp = std.time.timestamp(),
+                    .timestamp = agktime.timestamp(),
                 };
 
                 const approval_response = self.approval_fn(approval_request) catch {
@@ -309,12 +309,11 @@ pub fn confidenceBasedApprove(request: ApprovalRequest) AgentError!ApprovalRespo
 // Tests
 // ============================================================================
 
-
-    fn processStreamImpl(ptr: *anyopaque, message: Message, callbacks: StreamCallbacks) AgentError!void {
-        _ = ptr;
-        _ = message;
-        callbacks.onError(AgentError.NotImplemented);
-    }
+fn processStreamImpl(ptr: *anyopaque, message: Message, callbacks: StreamCallbacks) AgentError!void {
+    _ = ptr;
+    _ = message;
+    callbacks.onError(AgentError.NotImplemented);
+}
 
 test "HumanInLoopAgent: high confidence bypass" {
     // Skip test for now - requires mock infrastructure

--- a/agenkit-zig/src/patterns/memory.zig
+++ b/agenkit-zig/src/patterns/memory.zig
@@ -28,7 +28,7 @@
 /// const agenkit = @import("agenkit");
 ///
 /// pub fn main() !void {
-///     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+///     var gpa = std.heap.DebugAllocator(.{}){};
 ///     defer _ = gpa.deinit();
 ///     const allocator = gpa.allocator();
 ///

--- a/agenkit-zig/src/patterns/memory.zig
+++ b/agenkit-zig/src/patterns/memory.zig
@@ -54,8 +54,9 @@
 ///     }
 /// }
 /// ```
-
 const std = @import("std");
+const ioc = @import("../io_compat.zig");
+const agktime = @import("../time_compat.zig");
 const Allocator = std.mem.Allocator;
 const AgentError = @import("../agent.zig").AgentError;
 
@@ -80,7 +81,7 @@ pub const MemoryEntry = struct {
     ) !MemoryEntry {
         // Generate UUID-like ID
         var id_buf: [36]u8 = undefined;
-        const id_str = std.fmt.bufPrint(&id_buf, "{x:0>32}", .{std.crypto.random.int(u128)}) catch unreachable;
+        const id_str = std.fmt.bufPrint(&id_buf, "{x:0>32}", .{ioc.randomInt(u128)}) catch unreachable;
 
         const meta = if (metadata) |m| blk: {
             var new_map = std.StringHashMap([]const u8).init(allocator);
@@ -97,7 +98,7 @@ pub const MemoryEntry = struct {
             .id = try allocator.dupe(u8, id_str),
             .content = try allocator.dupe(u8, content),
             .metadata = meta,
-            .timestamp = std.time.timestamp(),
+            .timestamp = agktime.timestamp(),
             .access_count = 0,
             .last_accessed = null,
             .importance = importance,
@@ -145,7 +146,7 @@ pub const MemoryEntry = struct {
     /// Update access tracking
     pub fn markAccessed(self: *MemoryEntry) void {
         self.access_count += 1;
-        self.last_accessed = std.time.timestamp();
+        self.last_accessed = agktime.timestamp();
     }
 };
 
@@ -169,7 +170,7 @@ pub const WorkingMemory = struct {
         return WorkingMemory{
             .allocator = allocator,
             .max_messages = max_messages,
-            .messages = std.ArrayList(MemoryEntry){},
+            .messages = std.ArrayList(MemoryEntry).empty,
         };
     }
 
@@ -195,7 +196,7 @@ pub const WorkingMemory = struct {
     pub fn retrieve(self: *WorkingMemory, allocator: Allocator, query: []const u8, limit: usize) !std.ArrayList(MemoryEntry) {
         _ = query; // Working memory returns all recent messages
 
-        var results = std.ArrayList(MemoryEntry){};
+        var results = std.ArrayList(MemoryEntry).empty;
 
         const start = if (self.messages.items.len > limit)
             self.messages.items.len - limit
@@ -225,7 +226,7 @@ pub const WorkingMemory = struct {
 
     /// Get all working memory entries
     pub fn getAll(self: *const WorkingMemory, allocator: Allocator) !std.ArrayList(MemoryEntry) {
-        var results = std.ArrayList(MemoryEntry){};
+        var results = std.ArrayList(MemoryEntry).empty;
         for (self.messages.items) |*entry| {
             const cloned = try entry.clone();
             try results.append(allocator, cloned);
@@ -272,7 +273,7 @@ pub const ShortTermMemory = struct {
             .allocator = allocator,
             .max_messages = max_messages,
             .ttl_seconds = ttl_seconds,
-            .messages = std.ArrayList(MemoryEntry){},
+            .messages = std.ArrayList(MemoryEntry).empty,
         };
     }
 
@@ -285,7 +286,7 @@ pub const ShortTermMemory = struct {
 
     /// Clean expired entries
     fn cleanExpired(self: *ShortTermMemory) void {
-        const now = std.time.timestamp();
+        const now = agktime.timestamp();
         var i: usize = 0;
         while (i < self.messages.items.len) {
             const age = now - self.messages.items[i].timestamp;
@@ -326,7 +327,7 @@ pub const ShortTermMemory = struct {
         self.cleanExpired();
 
         // Sort by timestamp (most recent first)
-        var sorted = std.ArrayList(MemoryEntry){};
+        var sorted = std.ArrayList(MemoryEntry).empty;
         for (self.messages.items) |*entry| {
             const cloned = try entry.clone();
             try sorted.append(allocator, cloned);
@@ -339,7 +340,7 @@ pub const ShortTermMemory = struct {
         }.lessThan);
 
         // Take top limit
-        var results = std.ArrayList(MemoryEntry){};
+        var results = std.ArrayList(MemoryEntry).empty;
         const count = @min(sorted.items.len, limit);
         for (sorted.items[0..count]) |*entry| {
             // Mark accessed in original
@@ -434,7 +435,7 @@ pub const LongTermMemory = struct {
             score: f64,
         };
 
-        var scored_entries = std.ArrayList(ScoredEntry){};
+        var scored_entries = std.ArrayList(ScoredEntry).empty;
         defer scored_entries.deinit(allocator);
 
         const query_lower = try std.ascii.allocLowerString(allocator, query);
@@ -456,7 +457,7 @@ pub const LongTermMemory = struct {
             score += entry.importance * 0.3;
 
             // Recency weight
-            const now = std.time.timestamp();
+            const now = agktime.timestamp();
             const age_days: f64 = @as(f64, @floatFromInt(now - entry.timestamp)) / 86400.0;
             const recency_score = @max(0.0, 1.0 - age_days / 365.0);
             score += recency_score * 0.2;
@@ -472,7 +473,7 @@ pub const LongTermMemory = struct {
         }.lessThan);
 
         // Take top limit and clone
-        var results = std.ArrayList(MemoryEntry){};
+        var results = std.ArrayList(MemoryEntry).empty;
         const count = @min(scored_entries.items.len, limit);
         for (scored_entries.items[0..count]) |scored| {
             // Mark accessed in original
@@ -580,7 +581,7 @@ pub const MemoryHierarchy = struct {
         limit: usize,
         search_tiers: ?[]const []const u8,
     ) !std.ArrayList(MemoryEntry) {
-        var all_results = std.ArrayList(MemoryEntry){};
+        var all_results = std.ArrayList(MemoryEntry).empty;
         errdefer {
             for (all_results.items) |*entry| {
                 entry.deinit();
@@ -640,7 +641,7 @@ pub const MemoryHierarchy = struct {
         var seen = std.StringHashMap(void).init(allocator);
         defer seen.deinit();
 
-        var unique = std.ArrayList(MemoryEntry){};
+        var unique = std.ArrayList(MemoryEntry).empty;
         for (all_results.items) |*entry| {
             if (!seen.contains(entry.id)) {
                 try seen.put(entry.id, {});

--- a/agenkit-zig/src/patterns/multiagent.zig
+++ b/agenkit-zig/src/patterns/multiagent.zig
@@ -49,7 +49,6 @@
 ///     defer response.deinit();
 /// }
 /// ```
-
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 const Agent = @import("../agent.zig").Agent;
@@ -155,9 +154,9 @@ pub const MultiAgentOrchestrator = struct {
     pub fn init(allocator: Allocator, strategy: OrchestrationStrategy) !MultiAgentOrchestrator {
         return MultiAgentOrchestrator{
             .allocator = allocator,
-            .agents = std.ArrayList(RegisteredAgent){},
+            .agents = std.ArrayList(RegisteredAgent).empty,
             .strategy = strategy,
-            .tasks = std.ArrayList(AgentTask){},
+            .tasks = std.ArrayList(AgentTask).empty,
             .agent_name = try allocator.dupe(u8, "MultiAgentOrchestrator"),
         };
     }
@@ -188,7 +187,7 @@ pub const MultiAgentOrchestrator = struct {
 
     /// Get list of registered agent names
     pub fn listAgents(self: *const MultiAgentOrchestrator, allocator: Allocator) !std.ArrayList([]const u8) {
-        var names = std.ArrayList([]const u8){};
+        var names = std.ArrayList([]const u8).empty;
         for (self.agents.items) |entry| {
             try names.append(allocator, try allocator.dupe(u8, entry.name));
         }
@@ -211,7 +210,7 @@ pub const MultiAgentOrchestrator = struct {
             return AgentError.InvalidInput;
         }
 
-        var results = std.ArrayList([]const u8){};
+        var results = std.ArrayList([]const u8).empty;
         defer {
             for (results.items) |r| {
                 self.allocator.free(r);
@@ -256,7 +255,7 @@ pub const MultiAgentOrchestrator = struct {
         }
 
         // Combine all results
-        var combined = std.ArrayList(u8){};
+        var combined = std.ArrayList(u8).empty;
         defer combined.deinit(self.allocator);
 
         for (results.items, 0..) |r, i| {
@@ -307,7 +306,6 @@ pub const MultiAgentOrchestrator = struct {
         return Result{ .ok = response };
     }
 
-
     fn introspectImpl(ptr: *anyopaque, alloc: Allocator) Allocator.Error!IntrospectionResult {
         const caps = try capabilitiesImpl(ptr, alloc);
         defer {
@@ -343,12 +341,11 @@ pub const MultiAgentOrchestrator = struct {
 const testing = std.testing;
 const EchoAgent = @import("../agent.zig").EchoAgent;
 
-
-    fn processStreamImpl(ptr: *anyopaque, message: Message, callbacks: StreamCallbacks) AgentError!void {
-        _ = ptr;
-        _ = message;
-        callbacks.onError(AgentError.NotImplemented);
-    }
+fn processStreamImpl(ptr: *anyopaque, message: Message, callbacks: StreamCallbacks) AgentError!void {
+    _ = ptr;
+    _ = message;
+    callbacks.onError(AgentError.NotImplemented);
+}
 
 test "TaskStatus toString" {
     try testing.expectEqualStrings("pending", TaskStatus.pending.toString());

--- a/agenkit-zig/src/patterns/multiagent.zig
+++ b/agenkit-zig/src/patterns/multiagent.zig
@@ -26,7 +26,7 @@
 /// const agenkit = @import("agenkit");
 ///
 /// pub fn main() !void {
-///     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+///     var gpa = std.heap.DebugAllocator(.{}){};
 ///     defer _ = gpa.deinit();
 ///     const allocator = gpa.allocator();
 ///

--- a/agenkit-zig/src/patterns/parallel.zig
+++ b/agenkit-zig/src/patterns/parallel.zig
@@ -29,7 +29,6 @@
 ///   Each agent processes an independent copy of the input message.
 ///   Agents must not modify the message in place; they are expected to
 ///   produce a new Message as their result.
-
 const std = @import("std");
 const Agent = @import("../agent.zig").Agent;
 const AgentError = @import("../agent.zig").AgentError;
@@ -271,7 +270,6 @@ pub const ParallelAgent = struct {
         return Result{ .ok = aggregated };
     }
 
-
     fn introspectImpl(ptr: *anyopaque, alloc: Allocator) Allocator.Error!IntrospectionResult {
         const caps = try capabilitiesImpl(ptr, alloc);
         defer {
@@ -313,12 +311,11 @@ pub const ParallelPattern = ParallelAgent;
 // Tests
 // ============================================================================
 
-
-    fn processStreamImpl(ptr: *anyopaque, message: Message, callbacks: StreamCallbacks) AgentError!void {
-        _ = ptr;
-        _ = message;
-        callbacks.onError(AgentError.NotImplemented);
-    }
+fn processStreamImpl(ptr: *anyopaque, message: Message, callbacks: StreamCallbacks) AgentError!void {
+    _ = ptr;
+    _ = message;
+    callbacks.onError(AgentError.NotImplemented);
+}
 
 test "ParallelAgent basic execution" {
     const allocator = std.testing.allocator;
@@ -366,7 +363,7 @@ test "ParallelAgent custom aggregator" {
             }
 
             // Concatenate all content
-            var buffer = std.ArrayList(u8){};
+            var buffer = std.ArrayList(u8).empty;
             defer buffer.deinit(alloc);
 
             for (messages, 0..) |m, i| {
@@ -418,7 +415,7 @@ test "ParallelAgent name and capabilities" {
     var echo1 = try EchoAgent.init(allocator);
     defer echo1.agent().deinit();
 
-    const agents = [_]Agent{ echo1.agent() };
+    const agents = [_]Agent{echo1.agent()};
     var parallel = try ParallelAgent.init(allocator, &agents, "my_parallel", defaultAggregator);
     defer parallel.deinit();
 

--- a/agenkit-zig/src/patterns/planning.zig
+++ b/agenkit-zig/src/patterns/planning.zig
@@ -43,7 +43,6 @@
 ///     defer response.deinit();
 /// }
 /// ```
-
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 const Agent = @import("../agent.zig").Agent;
@@ -95,7 +94,7 @@ pub const PlanStep = struct {
     allocator: Allocator,
 
     pub fn init(allocator: Allocator, description: []const u8, step_number: usize, dependencies: []const usize) !PlanStep {
-        var deps = std.ArrayList(usize){};
+        var deps = std.ArrayList(usize).empty;
         try deps.appendSlice(allocator, dependencies);
 
         return PlanStep{
@@ -167,7 +166,7 @@ pub const Plan = struct {
     pub fn init(allocator: Allocator, goal: []const u8) !Plan {
         return Plan{
             .goal = try allocator.dupe(u8, goal),
-            .steps = std.ArrayList(PlanStep){},
+            .steps = std.ArrayList(PlanStep).empty,
             .allocator = allocator,
         };
     }
@@ -188,7 +187,7 @@ pub const Plan = struct {
     /// Get all steps that can be executed now
     pub fn getNextSteps(self: *const Plan, allocator: Allocator) !std.ArrayList(usize) {
         // Get completed step indices
-        var completed = std.ArrayList(usize){};
+        var completed = std.ArrayList(usize).empty;
         defer completed.deinit(allocator);
 
         for (self.steps.items, 0..) |step, i| {
@@ -198,7 +197,7 @@ pub const Plan = struct {
         }
 
         // Find pending steps with met dependencies
-        var next = std.ArrayList(usize){};
+        var next = std.ArrayList(usize).empty;
         for (self.steps.items) |step| {
             if (step.status == .pending and step.canExecute(completed.items)) {
                 try next.append(allocator, step.step_number);
@@ -427,7 +426,7 @@ pub const PlanningAgent = struct {
 
     /// Execute all steps in the plan
     fn executePlan(self: *PlanningAgent, plan: *Plan) ![]const u8 {
-        var results = std.ArrayList([]const u8){};
+        var results = std.ArrayList([]const u8).empty;
         defer {
             for (results.items) |r| {
                 self.allocator.free(r);
@@ -484,7 +483,7 @@ pub const PlanningAgent = struct {
         }
 
         // Generate summary
-        var summary = std.ArrayList(u8){};
+        var summary = std.ArrayList(u8).empty;
         defer summary.deinit(self.allocator);
 
         for (results.items) |r| {
@@ -588,7 +587,6 @@ pub const PlanningAgent = struct {
         return Result{ .ok = response };
     }
 
-
     fn introspectImpl(ptr: *anyopaque, alloc: Allocator) Allocator.Error!IntrospectionResult {
         const caps = try capabilitiesImpl(ptr, alloc);
         defer {
@@ -623,12 +621,11 @@ pub const PlanningAgent = struct {
 // Tests
 const testing = std.testing;
 
-
-    fn processStreamImpl(ptr: *anyopaque, message: Message, callbacks: StreamCallbacks) AgentError!void {
-        _ = ptr;
-        _ = message;
-        callbacks.onError(AgentError.NotImplemented);
-    }
+fn processStreamImpl(ptr: *anyopaque, message: Message, callbacks: StreamCallbacks) AgentError!void {
+    _ = ptr;
+    _ = message;
+    callbacks.onError(AgentError.NotImplemented);
+}
 
 test "StepStatus toString" {
     try testing.expectEqualStrings("pending", StepStatus.pending.toString());

--- a/agenkit-zig/src/patterns/planning.zig
+++ b/agenkit-zig/src/patterns/planning.zig
@@ -24,7 +24,7 @@
 /// const agenkit = @import("agenkit");
 ///
 /// pub fn main() !void {
-///     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+///     var gpa = std.heap.DebugAllocator(.{}){};
 ///     defer _ = gpa.deinit();
 ///     const allocator = gpa.allocator();
 ///

--- a/agenkit-zig/src/patterns/react.zig
+++ b/agenkit-zig/src/patterns/react.zig
@@ -11,7 +11,6 @@
 ///
 /// References:
 /// - ReAct Paper: https://arxiv.org/abs/2210.03629
-
 const std = @import("std");
 const Agent = @import("../agent.zig").Agent;
 const Message = @import("../message.zig").Message;
@@ -172,7 +171,7 @@ pub const ToolRegistry = struct {
     }
 
     pub fn listTools(self: *ToolRegistry, allocator: Allocator) ![][]const u8 {
-        var list = std.ArrayList([]const u8){};
+        var list = std.ArrayList([]const u8).empty;
         errdefer list.deinit(allocator);
 
         var iter = self.tools.keyIterator();
@@ -189,7 +188,7 @@ pub const ToolRegistry = struct {
             return try allocator.dupe(u8, "No tools available.");
         }
 
-        var buffer = std.ArrayList(u8){};
+        var buffer = std.ArrayList(u8).empty;
         defer buffer.deinit(allocator);
 
         try buffer.appendSlice(allocator, "Available tools:\n");
@@ -275,7 +274,7 @@ pub const ReActAgent = struct {
             .max_iterations = max_iterations,
             .system_prompt = system_prompt,
             .verbose = verbose,
-            .steps = .{},
+            .steps = .empty,
             .agent_name = try allocator.dupe(u8, "ReActAgent"),
         };
 
@@ -395,7 +394,6 @@ pub const ReActAgent = struct {
         return self.agent_name;
     }
 
-
     fn introspectImpl(ptr: *anyopaque, alloc: Allocator) Allocator.Error!IntrospectionResult {
         const caps = try capabilitiesImpl(ptr, alloc);
         defer {
@@ -461,7 +459,7 @@ pub const ReActAgent = struct {
     fn formatFinalResponse(self: *ReActAgent, answer: []const u8) !Message {
         if (self.verbose) {
             // Include thought process
-            var buffer = std.ArrayList(u8){};
+            var buffer = std.ArrayList(u8).empty;
             defer buffer.deinit(self.allocator);
 
             for (self.steps.items, 0..) |step, i| {
@@ -505,11 +503,11 @@ pub const ReActAgent = struct {
 
 // Tests
 
-    fn processStreamImpl(ptr: *anyopaque, message: Message, callbacks: StreamCallbacks) AgentError!void {
-        _ = ptr;
-        _ = message;
-        callbacks.onError(AgentError.NotImplemented);
-    }
+fn processStreamImpl(ptr: *anyopaque, message: Message, callbacks: StreamCallbacks) AgentError!void {
+    _ = ptr;
+    _ = message;
+    callbacks.onError(AgentError.NotImplemented);
+}
 
 test "Tool creation and execution" {
     const allocator = std.testing.allocator;

--- a/agenkit-zig/src/patterns/reasoning_with_tools.zig
+++ b/agenkit-zig/src/patterns/reasoning_with_tools.zig
@@ -43,7 +43,6 @@
 /// const result = try agent.agent().process(message);
 /// // Inspect reasoning trace in metadata
 /// ```
-
 const std = @import("std");
 const Agent = @import("../agent.zig").Agent;
 const AgentError = @import("../agent.zig").AgentError;
@@ -245,7 +244,6 @@ pub const ReasoningWithToolsAgent = struct {
         return self.allocator.realloc(prompt, offset);
     }
 
-
     fn introspectImpl(ptr: *anyopaque, alloc: Allocator) Allocator.Error!IntrospectionResult {
         const caps = try capabilitiesImpl(ptr, alloc);
         defer {
@@ -280,12 +278,11 @@ pub const ReasoningWithToolsAgent = struct {
 // Tests
 // ============================================================================
 
-
-    fn processStreamImpl(ptr: *anyopaque, message: Message, callbacks: StreamCallbacks) AgentError!void {
-        _ = ptr;
-        _ = message;
-        callbacks.onError(AgentError.NotImplemented);
-    }
+fn processStreamImpl(ptr: *anyopaque, message: Message, callbacks: StreamCallbacks) AgentError!void {
+    _ = ptr;
+    _ = message;
+    callbacks.onError(AgentError.NotImplemented);
+}
 
 test "ReasoningWithToolsAgent: initialization" {
     const allocator = std.testing.allocator;

--- a/agenkit-zig/src/patterns/reflection.zig
+++ b/agenkit-zig/src/patterns/reflection.zig
@@ -20,7 +20,6 @@
 /// References:
 /// - Reflexion: Language Agents with Verbal Reinforcement Learning
 /// - Self-Refine: Iterative Refinement with Self-Feedback
-
 const std = @import("std");
 const Agent = @import("../agent.zig").Agent;
 const AgentError = @import("../agent.zig").AgentError;
@@ -130,7 +129,7 @@ pub const ReflectionAgent = struct {
             .improvement_threshold = improvement_threshold,
             .critique_format = critique_format,
             .verbose = verbose,
-            .history = .{},
+            .history = .empty,
         };
         return self;
     }
@@ -567,7 +566,6 @@ pub const ReflectionAgent = struct {
         return Result{ .ok = result };
     }
 
-
     fn introspectImpl(ptr: *anyopaque, alloc: Allocator) Allocator.Error!IntrospectionResult {
         const caps = try capabilitiesImpl(ptr, alloc);
         defer {
@@ -600,12 +598,11 @@ pub const ReflectionAgent = struct {
 // Tests
 // ============================================================================
 
-
-    fn processStreamImpl(ptr: *anyopaque, message: Message, callbacks: StreamCallbacks) AgentError!void {
-        _ = ptr;
-        _ = message;
-        callbacks.onError(AgentError.NotImplemented);
-    }
+fn processStreamImpl(ptr: *anyopaque, message: Message, callbacks: StreamCallbacks) AgentError!void {
+    _ = ptr;
+    _ = message;
+    callbacks.onError(AgentError.NotImplemented);
+}
 
 test "ReflectionAgent basic functionality" {
     const allocator = std.testing.allocator;

--- a/agenkit-zig/src/patterns/router.zig
+++ b/agenkit-zig/src/patterns/router.zig
@@ -53,7 +53,6 @@
 ///
 /// const result = try router.agent().process(input_message);
 /// ```
-
 const std = @import("std");
 const Agent = @import("../agent.zig").Agent;
 const AgentError = @import("../agent.zig").AgentError;
@@ -411,12 +410,11 @@ pub const SimpleClassifier = struct {
 // Tests
 // ============================================================================
 
-
-    fn processStreamImpl(ptr: *anyopaque, message: Message, callbacks: StreamCallbacks) AgentError!void {
-        _ = ptr;
-        _ = message;
-        callbacks.onError(AgentError.NotImplemented);
-    }
+fn processStreamImpl(ptr: *anyopaque, message: Message, callbacks: StreamCallbacks) AgentError!void {
+    _ = ptr;
+    _ = message;
+    callbacks.onError(AgentError.NotImplemented);
+}
 
 test "RouterAgent: basic routing" {
     // Skip test for now - requires more complex mock infrastructure

--- a/agenkit-zig/src/patterns/sequential.zig
+++ b/agenkit-zig/src/patterns/sequential.zig
@@ -20,7 +20,6 @@
 ///     defer sequential.deinit();
 ///
 ///     const result = try sequential.agent().process(input_message);
-
 const std = @import("std");
 const Agent = @import("../agent.zig").Agent;
 const AgentError = @import("../agent.zig").AgentError;
@@ -197,12 +196,11 @@ pub const SequentialPattern = SequentialAgent;
 // Tests
 // ============================================================================
 
-
-    fn processStreamImpl(ptr: *anyopaque, message: Message, callbacks: StreamCallbacks) AgentError!void {
-        _ = ptr;
-        _ = message;
-        callbacks.onError(AgentError.NotImplemented);
-    }
+fn processStreamImpl(ptr: *anyopaque, message: Message, callbacks: StreamCallbacks) AgentError!void {
+    _ = ptr;
+    _ = message;
+    callbacks.onError(AgentError.NotImplemented);
+}
 
 test "SequentialAgent basic execution" {
     const allocator = std.testing.allocator;
@@ -283,11 +281,7 @@ test "SequentialAgent preserves transformations" {
             };
 
             // Add prefix
-            const new_text = std.fmt.allocPrint(
-                self.allocator,
-                "{s}{s}",
-                .{ self.prefix, text }
-            ) catch {
+            const new_text = std.fmt.allocPrint(self.allocator, "{s}{s}", .{ self.prefix, text }) catch {
                 return Result{ .err = AgentError.ProcessingFailed };
             };
             defer self.allocator.free(new_text);
@@ -298,7 +292,6 @@ test "SequentialAgent preserves transformations" {
 
             return Result{ .ok = response };
         }
-
 
         fn processStreamImplTransform(ptr: *anyopaque, message: Message, callbacks: StreamCallbacks) AgentError!void {
             _ = ptr;
@@ -349,7 +342,7 @@ test "SequentialAgent name and capabilities" {
     var echo1 = try EchoAgent.init(allocator);
     defer echo1.agent().deinit();
 
-    const agents = [_]Agent{ echo1.agent() };
+    const agents = [_]Agent{echo1.agent()};
     var sequential = try SequentialAgent.init(allocator, &agents, "my_pipeline");
     defer sequential.deinit();
 

--- a/agenkit-zig/src/patterns/supervisor.zig
+++ b/agenkit-zig/src/patterns/supervisor.zig
@@ -47,7 +47,6 @@
 ///
 /// const result = try supervisor.agent().process(complex_task);
 /// ```
-
 const std = @import("std");
 const Agent = @import("../agent.zig").Agent;
 const AgentError = @import("../agent.zig").AgentError;
@@ -511,12 +510,11 @@ pub const SimplePlanner = struct {
 // Tests
 // ============================================================================
 
-
-    fn processStreamImpl(ptr: *anyopaque, message: Message, callbacks: StreamCallbacks) AgentError!void {
-        _ = ptr;
-        _ = message;
-        callbacks.onError(AgentError.NotImplemented);
-    }
+fn processStreamImpl(ptr: *anyopaque, message: Message, callbacks: StreamCallbacks) AgentError!void {
+    _ = ptr;
+    _ = message;
+    callbacks.onError(AgentError.NotImplemented);
+}
 
 test "SupervisorAgent: basic coordination" {
     // Skip test for now - requires mock infrastructure

--- a/agenkit-zig/src/patterns/task.zig
+++ b/agenkit-zig/src/patterns/task.zig
@@ -29,7 +29,7 @@
 /// const agenkit = @import("agenkit");
 ///
 /// pub fn main() !void {
-///     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+///     var gpa = std.heap.DebugAllocator(.{}){};
 ///     defer _ = gpa.deinit();
 ///     const allocator = gpa.allocator();
 ///

--- a/agenkit-zig/src/patterns/task.zig
+++ b/agenkit-zig/src/patterns/task.zig
@@ -53,7 +53,6 @@
 ///     // Task automatically marked as completed, cannot reuse
 /// }
 /// ```
-
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 const Agent = @import("../agent.zig").Agent;
@@ -204,12 +203,11 @@ fn cloneMessage(allocator: Allocator, msg: Message) !Message {
 const testing = std.testing;
 const EchoAgent = @import("../agent.zig").EchoAgent;
 
-
-    fn processStreamImpl(ptr: *anyopaque, message: Message, callbacks: StreamCallbacks) AgentError!void {
-        _ = ptr;
-        _ = message;
-        callbacks.onError(AgentError.NotImplemented);
-    }
+fn processStreamImpl(ptr: *anyopaque, message: Message, callbacks: StreamCallbacks) AgentError!void {
+    _ = ptr;
+    _ = message;
+    callbacks.onError(AgentError.NotImplemented);
+}
 
 test "TaskConfig default" {
     const config = TaskConfig{};
@@ -381,7 +379,6 @@ const FailingAgent = struct {
 
         return Result{ .ok = response };
     }
-
 
     fn introspectImpl(ptr: *anyopaque, alloc: Allocator) Allocator.Error!IntrospectionResult {
         const caps = try capabilitiesImpl(ptr, alloc);

--- a/agenkit-zig/src/protocols/mcp.zig
+++ b/agenkit-zig/src/protocols/mcp.zig
@@ -24,8 +24,9 @@
 /// const tools = try cli.listTools(allocator);
 /// defer allocator.free(tools);
 /// ```
-
 const std = @import("std");
+const ioc = @import("../io_compat.zig");
+const agksync = @import("../sync_compat.zig");
 const Allocator = std.mem.Allocator;
 
 // ── Protocol constants ────────────────────────────────────────────────────────
@@ -86,7 +87,7 @@ pub const McpServerInfo = struct {
 /// Concatenate all text-type content blocks, separated by spaces.
 /// Caller owns the returned slice.
 pub fn textContent(allocator: Allocator, contents: []const McpContent) ![]u8 {
-    var parts = std.ArrayList(u8){};
+    var parts = std.ArrayList(u8).empty;
     defer parts.deinit(allocator);
     for (contents) |c| {
         if (std.mem.eql(u8, c.type, "text") and c.text.len > 0) {
@@ -151,7 +152,7 @@ pub const StdioClient = struct {
     args: []const []const u8,
     child: ?std.process.Child = null,
     next_id: u64 = 1,
-    mutex: std.Thread.Mutex = .{},
+    mutex: agksync.Mutex = .{},
     server_info_data: McpServerInfo = .{},
 
     pub fn init(allocator: Allocator, command: []const u8, args: []const []const u8) StdioClient {
@@ -184,15 +185,16 @@ pub const StdioClient = struct {
         argv[0] = self.command;
         for (self.args, 0..) |a, i| argv[i + 1] = a;
 
-        var child = std.process.Child.init(argv, self.allocator);
-        child.stdin_behavior = .Pipe;
-        child.stdout_behavior = .Pipe;
-        child.stderr_behavior = .Ignore;
-        try child.spawn();
+        const child = try std.process.spawn(ioc.io(), .{
+            .argv = argv,
+            .stdin = .pipe,
+            .stdout = .pipe,
+            .stderr = .ignore,
+        });
         self.child = child;
 
         // Build initialize params
-        var params_str = std.ArrayList(u8){};
+        var params_str = std.ArrayList(u8).empty;
         defer params_str.deinit(self.allocator);
         try params_str.appendSlice(self.allocator, "{\"protocolVersion\":\"");
         try params_str.appendSlice(self.allocator, PROTOCOL_VERSION);
@@ -244,7 +246,7 @@ pub const StdioClient = struct {
         const args_str = try std.json.Stringify.valueAlloc(self.allocator, args, .{});
         defer self.allocator.free(args_str);
 
-        var params_json = std.ArrayList(u8){};
+        var params_json = std.ArrayList(u8).empty;
         defer params_json.deinit(self.allocator);
         try params_json.appendSlice(self.allocator, "{\"name\":\"");
         try params_json.appendSlice(self.allocator, name);
@@ -269,9 +271,9 @@ pub const StdioClient = struct {
     fn deinitImpl(ptr: *anyopaque) void {
         const self: *StdioClient = @ptrCast(@alignCast(ptr));
         if (self.child) |*child| {
-            if (child.stdin) |stdin| stdin.close();
+            if (child.stdin) |stdin| stdin.close(ioc.io());
             child.stdin = null;
-            _ = child.wait() catch {};
+            _ = child.wait(ioc.io()) catch {};
         }
         if (self.server_info_data.name.len > 0) self.allocator.free(self.server_info_data.name);
         if (self.server_info_data.version.len > 0) self.allocator.free(self.server_info_data.version);
@@ -292,7 +294,7 @@ pub const StdioClient = struct {
         self.next_id += 1;
 
         // Build request line into a buffer
-        var line = std.ArrayList(u8){};
+        var line = std.ArrayList(u8).empty;
         defer line.deinit(self.allocator);
 
         // "{\"jsonrpc\":\"2.0\",\"id\":<id>,\"method\":\"<method>\""
@@ -314,11 +316,11 @@ pub const StdioClient = struct {
         try line.append(self.allocator, '}');
         try line.append(self.allocator, '\n');
 
-        try stdin_file.writeAll(line.items);
+        try stdin_file.writeStreamingAll(ioc.io(), line.items);
 
         // Read response line
         var read_buf: [65536]u8 = undefined;
-        var file_reader = stdout_file.reader(&read_buf);
+        var file_reader = stdout_file.reader(ioc.io(), &read_buf);
         const resp_line = try file_reader.interface.takeDelimiterExclusive('\n');
         const resp_owned = try self.allocator.dupe(u8, resp_line);
         defer self.allocator.free(resp_owned);
@@ -331,12 +333,12 @@ pub const StdioClient = struct {
         const child = &(self.child orelse return error.NotInitialized);
         const stdin_file = child.stdin orelse return error.NotInitialized;
 
-        var line = std.ArrayList(u8){};
+        var line = std.ArrayList(u8).empty;
         defer line.deinit(self.allocator);
         try line.appendSlice(self.allocator, "{\"jsonrpc\":\"2.0\",\"method\":\"");
         try line.appendSlice(self.allocator, method);
         try line.appendSlice(self.allocator, "\"}\n");
-        try stdin_file.writeAll(line.items);
+        try stdin_file.writeStreamingAll(ioc.io(), line.items);
     }
 };
 
@@ -374,7 +376,7 @@ pub const HttpClient = struct {
     fn initializeImpl(ptr: *anyopaque) !void {
         const self: *HttpClient = @ptrCast(@alignCast(ptr));
 
-        var params_str = std.ArrayList(u8){};
+        var params_str = std.ArrayList(u8).empty;
         defer params_str.deinit(self.allocator);
         try params_str.appendSlice(self.allocator, "{\"protocolVersion\":\"");
         try params_str.appendSlice(self.allocator, PROTOCOL_VERSION);
@@ -416,7 +418,7 @@ pub const HttpClient = struct {
         const args_str = try std.json.Stringify.valueAlloc(self.allocator, args, .{});
         defer self.allocator.free(args_str);
 
-        var params_json = std.ArrayList(u8){};
+        var params_json = std.ArrayList(u8).empty;
         defer params_json.deinit(self.allocator);
         try params_json.appendSlice(self.allocator, "{\"name\":\"");
         try params_json.appendSlice(self.allocator, name);
@@ -451,7 +453,7 @@ pub const HttpClient = struct {
         self.next_id += 1;
 
         // Build request body
-        var body = std.ArrayList(u8){};
+        var body = std.ArrayList(u8).empty;
         defer body.deinit(self.allocator);
 
         try body.appendSlice(self.allocator, "{\"jsonrpc\":\"2.0\",\"id\":");
@@ -472,14 +474,14 @@ pub const HttpClient = struct {
         try body.append(self.allocator, '}');
 
         // Make HTTP request
-        var http_client = std.http.Client{ .allocator = self.allocator };
+        var http_client = std.http.Client{ .allocator = self.allocator, .io = ioc.io() };
         defer http_client.deinit();
 
         const headers = [_]std.http.Header{
             .{ .name = "Content-Type", .value = "application/json" },
         };
 
-        var response_body: std.io.Writer.Allocating = .init(self.allocator);
+        var response_body: std.Io.Writer.Allocating = .init(self.allocator);
         defer response_body.deinit();
 
         const result = try http_client.fetch(.{
@@ -568,11 +570,11 @@ pub const McpServer = struct {
 
     /// Serve MCP protocol over stdin/stdout until EOF.
     pub fn serveStdio(self: *McpServer) !void {
-        const stdin_file = std.fs.File.stdin();
-        const stdout_file = std.fs.File.stdout();
+        const stdin_file = std.Io.File.stdin();
+        const stdout_file = std.Io.File.stdout();
 
         var read_buf: [65536]u8 = undefined;
-        var file_reader = stdin_file.reader(&read_buf);
+        var file_reader = stdin_file.reader(ioc.io(), &read_buf);
 
         while (true) {
             const line = file_reader.interface.takeDelimiterExclusive('\n') catch |err| switch (err) {
@@ -591,7 +593,7 @@ pub const McpServer = struct {
             if (response.len == 0) continue;
 
             var write_buf: [4096]u8 = undefined;
-            var file_writer = stdout_file.writer(&write_buf);
+            var file_writer = stdout_file.writer(ioc.io(), &write_buf);
             try file_writer.interface.writeAll(response);
             try file_writer.interface.writeByte('\n');
             try file_writer.interface.flush();
@@ -614,7 +616,7 @@ pub const McpServer = struct {
     }
 
     fn handleInitialize(self: *McpServer, id: u64) ![]u8 {
-        var buf = std.ArrayList(u8){};
+        var buf = std.ArrayList(u8).empty;
         defer buf.deinit(self.allocator);
         var id_buf: [24]u8 = undefined;
         const id_str = std.fmt.bufPrint(&id_buf, "{d}", .{id}) catch unreachable;
@@ -631,7 +633,7 @@ pub const McpServer = struct {
     }
 
     fn handleToolsList(self: *McpServer, id: u64) ![]u8 {
-        var buf = std.ArrayList(u8){};
+        var buf = std.ArrayList(u8).empty;
         defer buf.deinit(self.allocator);
         var id_buf: [24]u8 = undefined;
         const id_str = std.fmt.bufPrint(&id_buf, "{d}", .{id}) catch unreachable;
@@ -668,7 +670,7 @@ pub const McpServer = struct {
                 return self.errorResponse(id, -32603, "Tool execution failed");
             };
 
-            var buf = std.ArrayList(u8){};
+            var buf = std.ArrayList(u8).empty;
             defer buf.deinit(self.allocator);
             var id_buf: [24]u8 = undefined;
             const id_str = std.fmt.bufPrint(&id_buf, "{d}", .{id}) catch unreachable;
@@ -693,7 +695,7 @@ pub const McpServer = struct {
     }
 
     fn errorResponse(self: *McpServer, id: u64, code: i32, message: []const u8) ![]u8 {
-        var buf = std.ArrayList(u8){};
+        var buf = std.ArrayList(u8).empty;
         defer buf.deinit(self.allocator);
         var id_buf: [24]u8 = undefined;
         const id_str = std.fmt.bufPrint(&id_buf, "{d}", .{id}) catch unreachable;
@@ -916,14 +918,14 @@ fn deepCloneJsonValue(allocator: Allocator, value: std.json.Value) !std.json.Val
             return std.json.Value{ .array = new_arr };
         },
         .object => |obj| {
-            var new_obj = std.json.ObjectMap.init(allocator);
-            errdefer new_obj.deinit();
+            var new_obj = std.json.ObjectMap.empty;
+            errdefer new_obj.deinit(allocator);
             var it = obj.iterator();
             while (it.next()) |entry| {
                 const key = try allocator.dupe(u8, entry.key_ptr.*);
                 errdefer allocator.free(key);
                 const val = try deepCloneJsonValue(allocator, entry.value_ptr.*);
-                try new_obj.put(key, val);
+                try new_obj.put(allocator, key, val);
             }
             return std.json.Value{ .object = new_obj };
         },
@@ -946,7 +948,7 @@ fn freeJsonValue(allocator: Allocator, value: std.json.Value) void {
                 freeJsonValue(allocator, entry.value_ptr.*);
             }
             var mut_obj = obj;
-            mut_obj.deinit();
+            mut_obj.deinit(allocator);
         },
         else => {},
     }

--- a/agenkit-zig/src/root.zig
+++ b/agenkit-zig/src/root.zig
@@ -18,7 +18,7 @@
 /// const std = @import("std");
 ///
 /// pub fn main() !void {
-///     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+///     var gpa = std.heap.DebugAllocator(.{}){};
 ///     defer _ = gpa.deinit();
 ///     const allocator = gpa.allocator();
 ///

--- a/agenkit-zig/src/root.zig
+++ b/agenkit-zig/src/root.zig
@@ -57,6 +57,12 @@
 /// - Composable patterns
 const std = @import("std");
 
+// Zig 0.16 compatibility shims (time/sync/env primitives that moved to the Io model)
+pub const time_compat = @import("time_compat.zig");
+pub const sync_compat = @import("sync_compat.zig");
+pub const env_compat = @import("env_compat.zig");
+pub const io_compat = @import("io_compat.zig");
+
 // Core types
 pub const Message = @import("message.zig").Message;
 pub const Role = @import("message.zig").Role;

--- a/agenkit-zig/src/safety.zig
+++ b/agenkit-zig/src/safety.zig
@@ -29,7 +29,6 @@
 /// defer logger.deinit();
 /// try logger.logAccessGranted("user123", "/api/data", "my-agent");
 /// ```
-
 pub const validation = @import("safety/validation.zig");
 pub const permissions = @import("safety/permissions.zig");
 pub const anomaly = @import("safety/anomaly.zig");

--- a/agenkit-zig/src/safety/anomaly.zig
+++ b/agenkit-zig/src/safety/anomaly.zig
@@ -6,6 +6,7 @@
 /// - Repeated failures
 /// - Unusual input/output sizes
 const std = @import("std");
+const agktime = @import("../time_compat.zig");
 const mem = std.mem;
 const Allocator = std.mem.Allocator;
 const ArrayList = std.ArrayList;
@@ -69,10 +70,10 @@ pub const AnomalyDetector = struct {
             .request_timestamps = StringHashMap(ArrayList(f64)).init(allocator),
             .failure_counts = StringHashMap(i32).init(allocator),
             .request_counts = StringHashMap(i32).init(allocator),
-            .input_sizes = std.ArrayList(f64){},
-            .output_sizes = std.ArrayList(f64){},
-            .processing_times = std.ArrayList(f64){},
-            .recent_content = std.ArrayList([]const u8){},
+            .input_sizes = std.ArrayList(f64).empty,
+            .output_sizes = std.ArrayList(f64).empty,
+            .processing_times = std.ArrayList(f64).empty,
+            .recent_content = std.ArrayList([]const u8).empty,
             .allocator = allocator,
         };
     }
@@ -97,12 +98,12 @@ pub const AnomalyDetector = struct {
     };
 
     pub fn detectRateAnomaly(self: *AnomalyDetector, user_id: []const u8) !?AnomalyResult {
-        const now = @as(f64, @floatFromInt(std.time.timestamp()));
+        const now = @as(f64, @floatFromInt(agktime.timestamp()));
 
         // Get or create timestamp list for this user
         const result = try self.request_timestamps.getOrPut(user_id);
         if (!result.found_existing) {
-            result.value_ptr.* = std.ArrayList(f64){};
+            result.value_ptr.* = std.ArrayList(f64).empty;
         }
 
         var timestamps = result.value_ptr;
@@ -131,11 +132,11 @@ pub const AnomalyDetector = struct {
     }
 
     pub fn detectBurstAnomaly(self: *AnomalyDetector, user_id: []const u8) !?AnomalyResult {
-        const now = @as(f64, @floatFromInt(std.time.timestamp()));
+        const now = @as(f64, @floatFromInt(agktime.timestamp()));
 
         const result = try self.request_timestamps.getOrPut(user_id);
         if (!result.found_existing) {
-            result.value_ptr.* = std.ArrayList(f64){};
+            result.value_ptr.* = std.ArrayList(f64).empty;
         }
 
         const timestamps = result.value_ptr;

--- a/agenkit-zig/src/safety/audit.zig
+++ b/agenkit-zig/src/safety/audit.zig
@@ -3,6 +3,8 @@
 /// Provides structured logging of security events with file rotation and severity filtering.
 /// Audit logs are append-only and tamper-evident for compliance and forensics.
 const std = @import("std");
+const ioc = @import("../io_compat.zig");
+const agktime = @import("../time_compat.zig");
 const mem = std.mem;
 const fs = std.fs;
 const Allocator = std.mem.Allocator;
@@ -107,7 +109,7 @@ pub const SecurityAuditLogger = struct {
     max_bytes: usize,
     backup_count: i32,
     current_size: usize,
-    file: ?fs.File,
+    file: ?std.Io.File,
     allocator: Allocator,
 
     pub const Config = struct {
@@ -119,13 +121,13 @@ pub const SecurityAuditLogger = struct {
 
     pub fn init(allocator: Allocator, config: Config) !SecurityAuditLogger {
         // Open or create log file
-        const file = try fs.cwd().createFile(config.log_file_path, .{
+        const file = try std.Io.Dir.cwd().createFile(ioc.io(), config.log_file_path, .{
             .truncate = false,
             .read = true,
         });
 
         // Get current file size
-        const stat = try file.stat();
+        const stat = try file.stat(ioc.io());
         const current_size = stat.size;
 
         return SecurityAuditLogger{
@@ -141,7 +143,7 @@ pub const SecurityAuditLogger = struct {
 
     pub fn deinit(self: *SecurityAuditLogger) void {
         if (self.file) |file| {
-            file.close();
+            file.close(ioc.io());
         }
     }
 
@@ -165,10 +167,9 @@ pub const SecurityAuditLogger = struct {
             try self.rotateLog();
         }
 
-        // Write to file
+        // Write to file (append at the tracked end-of-file offset)
         if (self.file) |file| {
-            try file.seekFromEnd(0);
-            try file.writeAll(log_line);
+            try file.writePositionalAll(ioc.io(), log_line, self.current_size);
             self.current_size += log_line.len;
         }
     }
@@ -176,7 +177,7 @@ pub const SecurityAuditLogger = struct {
     fn rotateLog(self: *SecurityAuditLogger) !void {
         // Close current file
         if (self.file) |file| {
-            file.close();
+            file.close(ioc.io());
             self.file = null;
         }
 
@@ -189,17 +190,17 @@ pub const SecurityAuditLogger = struct {
             const new_name = try std.fmt.allocPrint(self.allocator, "{s}.{d}", .{ self.log_file_path, i + 1 });
             defer self.allocator.free(new_name);
 
-            fs.cwd().rename(old_name, new_name) catch {};
+            std.Io.Dir.cwd().rename(old_name, std.Io.Dir.cwd(), new_name, ioc.io()) catch {};
         }
 
         // Move current to .1
         const backup_name = try std.fmt.allocPrint(self.allocator, "{s}.1", .{self.log_file_path});
         defer self.allocator.free(backup_name);
 
-        fs.cwd().rename(self.log_file_path, backup_name) catch {};
+        std.Io.Dir.cwd().rename(self.log_file_path, std.Io.Dir.cwd(), backup_name, ioc.io()) catch {};
 
         // Create new log file
-        self.file = try fs.cwd().createFile(self.log_file_path, .{
+        self.file = try std.Io.Dir.cwd().createFile(ioc.io(), self.log_file_path, .{
             .truncate = true,
             .read = true,
         });
@@ -217,7 +218,7 @@ pub const SecurityAuditLogger = struct {
             .user_id = user_id,
             .agent_name = agent_name,
             .message = message,
-            .timestamp = std.time.timestamp(),
+            .timestamp = agktime.timestamp(),
         });
     }
 
@@ -231,7 +232,7 @@ pub const SecurityAuditLogger = struct {
             .user_id = user_id,
             .agent_name = agent_name,
             .message = message,
-            .timestamp = std.time.timestamp(),
+            .timestamp = agktime.timestamp(),
         });
     }
 
@@ -245,7 +246,7 @@ pub const SecurityAuditLogger = struct {
             .user_id = user_id,
             .agent_name = agent_name,
             .message = message,
-            .timestamp = std.time.timestamp(),
+            .timestamp = agktime.timestamp(),
         });
     }
 };
@@ -273,7 +274,7 @@ test "SecurityAuditLogger logs events" {
     const allocator = std.testing.allocator;
 
     const log_path = "test_audit.log";
-    defer fs.cwd().deleteFile(log_path) catch {};
+    defer std.Io.Dir.cwd().deleteFile(ioc.io(), log_path) catch {};
 
     var logger = try SecurityAuditLogger.init(allocator, .{ .log_file_path = log_path });
     defer logger.deinit();
@@ -281,9 +282,9 @@ test "SecurityAuditLogger logs events" {
     try logger.logAccessGranted("user123", "/api/data", "test-agent");
 
     // Verify file was created
-    const file = try fs.cwd().openFile(log_path, .{});
-    defer file.close();
+    const file = try std.Io.Dir.cwd().openFile(ioc.io(), log_path, .{});
+    defer file.close(ioc.io());
 
-    const stat = try file.stat();
+    const stat = try file.stat(ioc.io());
     try std.testing.expect(stat.size > 0);
 }

--- a/agenkit-zig/src/safety/permissions.zig
+++ b/agenkit-zig/src/safety/permissions.zig
@@ -85,12 +85,12 @@ pub const Sandbox = struct {
 
     pub fn init(allocator: Allocator, config: Config) !Sandbox {
         var sandbox = Sandbox{
-            .allowed_paths = std.ArrayList([]const u8){},
-            .denied_paths = std.ArrayList([]const u8){},
+            .allowed_paths = std.ArrayList([]const u8).empty,
+            .denied_paths = std.ArrayList([]const u8).empty,
             .allowed_commands = StringHashMap(void).init(allocator),
             .denied_commands = StringHashMap(void).init(allocator),
-            .allowed_domains = std.ArrayList([]const u8){},
-            .denied_domains = std.ArrayList([]const u8){},
+            .allowed_domains = std.ArrayList([]const u8).empty,
+            .denied_domains = std.ArrayList([]const u8).empty,
             .max_file_size = config.max_file_size,
             .max_execution_time = config.max_execution_time,
             .max_memory_mb = config.max_memory_mb,

--- a/agenkit-zig/src/safety/validation.zig
+++ b/agenkit-zig/src/safety/validation.zig
@@ -27,7 +27,7 @@ pub const PromptInjectionDetector = struct {
     pub fn init(allocator: Allocator, config: Config) !PromptInjectionDetector {
         var detector = PromptInjectionDetector{
             .threshold = config.threshold,
-            .patterns = std.ArrayList([]const u8){},
+            .patterns = std.ArrayList([]const u8).empty,
             .keywords = StringHashMap(i32).init(allocator),
             .allocator = allocator,
         };
@@ -79,7 +79,7 @@ pub const PromptInjectionDetector = struct {
 
     pub fn detect(self: *PromptInjectionDetector, text: []const u8) !DetectionResult {
         var score: f64 = 0.0;
-        var matched = std.ArrayList([]const u8){};
+        var matched = std.ArrayList([]const u8).empty;
 
         // Convert to lowercase for case-insensitive matching
         const lower_text = try std.ascii.allocLowerString(self.allocator, text);
@@ -134,7 +134,7 @@ pub const ContentFilter = struct {
     pub fn init(allocator: Allocator, config: Config) !ContentFilter {
         var filter = ContentFilter{
             .max_length = config.max_length,
-            .banned_words = std.ArrayList([]const u8){},
+            .banned_words = std.ArrayList([]const u8).empty,
             .check_pii = config.check_pii,
             .allocator = allocator,
         };
@@ -219,7 +219,7 @@ pub const SensitiveDataRedactor = struct {
 
     pub fn init(allocator: Allocator) !SensitiveDataRedactor {
         var redactor = SensitiveDataRedactor{
-            .patterns = std.ArrayList(Pattern){},
+            .patterns = std.ArrayList(Pattern).empty,
             .allocator = allocator,
         };
 

--- a/agenkit-zig/src/skills/agent.zig
+++ b/agenkit-zig/src/skills/agent.zig
@@ -92,27 +92,26 @@ pub const SkillEnabledAgent = struct {
         const self: *SkillEnabledAgent = @ptrCast(@alignCast(ptr));
 
         const base = try self.inner.capabilities(allocator);
-        defer {
-            for (base) |cap| allocator.free(cap);
-            allocator.free(base);
-        }
+        // Capability strings are borrowed from the inner agent (the array is
+        // owned, the strings are not — matching SequentialAgent/ParallelAgent).
+        defer allocator.free(base);
 
-        var out = std.ArrayList([]const u8).init(allocator);
+        var out = std.ArrayList([]const u8).empty;
         errdefer {
             for (out.items) |cap| allocator.free(cap);
-            out.deinit();
+            out.deinit(allocator);
         }
 
         var has_injection = false;
         for (base) |cap| {
             if (std.mem.eql(u8, cap, "skill_injection")) has_injection = true;
-            try out.append(try allocator.dupe(u8, cap));
+            try out.append(allocator, try allocator.dupe(u8, cap));
         }
         if (!has_injection) {
-            try out.append(try allocator.dupe(u8, "skill_injection"));
+            try out.append(allocator, try allocator.dupe(u8, "skill_injection"));
         }
 
-        return out.toOwnedSlice();
+        return out.toOwnedSlice(allocator);
     }
 
     fn processImpl(ptr: *anyopaque, message: Message) AgentError!Result {
@@ -136,19 +135,19 @@ pub const SkillEnabledAgent = struct {
         }
 
         // Build the "<available_skills>...</available_skills>\n\n" + query prefix.
-        var content_buf = std.ArrayList(u8).init(self.allocator);
-        defer content_buf.deinit();
-        content_buf.appendSlice("<available_skills>\n") catch return AgentError.ProcessingFailed;
+        var content_buf = std.ArrayList(u8).empty;
+        defer content_buf.deinit(self.allocator);
+        content_buf.appendSlice(self.allocator, "<available_skills>\n") catch return AgentError.ProcessingFailed;
         for (relevant, 0..) |skill, i| {
-            if (i > 0) content_buf.appendSlice("\n\n") catch return AgentError.ProcessingFailed;
+            if (i > 0) content_buf.appendSlice(self.allocator, "\n\n") catch return AgentError.ProcessingFailed;
             const block = skill.toPrompt(self.allocator) catch return AgentError.ProcessingFailed;
             defer self.allocator.free(block);
-            content_buf.appendSlice(block) catch return AgentError.ProcessingFailed;
+            content_buf.appendSlice(self.allocator, block) catch return AgentError.ProcessingFailed;
         }
-        content_buf.appendSlice("\n</available_skills>\n\n") catch return AgentError.ProcessingFailed;
-        content_buf.appendSlice(query) catch return AgentError.ProcessingFailed;
+        content_buf.appendSlice(self.allocator, "\n</available_skills>\n\n") catch return AgentError.ProcessingFailed;
+        content_buf.appendSlice(self.allocator, query) catch return AgentError.ProcessingFailed;
 
-        const augmented_text = content_buf.toOwnedSlice() catch return AgentError.ProcessingFailed;
+        const augmented_text = content_buf.toOwnedSlice(self.allocator) catch return AgentError.ProcessingFailed;
 
         // Construct the augmented message with active_skills metadata.
         var augmented = Message.withText(self.allocator, message.role, augmented_text) catch {
@@ -156,7 +155,14 @@ pub const SkillEnabledAgent = struct {
             return AgentError.ProcessingFailed;
         };
         self.allocator.free(augmented_text); // withText duped the text
-        defer augmented.deinit();
+        // `augmented` is a transient message: the wrapped agent copies its
+        // metadata by reference into the response (which the caller owns), so we
+        // must not deep-free those values here. Free only `augmented`'s own
+        // allocations (its content text and the metadata map's backing storage).
+        defer {
+            augmented.content.deinit(augmented.allocator);
+            augmented.metadata.object.deinit(augmented.allocator);
+        }
 
         // Copy existing metadata from the source message.
         var meta_it = message.metadata.object.iterator();
@@ -205,19 +211,29 @@ pub const SkillEnabledAgent = struct {
 const testing = std.testing;
 const EchoAgent = @import("../agent.zig").EchoAgent;
 
-fn makeSkillDir(dir: std.fs.Dir, name: []const u8, description: []const u8) !void {
-    try dir.makeDir(name);
-    var sub = try dir.openDir(name, .{});
-    defer sub.close();
+fn makeSkillDir(dir: std.Io.Dir, name: []const u8, description: []const u8) !void {
+    const io = testing.io;
+    try dir.createDir(io, name, .default_dir);
+    var sub = try dir.openDir(io, name, .{});
+    defer sub.close(io);
     var buf: [4096]u8 = undefined;
     const content = try std.fmt.bufPrint(
         &buf,
         "---\nname: {s}\ndescription: {s}\n---\nInstructions here.",
         .{ name, description },
     );
-    const file = try sub.createFile("SKILL.md", .{});
-    defer file.close();
-    try file.writeAll(content);
+    var file = try sub.createFile(io, "SKILL.md", .{});
+    defer file.close(io);
+    try file.writeStreamingAll(io, content);
+}
+
+fn realpathAlloc(dir: std.Io.Dir, allocator: std.mem.Allocator, sub_path: []const u8) ![]u8 {
+    const io = testing.io;
+    var sub = try dir.openDir(io, sub_path, .{});
+    defer sub.close(io);
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const len = try sub.realPath(io, &buf);
+    return allocator.dupe(u8, buf[0..len]);
 }
 
 test "skill agent augments matching message" {
@@ -225,7 +241,7 @@ test "skill agent augments matching message" {
     var tmp = testing.tmpDir(.{});
     defer tmp.cleanup();
     try makeSkillDir(tmp.dir, "pdf-processing", "Extract text from PDF documents.");
-    const root = try tmp.dir.realpathAlloc(allocator, ".");
+    const root = try realpathAlloc(tmp.dir, allocator, ".");
     defer allocator.free(root);
 
     const paths = [_][]const u8{root};
@@ -255,7 +271,7 @@ test "skill agent passthrough when no skills match" {
     var tmp = testing.tmpDir(.{});
     defer tmp.cleanup();
     try makeSkillDir(tmp.dir, "email-compose", "Compose professional emails.");
-    const root = try tmp.dir.realpathAlloc(allocator, ".");
+    const root = try realpathAlloc(tmp.dir, allocator, ".");
     defer allocator.free(root);
 
     const paths = [_][]const u8{root};
@@ -285,7 +301,7 @@ test "skill agent sets active_skills metadata" {
     var tmp = testing.tmpDir(.{});
     defer tmp.cleanup();
     try makeSkillDir(tmp.dir, "csv-tools", "Handle and transform CSV spreadsheets.");
-    const root = try tmp.dir.realpathAlloc(allocator, ".");
+    const root = try realpathAlloc(tmp.dir, allocator, ".");
     defer allocator.free(root);
 
     const paths = [_][]const u8{root};

--- a/agenkit-zig/src/skills/loader.zig
+++ b/agenkit-zig/src/skills/loader.zig
@@ -36,6 +36,7 @@
 ///   remain owned by the registry — do NOT deinit them.
 const std = @import("std");
 const Allocator = std.mem.Allocator;
+const ioc = @import("../io_compat.zig");
 
 /// Errors raised while loading a skill from disk.
 pub const SkillError = error{
@@ -81,17 +82,15 @@ pub const AgentSkill = struct {
     ///
     /// The returned skill owns all of its memory; the caller must `deinit` it.
     pub fn fromDirectory(allocator: Allocator, skill_dir: []const u8) !AgentSkill {
-        var dir = std.fs.cwd().openDir(skill_dir, .{}) catch {
+        const io = ioc.io();
+        var dir = std.Io.Dir.cwd().openDir(io, skill_dir, .{}) catch {
             return SkillError.MissingSkillFile;
         };
-        defer dir.close();
+        defer dir.close(io);
 
-        const file = dir.openFile("SKILL.md", .{}) catch {
+        const raw = dir.readFileAlloc(io, "SKILL.md", allocator, .unlimited) catch {
             return SkillError.MissingSkillFile;
         };
-        defer file.close();
-
-        const raw = try file.readToEndAlloc(allocator, 16 * 1024 * 1024); // 16MB cap
         defer allocator.free(raw);
 
         return fromContent(allocator, raw, skill_dir);
@@ -221,14 +220,14 @@ const Frontmatter = struct {
         var self = Frontmatter{
             .allocator = allocator,
             .fields = std.StringHashMap([]const u8).init(allocator),
-            .metadata = std.ArrayList(MetadataEntry).init(allocator),
+            .metadata = std.ArrayList(MetadataEntry).empty,
         };
         errdefer self.deinit();
 
         var in_metadata = false;
         var lines = std.mem.splitScalar(u8, text, '\n');
         while (lines.next()) |raw_line| {
-            const line = std.mem.trimRight(u8, raw_line, " \t\r");
+            const line = std.mem.trimEnd(u8, raw_line, " \t\r");
             if (line.len == 0) continue;
 
             const indent = leadingSpaces(line);
@@ -251,7 +250,7 @@ const Frontmatter = struct {
             } else if (in_metadata) {
                 // Indented child of the metadata block.
                 if (value.len == 0) continue;
-                try self.metadata.append(.{ .key = key, .value = value });
+                try self.metadata.append(allocator, .{ .key = key, .value = value });
             }
         }
 
@@ -286,7 +285,7 @@ const Frontmatter = struct {
 
     fn deinit(self: *Frontmatter) void {
         self.fields.deinit();
-        self.metadata.deinit();
+        self.metadata.deinit(self.allocator);
     }
 };
 
@@ -350,12 +349,13 @@ pub const SkillRegistry = struct {
     /// If a skill name is already loaded it is replaced (matching the Python
     /// `self._skills[skill.name] = skill` behaviour).
     pub fn discoverSkills(self: *SkillRegistry) !void {
+        const io = ioc.io();
         for (self.search_paths) |search_path| {
-            var dir = std.fs.cwd().openDir(search_path, .{ .iterate = true }) catch continue;
-            defer dir.close();
+            var dir = std.Io.Dir.cwd().openDir(io, search_path, .{ .iterate = true }) catch continue;
+            defer dir.close(io);
 
             var iter = dir.iterate();
-            while (try iter.next()) |entry| {
+            while (try iter.next(io)) |entry| {
                 if (entry.kind != .directory) continue;
 
                 const skill_path = try std.fs.path.join(
@@ -414,8 +414,8 @@ pub const SkillRegistry = struct {
             skill: *const AgentSkill,
         };
 
-        var scored = std.ArrayList(Scored).init(allocator);
-        defer scored.deinit();
+        var scored = std.ArrayList(Scored).empty;
+        defer scored.deinit(allocator);
 
         var it = self.skills.iterator();
         while (it.next()) |entry| {
@@ -436,7 +436,7 @@ pub const SkillRegistry = struct {
             score += wordOverlap(query_lower, desc_lower);
 
             if (score > 0) {
-                try scored.append(.{ .score = score, .skill = skill });
+                try scored.append(allocator, .{ .score = score, .skill = skill });
             }
         }
 
@@ -499,25 +499,36 @@ fn wordOverlap(query_lower: []const u8, desc_lower: []const u8) i64 {
 const testing = std.testing;
 
 /// Create a minimal valid skill directory inside `dir`.
-fn makeSkillDir(dir: std.fs.Dir, name: []const u8, description: []const u8, body: []const u8) !void {
-    try dir.makeDir(name);
-    var sub = try dir.openDir(name, .{});
-    defer sub.close();
+fn makeSkillDir(dir: std.Io.Dir, name: []const u8, description: []const u8, body: []const u8) !void {
+    const io = testing.io;
+    try dir.createDir(io, name, .default_dir);
+    var sub = try dir.openDir(io, name, .{});
+    defer sub.close(io);
     var buf: [4096]u8 = undefined;
     const content = try std.fmt.bufPrint(
         &buf,
         "---\nname: {s}\ndescription: {s}\n---\n{s}",
         .{ name, description, body },
     );
-    const file = try sub.createFile("SKILL.md", .{});
-    defer file.close();
-    try file.writeAll(content);
+    var file = try sub.createFile(io, "SKILL.md", .{});
+    defer file.close(io);
+    try file.writeStreamingAll(io, content);
 }
 
-fn writeRawFile(dir: std.fs.Dir, sub_path: []const u8, data: []const u8) !void {
-    const file = try dir.createFile(sub_path, .{});
-    defer file.close();
-    try file.writeAll(data);
+fn realpathAlloc(dir: std.Io.Dir, allocator: Allocator, sub_path: []const u8) ![]u8 {
+    const io = testing.io;
+    var sub = try dir.openDir(io, sub_path, .{});
+    defer sub.close(io);
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const len = try sub.realPath(io, &buf);
+    return allocator.dupe(u8, buf[0..len]);
+}
+
+fn writeRawFile(dir: std.Io.Dir, sub_path: []const u8, data: []const u8) !void {
+    const io = testing.io;
+    var file = try dir.createFile(io, sub_path, .{});
+    defer file.close(io);
+    try file.writeStreamingAll(io, data);
 }
 
 test "fromContent loads a valid skill" {
@@ -570,8 +581,8 @@ test "fromContent missing description" {
 test "fromDirectory missing SKILL.md" {
     var tmp = testing.tmpDir(.{});
     defer tmp.cleanup();
-    try tmp.dir.makeDir("empty");
-    const path = try tmp.dir.realpathAlloc(testing.allocator, "empty");
+    try tmp.dir.createDir(testing.io, "empty", .default_dir);
+    const path = try realpathAlloc(tmp.dir, testing.allocator, "empty");
     defer testing.allocator.free(path);
 
     try testing.expectError(SkillError.MissingSkillFile, AgentSkill.fromDirectory(testing.allocator, path));
@@ -581,7 +592,7 @@ test "fromDirectory loads from disk" {
     var tmp = testing.tmpDir(.{});
     defer tmp.cleanup();
     try makeSkillDir(tmp.dir, "csv-tools", "Handle CSV files.", "Parse and write CSV.");
-    const path = try tmp.dir.realpathAlloc(testing.allocator, "csv-tools");
+    const path = try realpathAlloc(tmp.dir, testing.allocator, "csv-tools");
     defer testing.allocator.free(path);
 
     var skill = try AgentSkill.fromDirectory(testing.allocator, path);
@@ -611,7 +622,7 @@ test "registry skips non-directories" {
     var tmp = testing.tmpDir(.{});
     defer tmp.cleanup();
     try writeRawFile(tmp.dir, "not_a_dir.md", "ignored");
-    const root = try tmp.dir.realpathAlloc(testing.allocator, ".");
+    const root = try realpathAlloc(tmp.dir, testing.allocator, ".");
     defer testing.allocator.free(root);
 
     const paths = [_][]const u8{root};
@@ -626,7 +637,7 @@ test "registry discovers valid skills" {
     defer tmp.cleanup();
     try makeSkillDir(tmp.dir, "skill-a", "Skill A description.", "Body.");
     try makeSkillDir(tmp.dir, "skill-b", "Skill B description.", "Body.");
-    const root = try tmp.dir.realpathAlloc(testing.allocator, ".");
+    const root = try realpathAlloc(tmp.dir, testing.allocator, ".");
     defer testing.allocator.free(root);
 
     const paths = [_][]const u8{root};
@@ -643,7 +654,7 @@ test "registry find relevant name match" {
     defer tmp.cleanup();
     try makeSkillDir(tmp.dir, "pdf-processing", "Work with PDF documents.", "Body.");
     try makeSkillDir(tmp.dir, "csv-tools", "Handle CSV spreadsheets.", "Body.");
-    const root = try tmp.dir.realpathAlloc(testing.allocator, ".");
+    const root = try realpathAlloc(tmp.dir, testing.allocator, ".");
     defer testing.allocator.free(root);
 
     const paths = [_][]const u8{root};
@@ -668,7 +679,7 @@ test "registry find relevant respects max_results" {
         const desc = try std.fmt.bufPrint(&desc_buf, "A skill about document processing number {d}.", .{i});
         try makeSkillDir(tmp.dir, name, desc, "Body.");
     }
-    const root = try tmp.dir.realpathAlloc(testing.allocator, ".");
+    const root = try realpathAlloc(tmp.dir, testing.allocator, ".");
     defer testing.allocator.free(root);
 
     const paths = [_][]const u8{root};
@@ -685,7 +696,7 @@ test "registry get skill" {
     var tmp = testing.tmpDir(.{});
     defer tmp.cleanup();
     try makeSkillDir(tmp.dir, "email-compose", "Compose professional emails.", "Body.");
-    const root = try tmp.dir.realpathAlloc(testing.allocator, ".");
+    const root = try realpathAlloc(tmp.dir, testing.allocator, ".");
     defer testing.allocator.free(root);
 
     const paths = [_][]const u8{root};

--- a/agenkit-zig/src/sync_compat.zig
+++ b/agenkit-zig/src/sync_compat.zig
@@ -1,0 +1,150 @@
+//! Synchronization primitives compatible with the pre-0.16 `std.Thread` API.
+//!
+//! Zig 0.16 moved `Mutex`, `RwLock`, and `Condition` into the `Io` model
+//! (`std.Io.Mutex.lock(io)` etc.), which would require threading an `Io`
+//! instance through every lock site in the toolkit. To preserve the existing
+//! `lock()` / `unlock()` / `wait(&mutex)` API (and behaviour) without that
+//! invasive change, this module provides drop-in equivalents built on atomics
+//! and cooperative yielding.
+//!
+//! These are intentionally simple. The toolkit's hot paths are not
+//! lock-bound; correctness (mutual exclusion, blocking wait/signal across the
+//! batch-processor thread) matters more than raw throughput here.
+
+const std = @import("std");
+const builtin = @import("builtin");
+
+fn spin() void {
+    if (builtin.single_threaded) return;
+    std.Thread.yield() catch {};
+}
+
+/// Mutual-exclusion lock mirroring the old `std.Thread.Mutex` API.
+pub const Mutex = struct {
+    state: std.atomic.Value(u32) = std.atomic.Value(u32).init(0),
+
+    pub fn tryLock(self: *Mutex) bool {
+        return self.state.cmpxchgStrong(0, 1, .acquire, .monotonic) == null;
+    }
+
+    pub fn lock(self: *Mutex) void {
+        while (!self.tryLock()) spin();
+    }
+
+    pub fn unlock(self: *Mutex) void {
+        self.state.store(0, .release);
+    }
+};
+
+/// Reader/writer lock mirroring the old `std.Thread.RwLock` API.
+///
+/// Writers are exclusive; readers share. A positive count means that many
+/// readers hold the lock; the sentinel value means a writer holds it.
+pub const RwLock = struct {
+    state: std.atomic.Value(u32) = std.atomic.Value(u32).init(0),
+
+    const writer_locked: u32 = std.math.maxInt(u32);
+
+    pub fn tryLock(self: *RwLock) bool {
+        return self.state.cmpxchgStrong(0, writer_locked, .acquire, .monotonic) == null;
+    }
+
+    pub fn lock(self: *RwLock) void {
+        while (!self.tryLock()) spin();
+    }
+
+    pub fn unlock(self: *RwLock) void {
+        self.state.store(0, .release);
+    }
+
+    pub fn tryLockShared(self: *RwLock) bool {
+        var current = self.state.load(.monotonic);
+        while (current != writer_locked) {
+            if (self.state.cmpxchgWeak(current, current + 1, .acquire, .monotonic)) |actual| {
+                current = actual;
+            } else {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    pub fn lockShared(self: *RwLock) void {
+        while (!self.tryLockShared()) spin();
+    }
+
+    pub fn unlockShared(self: *RwLock) void {
+        _ = self.state.fetchSub(1, .release);
+    }
+};
+
+/// Condition variable mirroring the old `std.Thread.Condition` API.
+///
+/// `wait` releases the supplied mutex, blocks until a `signal`/`broadcast`
+/// bumps the generation counter, then re-acquires the mutex — exactly the
+/// contract callers relied on.
+pub const Condition = struct {
+    generation: std.atomic.Value(u32) = std.atomic.Value(u32).init(0),
+
+    pub fn wait(self: *Condition, mutex: *Mutex) void {
+        const gen = self.generation.load(.acquire);
+        mutex.unlock();
+        while (self.generation.load(.acquire) == gen) spin();
+        mutex.lock();
+    }
+
+    pub fn signal(self: *Condition) void {
+        _ = self.generation.fetchAdd(1, .release);
+    }
+
+    pub fn broadcast(self: *Condition) void {
+        _ = self.generation.fetchAdd(1, .release);
+    }
+};
+
+test "mutex provides mutual exclusion" {
+    var m: Mutex = .{};
+    m.lock();
+    try std.testing.expect(!m.tryLock());
+    m.unlock();
+    try std.testing.expect(m.tryLock());
+    m.unlock();
+}
+
+test "rwlock allows shared readers, exclusive writer" {
+    var rw: RwLock = .{};
+    rw.lockShared();
+    try std.testing.expect(rw.tryLockShared());
+    try std.testing.expect(!rw.tryLock());
+    rw.unlockShared();
+    rw.unlockShared();
+    try std.testing.expect(rw.tryLock());
+    rw.unlock();
+}
+
+test "condition wake across threads" {
+    var m: Mutex = .{};
+    var cond: Condition = .{};
+    var ready = std.atomic.Value(bool).init(false);
+
+    const Ctx = struct {
+        m: *Mutex,
+        cond: *Condition,
+        ready: *std.atomic.Value(bool),
+        fn run(ctx: @This()) void {
+            var i: usize = 0;
+            while (i < 1000) : (i += 1) std.atomic.spinLoopHint();
+            ctx.ready.store(true, .release);
+            ctx.cond.signal();
+        }
+    };
+
+    m.lock();
+    const t = try std.Thread.spawn(.{}, Ctx.run, .{Ctx{ .m = &m, .cond = &cond, .ready = &ready }});
+    while (!ready.load(.acquire)) {
+        cond.wait(&m);
+    }
+    m.unlock();
+    t.join();
+    try std.testing.expect(ready.load(.acquire));
+}

--- a/agenkit-zig/src/techniques/reasoning/chain_of_thought.zig
+++ b/agenkit-zig/src/techniques/reasoning/chain_of_thought.zig
@@ -5,7 +5,6 @@
 ///
 /// Reference: "Chain-of-Thought Prompting Elicits Reasoning in Large Language Models"
 /// Wei et al., 2022 - https://arxiv.org/abs/2201.11903
-
 const std = @import("std");
 const Agent = @import("../../agent.zig").Agent;
 const AgentError = @import("../../agent.zig").AgentError;
@@ -178,7 +177,7 @@ pub const ChainOfThoughtAgent = struct {
 
     /// Extract numbered steps (1. Step or 1) Step)
     fn extractNumberedSteps(self: *ChainOfThoughtAgent, text: []const u8) !?[][]const u8 {
-        var steps = std.ArrayList([]const u8).init(self.allocator);
+        var steps = std.ArrayList([]const u8).empty;
         errdefer {
             for (steps.items) |step| {
                 self.allocator.free(step);
@@ -221,7 +220,7 @@ pub const ChainOfThoughtAgent = struct {
 
     /// Extract bullet point steps (-, *, •)
     fn extractBulletSteps(self: *ChainOfThoughtAgent, text: []const u8) !?[][]const u8 {
-        var steps = std.ArrayList([]const u8).init(self.allocator);
+        var steps = std.ArrayList([]const u8).empty;
         errdefer {
             for (steps.items) |step| {
                 self.allocator.free(step);
@@ -262,7 +261,7 @@ pub const ChainOfThoughtAgent = struct {
 
     /// Extract steps using delimiter
     fn extractDelimiterSteps(self: *ChainOfThoughtAgent, text: []const u8) ![][]const u8 {
-        var steps = std.ArrayList([]const u8).init(self.allocator);
+        var steps = std.ArrayList([]const u8).empty;
         errdefer {
             for (steps.items) |step| {
                 self.allocator.free(step);

--- a/agenkit-zig/src/techniques/reasoning/graph_of_thought.zig
+++ b/agenkit-zig/src/techniques/reasoning/graph_of_thought.zig
@@ -518,7 +518,7 @@ test "GraphOfThought name and capabilities" {
     const testing = std.testing;
     const MockAgent = @import("../../test_utils.zig").MockAgent;
 
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -544,7 +544,7 @@ test "GraphOfThought custom config" {
     const testing = std.testing;
     const MockAgent = @import("../../test_utils.zig").MockAgent;
 
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -580,7 +580,7 @@ test "GraphOfThought basic functionality" {
     const testing = std.testing;
     const MockAgent = @import("../../test_utils.zig").MockAgent;
 
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -613,7 +613,7 @@ test "GraphOfThought max_nodes enforcement" {
     const testing = std.testing;
     const MockAgent = @import("../../test_utils.zig").MockAgent;
 
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -645,7 +645,7 @@ test "GraphOfThought path_based aggregation" {
     const testing = std.testing;
     const MockAgent = @import("../../test_utils.zig").MockAgent;
 
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -676,7 +676,7 @@ test "GraphOfThought node_based aggregation" {
     const testing = std.testing;
     const MockAgent = @import("../../test_utils.zig").MockAgent;
 
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -707,7 +707,7 @@ test "GraphOfThought metadata completeness" {
     const testing = std.testing;
     const MockAgent = @import("../../test_utils.zig").MockAgent;
 
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -750,7 +750,7 @@ test "GraphOfThought response role" {
     const testing = std.testing;
     const MockAgent = @import("../../test_utils.zig").MockAgent;
 
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/agenkit-zig/src/techniques/reasoning/graph_of_thought.zig
+++ b/agenkit-zig/src/techniques/reasoning/graph_of_thought.zig
@@ -12,7 +12,6 @@
 /// Reference:
 /// - Paper: https://arxiv.org/abs/2308.09687
 /// - "Graph of Thoughts: Solving Elaborate Problems with Large Language Models"
-
 const std = @import("std");
 const Agent = @import("../../agent.zig").Agent;
 const AgentError = @import("../../agent.zig").AgentError;
@@ -179,7 +178,7 @@ pub const GraphOfThoughtAgent = struct {
 
     // Helper: Generate premises
     fn generatePremises(self: *GraphOfThoughtAgent, problem: []const u8) ![][]const u8 {
-        var prompt_buf = std.ArrayList(u8).init(self.allocator);
+        var prompt_buf = std.ArrayList(u8).empty;
         defer prompt_buf.deinit();
 
         const writer = prompt_buf.writer();
@@ -196,7 +195,7 @@ pub const GraphOfThoughtAgent = struct {
 
     // Helper: Generate thoughts
     fn generateThoughts(self: *GraphOfThoughtAgent, problem: []const u8, existing: []const []const u8, max_new: usize) ![][]const u8 {
-        var prompt_buf = std.ArrayList(u8).init(self.allocator);
+        var prompt_buf = std.ArrayList(u8).empty;
         defer prompt_buf.deinit();
 
         const writer = prompt_buf.writer();
@@ -222,7 +221,7 @@ pub const GraphOfThoughtAgent = struct {
 
     // Helper: Identify connection
     fn identifyConnection(self: *GraphOfThoughtAgent, thought1: []const u8, thought2: []const u8) !?EdgeType {
-        var prompt_buf = std.ArrayList(u8).init(self.allocator);
+        var prompt_buf = std.ArrayList(u8).empty;
         defer prompt_buf.deinit();
 
         const writer = prompt_buf.writer();
@@ -262,7 +261,7 @@ pub const GraphOfThoughtAgent = struct {
 
     // Helper: Parse lines from response
     fn parseLines(self: *GraphOfThoughtAgent, text: []const u8, max_lines: usize) ![][]const u8 {
-        var lines = std.ArrayList([]const u8).init(self.allocator);
+        var lines = std.ArrayList([]const u8).empty;
         defer {
             for (lines.items) |line| {
                 self.allocator.free(line);
@@ -311,7 +310,7 @@ pub const GraphOfThoughtAgent = struct {
             self.allocator.free(premises);
         }
 
-        var premise_ids = std.ArrayList(usize).init(self.allocator);
+        var premise_ids = std.ArrayList(usize).empty;
         defer premise_ids.deinit();
 
         for (premises) |premise| {
@@ -320,7 +319,7 @@ pub const GraphOfThoughtAgent = struct {
         }
 
         // Generate intermediate thoughts
-        var all_thoughts = std.ArrayList([]const u8).init(self.allocator);
+        var all_thoughts = std.ArrayList([]const u8).empty;
         defer {
             for (all_thoughts.items) |t| {
                 self.allocator.free(t);
@@ -332,7 +331,7 @@ pub const GraphOfThoughtAgent = struct {
             try all_thoughts.append(try self.allocator.dupe(u8, p));
         }
 
-        var node_ids = std.ArrayList(usize).init(self.allocator);
+        var node_ids = std.ArrayList(usize).empty;
         defer node_ids.deinit();
 
         try node_ids.appendSlice(premise_ids.items);
@@ -382,7 +381,7 @@ pub const GraphOfThoughtAgent = struct {
 
         // Generate conclusion
         if (graph.nodeCount() < self.config.max_nodes) {
-            var conclusion_prompt = std.ArrayList(u8).init(self.allocator);
+            var conclusion_prompt = std.ArrayList(u8).empty;
             defer conclusion_prompt.deinit();
 
             const writer = conclusion_prompt.writer();
@@ -421,7 +420,7 @@ pub const GraphOfThoughtAgent = struct {
         const conclusions = try graph.getConclusions(self.allocator);
         defer self.allocator.free(conclusions);
 
-        var all_paths = std.ArrayList([]usize).init(self.allocator);
+        var all_paths = std.ArrayList([]usize).empty;
         defer {
             for (all_paths.items) |path| {
                 self.allocator.free(path);
@@ -776,4 +775,3 @@ test "GraphOfThought response role" {
 
     try testing.expectEqual(Message.Role.assistant, result.ok.role);
 }
-

--- a/agenkit-zig/src/techniques/reasoning/least_to_most.zig
+++ b/agenkit-zig/src/techniques/reasoning/least_to_most.zig
@@ -8,7 +8,6 @@
 ///
 /// Reference: "Least-to-Most Prompting Enables Complex Reasoning in Large Language Models"
 /// Zhou et al., 2022 - https://arxiv.org/abs/2205.10625
-
 const std = @import("std");
 const Agent = @import("../../agent.zig").Agent;
 const AgentError = @import("../../agent.zig").AgentError;
@@ -111,7 +110,7 @@ pub const LeastToMostAgent = struct {
         }
 
         // Step 2: Solve subproblems sequentially
-        var solutions = std.ArrayListUnmanaged([]const u8){};
+        var solutions = std.ArrayListUnmanaged([]const u8).empty;
         defer {
             for (solutions.items) |sol| {
                 self.allocator.free(sol);
@@ -157,7 +156,7 @@ pub const LeastToMostAgent = struct {
         };
 
         // Add subproblems array
-        var subproblems_array = std.ArrayListUnmanaged(std.json.Value){};
+        var subproblems_array = std.ArrayListUnmanaged(std.json.Value).empty;
         for (subproblems) |sub| {
             const dupe_content = self.allocator.dupe(u8, sub.content) catch {
                 // Clean up any already added items
@@ -187,7 +186,7 @@ pub const LeastToMostAgent = struct {
         };
 
         // Add solutions array
-        var solutions_array = std.ArrayListUnmanaged(std.json.Value){};
+        var solutions_array = std.ArrayListUnmanaged(std.json.Value).empty;
         for (solutions.items) |sol| {
             const dupe_sol = self.allocator.dupe(u8, sol) catch {
                 // Clean up any already added items
@@ -250,7 +249,7 @@ pub const LeastToMostAgent = struct {
                 self.allocator.free(subproblem_texts);
             }
 
-            var subproblems = std.ArrayListUnmanaged(Subproblem){};
+            var subproblems = std.ArrayListUnmanaged(Subproblem).empty;
             errdefer {
                 for (subproblems.items) |*sub| {
                     var mutable_sub = sub.*;
@@ -305,7 +304,7 @@ pub const LeastToMostAgent = struct {
 
     /// Parse subproblems from LLM response
     fn parseSubproblems(self: *LeastToMostAgent, response_text: []const u8, original_problem: []const u8) ![]Subproblem {
-        var subproblems = std.ArrayListUnmanaged(Subproblem){};
+        var subproblems = std.ArrayListUnmanaged(Subproblem).empty;
         errdefer {
             for (subproblems.items) |*sub| {
                 var mutable_sub = sub.*;
@@ -364,21 +363,19 @@ pub const LeastToMostAgent = struct {
         subproblem: Subproblem,
         previous_solutions: []const []const u8,
     ) ![]const u8 {
-        var prompt_buf = std.ArrayListUnmanaged(u8){};
+        var prompt_buf = std.ArrayListUnmanaged(u8).empty;
         defer prompt_buf.deinit(self.allocator);
-
-        const writer = prompt_buf.writer(self.allocator);
 
         if (self.config.compose_solutions and previous_solutions.len > 0) {
             // Include previous solutions as context
-            try writer.writeAll("Given these previous solutions to simpler subproblems:\n\n");
+            try prompt_buf.appendSlice(self.allocator, "Given these previous solutions to simpler subproblems:\n\n");
             for (previous_solutions, 0..) |sol, i| {
-                try writer.print("Previous solution {d}: {s}\n", .{ i + 1, sol });
+                try prompt_buf.print(self.allocator, "Previous solution {d}: {s}\n", .{ i + 1, sol });
             }
-            try writer.print("\nNow solve this subproblem:\n{s}\n\nSolution:", .{subproblem.content});
+            try prompt_buf.print(self.allocator, "\nNow solve this subproblem:\n{s}\n\nSolution:", .{subproblem.content});
         } else {
             // Solve without context
-            try writer.print("Solve this subproblem:\n\n{s}\n\nSolution:", .{subproblem.content});
+            try prompt_buf.print(self.allocator, "Solve this subproblem:\n\n{s}\n\nSolution:", .{subproblem.content});
         }
 
         const prompt = try prompt_buf.toOwnedSlice(self.allocator);

--- a/agenkit-zig/src/techniques/reasoning/least_to_most.zig
+++ b/agenkit-zig/src/techniques/reasoning/least_to_most.zig
@@ -408,7 +408,7 @@ pub const LeastToMostAgent = struct {
 // Tests
 test "LeastToMostAgent - basic functionality" {
     const testing = std.testing;
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -511,7 +511,7 @@ test "LeastToMostAgent - basic functionality" {
 
 test "LeastToMostAgent - name and capabilities" {
     const testing = std.testing;
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -587,7 +587,7 @@ test "LeastToMostAgent - name and capabilities" {
 
 test "LeastToMostAgent - decomposition verification" {
     const testing = std.testing;
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -687,7 +687,7 @@ test "LeastToMostAgent - decomposition verification" {
 
 test "LeastToMostAgent - sequential solving" {
     const testing = std.testing;
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -785,7 +785,7 @@ test "LeastToMostAgent - sequential solving" {
 
 test "LeastToMostAgent - final solution is last" {
     const testing = std.testing;
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -880,7 +880,7 @@ test "LeastToMostAgent - final solution is last" {
 
 test "LeastToMostAgent - max subproblems limit" {
     const testing = std.testing;
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -978,7 +978,7 @@ test "LeastToMostAgent - max subproblems limit" {
 
 test "LeastToMostAgent - custom decomposer" {
     const testing = std.testing;
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -1085,7 +1085,7 @@ test "LeastToMostAgent - custom decomposer" {
 
 test "LeastToMostAgent - compose solutions enabled" {
     const testing = std.testing;
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -1179,7 +1179,7 @@ test "LeastToMostAgent - compose solutions enabled" {
 
 test "LeastToMostAgent - compose solutions disabled" {
     const testing = std.testing;
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -1273,7 +1273,7 @@ test "LeastToMostAgent - compose solutions disabled" {
 
 test "LeastToMostAgent - parse numbered steps with periods" {
     const testing = std.testing;
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -1372,7 +1372,7 @@ test "LeastToMostAgent - parse numbered steps with periods" {
 
 test "LeastToMostAgent - parse numbered steps with parentheses" {
     const testing = std.testing;
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -1471,7 +1471,7 @@ test "LeastToMostAgent - parse numbered steps with parentheses" {
 
 test "LeastToMostAgent - skip empty lines" {
     const testing = std.testing;
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -1567,7 +1567,7 @@ test "LeastToMostAgent - skip empty lines" {
 
 test "LeastToMostAgent - atomic problem fallback" {
     const testing = std.testing;
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -1660,7 +1660,7 @@ test "LeastToMostAgent - atomic problem fallback" {
 
 test "LeastToMostAgent - whitespace trimming" {
     const testing = std.testing;
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -1757,7 +1757,7 @@ test "LeastToMostAgent - whitespace trimming" {
 
 test "LeastToMostAgent - metadata includes all fields" {
     const testing = std.testing;
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/agenkit-zig/src/techniques/reasoning/plan_and_solve.zig
+++ b/agenkit-zig/src/techniques/reasoning/plan_and_solve.zig
@@ -6,7 +6,6 @@
 ///
 /// Reference: "Plan-and-Solve Prompting: Improving Zero-Shot Chain-of-Thought Reasoning"
 /// Lei Wang et al., 2023 - https://arxiv.org/abs/2305.04091
-
 const std = @import("std");
 const Agent = @import("../../agent.zig").Agent;
 const AgentError = @import("../../agent.zig").AgentError;
@@ -57,7 +56,7 @@ pub const Plan = struct {
     pub fn init(allocator: Allocator, problem: []const u8) !Plan {
         const problem_copy = try allocator.dupe(u8, problem);
         return Plan{
-            .steps = std.ArrayList(PlanStep).init(allocator),
+            .steps = std.ArrayList(PlanStep).empty,
             .problem = problem_copy,
             .strategy = null,
             .validated = false,
@@ -289,9 +288,9 @@ pub const PlanAndSolveAgent = struct {
             var start: usize = 0;
             while (start < trimmed.len and
                 (std.ascii.isDigit(trimmed[start]) or
-                trimmed[start] == '.' or
-                trimmed[start] == ')' or
-                std.ascii.isWhitespace(trimmed[start])))
+                    trimmed[start] == '.' or
+                    trimmed[start] == ')' or
+                    std.ascii.isWhitespace(trimmed[start])))
             {
                 start += 1;
             }
@@ -341,7 +340,7 @@ pub const PlanAndSolveAgent = struct {
     }
 
     fn formatPlan(self: *PlanAndSolveAgent, plan: *Plan) ![]const u8 {
-        var buffer = std.ArrayList(u8).init(self.allocator);
+        var buffer = std.ArrayList(u8).empty;
         defer buffer.deinit();
 
         const writer = buffer.writer();
@@ -363,7 +362,7 @@ pub const PlanAndSolveAgent = struct {
         previous_results: []const []const u8,
     ) ![]const u8 {
         const prompt = if (previous_results.len > 0) blk: {
-            var buffer = std.ArrayList(u8).init(self.allocator);
+            var buffer = std.ArrayList(u8).empty;
             defer buffer.deinit();
 
             const writer = buffer.writer();
@@ -398,7 +397,7 @@ pub const PlanAndSolveAgent = struct {
     }
 
     fn executePlan(self: *PlanAndSolveAgent, plan: *Plan) ![][]const u8 {
-        var results = std.ArrayList([]const u8).init(self.allocator);
+        var results = std.ArrayList([]const u8).empty;
         errdefer {
             for (results.items) |result| {
                 self.allocator.free(result);

--- a/agenkit-zig/src/techniques/reasoning/reasoning_graph.zig
+++ b/agenkit-zig/src/techniques/reasoning/reasoning_graph.zig
@@ -10,7 +10,6 @@
 /// - Path aggregation
 ///
 /// Reference: Graph-of-Thought paper: https://arxiv.org/abs/2308.09687
-
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 
@@ -72,7 +71,7 @@ pub const ReasoningGraph = struct {
         return ReasoningGraph{
             .allocator = allocator,
             .nodes = std.AutoHashMap(usize, ThoughtNode).init(allocator),
-            .edges = std.ArrayList(LogicalEdge).init(allocator),
+            .edges = std.ArrayList(LogicalEdge).empty,
             .next_id = 0,
             .outgoing = std.AutoHashMap(usize, std.ArrayList(usize)).init(allocator),
             .incoming = std.AutoHashMap(usize, std.ArrayList(usize)).init(allocator),
@@ -117,8 +116,8 @@ pub const ReasoningGraph = struct {
         };
 
         try self.nodes.put(node_id, node);
-        try self.outgoing.put(node_id, std.ArrayList(usize).init(self.allocator));
-        try self.incoming.put(node_id, std.ArrayList(usize).init(self.allocator));
+        try self.outgoing.put(node_id, std.ArrayList(usize).empty);
+        try self.incoming.put(node_id, std.ArrayList(usize).empty);
 
         return node_id;
     }
@@ -152,7 +151,7 @@ pub const ReasoningGraph = struct {
 
     /// Get all premise nodes
     pub fn getPremises(self: *const ReasoningGraph, allocator: Allocator) ![]const *const ThoughtNode {
-        var premises = std.ArrayList(*const ThoughtNode).init(allocator);
+        var premises = std.ArrayList(*const ThoughtNode).empty;
         defer premises.deinit();
 
         var iter = self.nodes.valueIterator();
@@ -167,7 +166,7 @@ pub const ReasoningGraph = struct {
 
     /// Get all conclusion nodes
     pub fn getConclusions(self: *const ReasoningGraph, allocator: Allocator) ![]const *const ThoughtNode {
-        var conclusions = std.ArrayList(*const ThoughtNode).init(allocator);
+        var conclusions = std.ArrayList(*const ThoughtNode).empty;
         defer conclusions.deinit();
 
         var iter = self.nodes.valueIterator();
@@ -182,7 +181,7 @@ pub const ReasoningGraph = struct {
 
     /// Find all paths from start to end node
     pub fn findPaths(self: *const ReasoningGraph, allocator: Allocator, start: usize, end: usize, max_length: usize) ![][]usize {
-        var paths = std.ArrayList([]usize).init(allocator);
+        var paths = std.ArrayList([]usize).empty;
         defer {
             for (paths.items) |path| {
                 allocator.free(path);
@@ -193,7 +192,7 @@ pub const ReasoningGraph = struct {
         var visited = std.AutoHashMap(usize, void).init(allocator);
         defer visited.deinit();
 
-        var current_path = std.ArrayList(usize).init(allocator);
+        var current_path = std.ArrayList(usize).empty;
         defer current_path.deinit();
 
         try self.dfsPath(allocator, start, end, max_length, &visited, &current_path, &paths);

--- a/agenkit-zig/src/techniques/reasoning/reasoning_tree.zig
+++ b/agenkit-zig/src/techniques/reasoning/reasoning_tree.zig
@@ -2,7 +2,6 @@
 ///
 /// Provides a tree structure for exploring multiple reasoning paths with
 /// branching, evaluation, pruning, and backtracking capabilities.
-
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 
@@ -85,7 +84,7 @@ pub const ReasoningTree = struct {
             .id = node_id,
             .content = try self.allocator.dupe(u8, content),
             .parent_id = null,
-            .children_ids = std.ArrayList(usize).init(self.allocator),
+            .children_ids = std.ArrayList(usize).empty,
             .depth = 0,
             .score = 0.0,
             .state = .open,
@@ -115,7 +114,7 @@ pub const ReasoningTree = struct {
             .id = child_id,
             .content = try self.allocator.dupe(u8, content),
             .parent_id = parent_id,
-            .children_ids = std.ArrayList(usize).init(self.allocator),
+            .children_ids = std.ArrayList(usize).empty,
             .depth = parent_depth + 1,
             .score = score,
             .state = .open,
@@ -141,13 +140,13 @@ pub const ReasoningTree = struct {
 
     /// Get the path from root to a specific node
     pub fn getPath(self: *ReasoningTree, node_id: usize, allocator: Allocator) ![]const *const ReasoningNode {
-        var path = std.ArrayList(*const ReasoningNode).init(allocator);
-        errdefer path.deinit();
+        var path = std.ArrayList(*const ReasoningNode).empty;
+        errdefer path.deinit(allocator);
 
         var current_id: ?usize = node_id;
         while (current_id) |id| {
             if (self.nodes.getPtr(id)) |node| {
-                try path.append(node);
+                try path.append(allocator, node);
                 current_id = node.parent_id;
             } else {
                 break;
@@ -157,7 +156,7 @@ pub const ReasoningTree = struct {
         // Reverse to get root-to-leaf order
         std.mem.reverse(*const ReasoningNode, path.items);
 
-        return try path.toOwnedSlice();
+        return try path.toOwnedSlice(allocator);
     }
 
     /// Get path content as concatenated text

--- a/agenkit-zig/src/techniques/reasoning/self_consistency.zig
+++ b/agenkit-zig/src/techniques/reasoning/self_consistency.zig
@@ -5,7 +5,6 @@
 ///
 /// Reference: "Self-Consistency Improves Chain of Thought Reasoning in Language Models"
 /// Wang et al., 2022 - https://arxiv.org/abs/2203.11171
-
 const std = @import("std");
 const Agent = @import("../../agent.zig").Agent;
 const AgentError = @import("../../agent.zig").AgentError;
@@ -135,7 +134,7 @@ pub const SelfConsistencyAgent = struct {
         const self: *SelfConsistencyAgent = @ptrCast(@alignCast(ptr));
 
         // Generate multiple samples
-        var samples = std.ArrayList([]const u8).init(self.allocator);
+        var samples = std.ArrayList([]const u8).empty;
         defer {
             for (samples.items) |sample| {
                 self.allocator.free(sample);
@@ -143,7 +142,7 @@ pub const SelfConsistencyAgent = struct {
             samples.deinit();
         }
 
-        var extracted_answers = std.ArrayList([]const u8).init(self.allocator);
+        var extracted_answers = std.ArrayList([]const u8).empty;
         defer {
             for (extracted_answers.items) |answer| {
                 self.allocator.free(answer);
@@ -224,7 +223,7 @@ pub const SelfConsistencyAgent = struct {
 
         for (answers) |answer| {
             // Normalize (lowercase, trim)
-            var normalized = std.ArrayList(u8).init(self.allocator);
+            var normalized = std.ArrayList(u8).empty;
             defer normalized.deinit();
 
             for (answer) |c| {

--- a/agenkit-zig/src/techniques/reasoning/tree_of_thought.zig
+++ b/agenkit-zig/src/techniques/reasoning/tree_of_thought.zig
@@ -5,7 +5,6 @@
 ///
 /// Reference: "Tree of Thoughts: Deliberate Problem Solving with Large Language Models"
 /// Yao et al., 2023 - https://arxiv.org/abs/2305.10601
-
 const std = @import("std");
 const Agent = @import("../../agent.zig").Agent;
 const AgentError = @import("../../agent.zig").AgentError;
@@ -221,7 +220,7 @@ pub const TreeOfThoughtAgent = struct {
 
     /// Generate N varied reasoning branches for a prompt (sequential in Zig)
     fn generateBranches(self: *TreeOfThoughtAgent, prompt: []const u8, n: usize) ![][]const u8 {
-        var branches = std.ArrayList([]const u8).init(self.allocator);
+        var branches = std.ArrayList([]const u8).empty;
         errdefer {
             for (branches.items) |branch| {
                 self.allocator.free(branch);
@@ -273,7 +272,7 @@ pub const TreeOfThoughtAgent = struct {
             self.allocator.free(branches);
         }
 
-        var child_ids = std.ArrayList(usize).init(self.allocator);
+        var child_ids = std.ArrayList(usize).empty;
         errdefer child_ids.deinit();
 
         for (branches) |branch| {
@@ -302,7 +301,7 @@ pub const TreeOfThoughtAgent = struct {
 
     /// Perform breadth-first search on the tree
     fn searchBFS(self: *TreeOfThoughtAgent, tree: *ReasoningTree, root_id: usize) !void {
-        var queue = std.ArrayList(usize).init(self.allocator);
+        var queue = std.ArrayList(usize).empty;
         defer queue.deinit();
 
         try queue.append(root_id);
@@ -330,7 +329,7 @@ pub const TreeOfThoughtAgent = struct {
 
     /// Perform depth-first search on the tree
     fn searchDFS(self: *TreeOfThoughtAgent, tree: *ReasoningTree, root_id: usize) !void {
-        var stack = std.ArrayList(usize).init(self.allocator);
+        var stack = std.ArrayList(usize).empty;
         defer stack.deinit();
 
         try stack.append(root_id);

--- a/agenkit-zig/src/test_utils.zig
+++ b/agenkit-zig/src/test_utils.zig
@@ -1,8 +1,8 @@
 /// Test utilities for Agenkit Zig
 ///
 /// Provides reusable mocks, fixtures, and helpers for testing agents.
-
 const std = @import("std");
+const agktime = @import("time_compat.zig");
 const Agent = @import("agent.zig").Agent;
 const AgentError = @import("agent.zig").AgentError;
 const Result = @import("agent.zig").Result;
@@ -338,7 +338,7 @@ pub const MockLLM = struct {
 
         // Simulate network delay if configured
         if (self.delay_ms > 0) {
-            std.time.sleep(self.delay_ms * std.time.ns_per_ms);
+            agktime.sleep(self.delay_ms * std.time.ns_per_ms);
         }
 
         // Simulate failure if configured

--- a/agenkit-zig/src/test_utils.zig
+++ b/agenkit-zig/src/test_utils.zig
@@ -402,7 +402,7 @@ pub const MockLLM = struct {
 test "MockAgent basic functionality" {
     const testing = std.testing;
 
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -446,7 +446,7 @@ test "MockAgent basic functionality" {
 test "MockAgent capabilities" {
     const testing = std.testing;
 
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -465,7 +465,7 @@ test "MockAgent capabilities" {
 test "MockAgent reset call count" {
     const testing = std.testing;
 
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -490,7 +490,7 @@ test "MockAgent reset call count" {
 test "FailingMockAgent returns error" {
     const testing = std.testing;
 
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -510,7 +510,7 @@ test "FailingMockAgent returns error" {
 test "MockAgent introspection" {
     const testing = std.testing;
 
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -528,7 +528,7 @@ test "MockAgent introspection" {
 test "MockLLM basic functionality" {
     const testing = std.testing;
 
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -552,7 +552,7 @@ test "MockLLM basic functionality" {
 test "MockLLM LLM parameters" {
     const testing = std.testing;
 
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -575,7 +575,7 @@ test "MockLLM LLM parameters" {
 test "MockLLM failure mode" {
     const testing = std.testing;
 
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
@@ -595,7 +595,7 @@ test "MockLLM failure mode" {
 test "MockLLM introspection" {
     const testing = std.testing;
 
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/agenkit-zig/src/time_compat.zig
+++ b/agenkit-zig/src/time_compat.zig
@@ -1,0 +1,90 @@
+//! Wall-clock time helpers compatible with the pre-0.16 `std.time` API.
+//!
+//! Zig 0.16 removed the free functions `std.time.timestamp`,
+//! `std.time.milliTimestamp`, and `std.time.nanoTimestamp` in favour of the
+//! `Io`-based `std.Io.Clock.now` API. Threading an `Io` instance through every
+//! call site in the toolkit would be invasive and would change many public
+//! signatures, so this module restores the old, allocation-free behaviour by
+//! reading the platform real-time clock directly — exactly how the standard
+//! library's own `Io.Threaded.nowPosix` does it.
+//!
+//! Semantics match the old `std.time` functions:
+//! - `timestamp()`      -> seconds since the Unix epoch (UTC)
+//! - `milliTimestamp()` -> milliseconds since the Unix epoch (UTC)
+//! - `nanoTimestamp()`  -> nanoseconds since the Unix epoch (UTC)
+
+const std = @import("std");
+const builtin = @import("builtin");
+const posix = std.posix;
+
+/// Nanoseconds since the Unix epoch (UTC).
+pub fn nanoTimestamp() i128 {
+    switch (builtin.os.tag) {
+        .windows => {
+            // RtlGetSystemTimePrecise() returns 100ns ticks since 1601-01-01.
+            const epoch_adj = std.time.epoch.windows * (std.time.ns_per_s / 100);
+            const ticks: i128 = std.os.windows.ntdll.RtlGetSystemTimePrecise();
+            return (ticks + epoch_adj) * 100;
+        },
+        .wasi => {
+            var ns: std.os.wasi.timestamp_t = undefined;
+            const err = std.os.wasi.clock_time_get(.REALTIME, 1, &ns);
+            if (err != .SUCCESS) return 0;
+            return ns;
+        },
+        else => {
+            var ts: posix.timespec = undefined;
+            switch (posix.errno(posix.system.clock_gettime(.REALTIME, &ts))) {
+                .SUCCESS => return @as(i128, ts.sec) * std.time.ns_per_s + ts.nsec,
+                else => return 0,
+            }
+        },
+    }
+}
+
+/// Milliseconds since the Unix epoch (UTC).
+pub fn milliTimestamp() i64 {
+    return @intCast(@divFloor(nanoTimestamp(), std.time.ns_per_ms));
+}
+
+/// Seconds since the Unix epoch (UTC).
+pub fn timestamp() i64 {
+    return @intCast(@divFloor(nanoTimestamp(), std.time.ns_per_s));
+}
+
+/// Block the current thread for approximately `nanoseconds`.
+///
+/// Replaces the removed `std.time.sleep` / `std.Thread.sleep`. Uses libc
+/// `nanosleep` when available (efficient, scheduler-friendly); otherwise busy
+/// waits against the real-time clock.
+pub fn sleep(nanoseconds: u64) void {
+    if (builtin.os.tag == .windows) {
+        std.os.windows.kernel32.Sleep(@intCast(nanoseconds / std.time.ns_per_ms));
+        return;
+    }
+    if (builtin.link_libc) {
+        var req: std.c.timespec = .{
+            .sec = @intCast(nanoseconds / std.time.ns_per_s),
+            .nsec = @intCast(nanoseconds % std.time.ns_per_s),
+        };
+        var rem: std.c.timespec = undefined;
+        while (std.c.nanosleep(&req, &rem) != 0) {
+            // Interrupted by a signal; resume with the remaining time.
+            req = rem;
+        }
+        return;
+    }
+    const deadline = nanoTimestamp() + @as(i128, nanoseconds);
+    while (nanoTimestamp() < deadline) std.atomic.spinLoopHint();
+}
+
+test "timestamps are monotonic-ish and ordered by magnitude" {
+    const ns = nanoTimestamp();
+    const ms = milliTimestamp();
+    const s = timestamp();
+    try std.testing.expect(ns > 0);
+    try std.testing.expect(ms > 0);
+    try std.testing.expect(s > 0);
+    // Sanity: a recent date (> 2020-01-01) in seconds.
+    try std.testing.expect(s > 1_577_836_800);
+}

--- a/agenkit-zig/src/tool.zig
+++ b/agenkit-zig/src/tool.zig
@@ -56,7 +56,7 @@
 ///         const query = params.object.get("query") orelse return error.MissingParameter;
 ///
 ///         // Perform search...
-///         var result_data = json.ObjectMap.init(allocator);
+///         var result_data = json.ObjectMap.empty;
 ///         try result_data.put("results", json.Value{ .string = "Search results..." });
 ///
 ///         return ToolResult{
@@ -131,7 +131,7 @@ pub const ToolResult = struct {
                     freeJsonValue(allocator, entry.value_ptr.*);
                 }
                 var mut_obj = obj;
-                mut_obj.deinit();
+                mut_obj.deinit(allocator);
             },
             else => {},
         }
@@ -139,15 +139,13 @@ pub const ToolResult = struct {
 
     /// Get result as JSON string
     pub fn asJson(self: *const ToolResult, allocator: Allocator) ![]const u8 {
-        var obj = json.ObjectMap.init(allocator);
-        defer obj.deinit();
+        var obj = json.ObjectMap.empty;
+        defer obj.deinit(allocator);
 
-        try obj.put("id", json.Value{ .string = self.id });
-        try obj.put("result", self.result);
+        try obj.put(allocator, "id", json.Value{ .string = self.id });
+        try obj.put(allocator, "result", self.result);
 
-        var string = std.ArrayList(u8).init(allocator);
-        try std.json.stringify(json.Value{ .object = obj }, .{}, string.writer());
-        return string.toOwnedSlice();
+        return std.json.Stringify.valueAlloc(allocator, json.Value{ .object = obj }, .{});
     }
 };
 
@@ -216,7 +214,7 @@ pub const Tool = struct {
     ///
     /// Example:
     /// ```zig
-    /// var params = json.ObjectMap.init(allocator);
+    /// var params = json.ObjectMap.empty;
     /// try params.put("query", json.Value{ .string = "What is the weather?" });
     ///
     /// var result = try tool.execute(json.Value{ .object = params }, allocator);
@@ -302,9 +300,9 @@ test "EchoTool basic functionality" {
     try std.testing.expectEqualStrings("Echo back the provided parameters", tool_iface.description());
 
     // Create test parameters
-    var params = json.ObjectMap.init(allocator);
+    var params = json.ObjectMap.empty;
     const test_str = try allocator.dupe(u8, "value");
-    try params.put("test", json.Value{ .string = test_str });
+    try params.put(allocator, "test", json.Value{ .string = test_str });
 
     // Execute tool (ToolResult takes ownership of params and its contents)
     var result = try tool_iface.execute(json.Value{ .object = params }, allocator);
@@ -320,9 +318,9 @@ test "EchoTool basic functionality" {
 test "ToolResult creation and cleanup" {
     const allocator = std.testing.allocator;
 
-    var result_data = json.ObjectMap.init(allocator);
+    var result_data = json.ObjectMap.empty;
     const status_str = try allocator.dupe(u8, "success");
-    try result_data.put("status", json.Value{ .string = status_str });
+    try result_data.put(allocator, "status", json.Value{ .string = status_str });
 
     var result = try ToolResult.init(allocator, "test_id", json.Value{ .object = result_data });
     defer result.deinit();

--- a/agenkit-zig/src/transports/grpc.zig
+++ b/agenkit-zig/src/transports/grpc.zig
@@ -21,7 +21,7 @@
 ///! var agent = try GrpcAgent.init(allocator, config);
 ///! defer agent.deinit();
 ///!
-///! var messages = std.ArrayList(Message).init(allocator);
+///! var messages = std.ArrayList(Message).empty;
 ///! defer messages.deinit();
 ///! try messages.append(Message.init("user", "Hello via gRPC!"));
 ///!
@@ -49,7 +49,6 @@
 ///! - Option 1: Bind to C++ gRPC library via @cImport
 ///! - Option 2: Implement HTTP/2 client with protobuf encoding
 ///! - Option 3: Use existing zig-http2 + protobuf-zig
-
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 const Message = @import("../message.zig").Message;
@@ -170,7 +169,7 @@ pub const GrpcAgent = struct {
     /// };
     ///
     /// var context = grpc.ClientContext{};
-    /// context.set_deadline(std.time.timestamp() + config.timeout_secs);
+    /// context.set_deadline(agktime.timestamp() + config.timeout_secs);
     ///
     /// var response: agent.Response = undefined;
     /// const status = stub.Process(&context, &request, &response);

--- a/agenkit-zig/src/transports/websocket.zig
+++ b/agenkit-zig/src/transports/websocket.zig
@@ -22,7 +22,7 @@
 ///! var agent = try WebSocketAgent.init(allocator, config);
 ///! defer agent.deinit();
 ///!
-///! var messages = std.ArrayList(Message).init(allocator);
+///! var messages = std.ArrayList(Message).empty;
 ///! defer messages.deinit();
 ///! try messages.append(Message.init("user", "Hello via WebSocket!"));
 ///!
@@ -47,7 +47,6 @@
 ///! - Option 2: zig-websocket library (community)
 ///! - Option 3: Call C WebSocket library via @cImport
 ///! - Option 4: Implement WebSocket protocol from RFC 6455
-
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 const Message = @import("../message.zig").Message;
@@ -107,7 +106,7 @@ pub const WebSocketAgent = struct {
     // ping_thread: ?std.Thread,
     // receive_thread: ?std.Thread,
     // should_stop: bool,
-    // mutex: std.Thread.Mutex,
+    // mutex: agksync.Mutex,
 
     const Self = @This();
 
@@ -241,7 +240,7 @@ pub const WebSocketAgent = struct {
     ///     const delay = self.config.initial_retry_delay_ms * std.math.pow(u64, 2, attempt);
     ///     const capped_delay = @min(delay, self.config.max_retry_delay_ms);
     ///
-    ///     std.time.sleep(capped_delay * std.time.ns_per_ms);
+    ///     agktime.sleep(capped_delay * std.time.ns_per_ms);
     ///
     ///     if (try self.tryConnect()) {
     ///         self.connected = true;

--- a/agenkit-zig/tests/cross_language/message_serialization_test.zig
+++ b/agenkit-zig/tests/cross_language/message_serialization_test.zig
@@ -14,10 +14,7 @@ const Role = agenkit.Role;
 fn loadFixtures(allocator: std.mem.Allocator) !json.Parsed(json.Value) {
     // Path from project root (where zig build is run)
     const fixtures_path = "../tests/cross_language/fixtures/messages.json";
-    const file = try std.fs.cwd().openFile(fixtures_path, .{});
-    defer file.close();
-
-    const content = try file.readToEndAlloc(allocator, 1024 * 1024);
+    const content = try std.Io.Dir.cwd().readFileAlloc(agenkit.io_compat.io(), fixtures_path, allocator, .limited(1024 * 1024));
     defer allocator.free(content);
 
     return try json.parseFromSlice(json.Value, allocator, content, .{});
@@ -27,10 +24,7 @@ fn loadFixtures(allocator: std.mem.Allocator) !json.Parsed(json.Value) {
 fn loadSchema(allocator: std.mem.Allocator) !json.Parsed(json.Value) {
     // Path from project root (where zig build is run)
     const schema_path = "../tests/cross_language/schemas/message.schema.json";
-    const file = try std.fs.cwd().openFile(schema_path, .{});
-    defer file.close();
-
-    const content = try file.readToEndAlloc(allocator, 1024 * 1024);
+    const content = try std.Io.Dir.cwd().readFileAlloc(agenkit.io_compat.io(), schema_path, allocator, .limited(1024 * 1024));
     defer allocator.free(content);
 
     return try json.parseFromSlice(json.Value, allocator, content, .{});
@@ -147,7 +141,7 @@ test "simple user message" {
     const serialized = try msg.toJson(allocator);
     defer {
         var mut_serialized = serialized;
-        mut_serialized.object.deinit();
+        mut_serialized.object.deinit(allocator);
     }
     try validateAgainstSchema(serialized, schema.value);
 
@@ -195,13 +189,13 @@ test "assistant message with metadata" {
     const serialized = try msg.toJson(allocator);
     defer {
         var mut_serialized = serialized;
-        mut_serialized.object.deinit();
+        mut_serialized.object.deinit(allocator);
     }
     try validateAgainstSchema(serialized, schema.value);
 
     // Clean up text content and metadata ObjectMap (not the values - owned by fixtures)
     allocator.free(msg.content.text);
-    msg.metadata.object.deinit();
+    msg.metadata.object.deinit(allocator);
 }
 
 test "system message" {
@@ -229,7 +223,7 @@ test "system message" {
     const serialized = try msg.toJson(allocator);
     defer {
         var mut_serialized = serialized;
-        mut_serialized.object.deinit();
+        mut_serialized.object.deinit(allocator);
     }
     try validateAgainstSchema(serialized, schema.value);
 }
@@ -273,11 +267,11 @@ test "tool message structured" {
     const serialized = try msg.toJson(allocator);
     defer {
         var mut_serialized = serialized;
-        mut_serialized.object.deinit();
+        mut_serialized.object.deinit(allocator);
     }
     try validateAgainstSchema(serialized, schema.value);
     // Clean up metadata ObjectMap (content and values are owned by fixtures)
-    msg.metadata.object.deinit();
+    msg.metadata.object.deinit(allocator);
 }
 
 test "empty content" {
@@ -305,7 +299,7 @@ test "empty content" {
     const serialized = try msg.toJson(allocator);
     defer {
         var mut_serialized = serialized;
-        mut_serialized.object.deinit();
+        mut_serialized.object.deinit(allocator);
     }
     try validateAgainstSchema(serialized, schema.value);
 }
@@ -345,13 +339,13 @@ test "large content" {
     const serialized = try msg.toJson(allocator);
     defer {
         var mut_serialized = serialized;
-        mut_serialized.object.deinit();
+        mut_serialized.object.deinit(allocator);
     }
     try validateAgainstSchema(serialized, schema.value);
 
     // Clean up text content and metadata ObjectMap (not the values - owned by fixtures)
     allocator.free(msg.content.text);
-    msg.metadata.object.deinit();
+    msg.metadata.object.deinit(allocator);
 }
 
 test "unicode content" {
@@ -388,13 +382,13 @@ test "unicode content" {
     const serialized = try msg.toJson(allocator);
     defer {
         var mut_serialized = serialized;
-        mut_serialized.object.deinit();
+        mut_serialized.object.deinit(allocator);
     }
     try validateAgainstSchema(serialized, schema.value);
 
     // Clean up text content and metadata ObjectMap (not the values - owned by fixtures)
     allocator.free(msg.content.text);
-    msg.metadata.object.deinit();
+    msg.metadata.object.deinit(allocator);
 }
 
 test "nested metadata" {
@@ -437,13 +431,13 @@ test "nested metadata" {
     const serialized = try msg.toJson(allocator);
     defer {
         var mut_serialized = serialized;
-        mut_serialized.object.deinit();
+        mut_serialized.object.deinit(allocator);
     }
     try validateAgainstSchema(serialized, schema.value);
 
     // Clean up text content and metadata ObjectMap (not the values - owned by fixtures)
     allocator.free(msg.content.text);
-    msg.metadata.object.deinit();
+    msg.metadata.object.deinit(allocator);
 }
 
 test "numeric metadata" {
@@ -483,13 +477,13 @@ test "numeric metadata" {
     const serialized = try msg.toJson(allocator);
     defer {
         var mut_serialized = serialized;
-        mut_serialized.object.deinit();
+        mut_serialized.object.deinit(allocator);
     }
     try validateAgainstSchema(serialized, schema.value);
 
     // Clean up text content and metadata ObjectMap (not the values - owned by fixtures)
     allocator.free(msg.content.text);
-    msg.metadata.object.deinit();
+    msg.metadata.object.deinit(allocator);
 }
 
 test "all fixtures roundtrip" {
@@ -530,7 +524,7 @@ test "all fixtures roundtrip" {
         const serialized = try msg.toJson(allocator);
         defer {
             var mut_serialized = serialized;
-            mut_serialized.object.deinit();
+            mut_serialized.object.deinit(allocator);
         }
         try validateAgainstSchema(serialized, schema.value);
 
@@ -542,6 +536,6 @@ test "all fixtures roundtrip" {
         if (has_text_content) {
             allocator.free(msg.content.text);
         }
-        msg.metadata.object.deinit();
+        msg.metadata.object.deinit(allocator);
     }
 }

--- a/agenkit-zig/tests/cross_language/rate_limiter_behavior_test.zig
+++ b/agenkit-zig/tests/cross_language/rate_limiter_behavior_test.zig
@@ -7,6 +7,7 @@ const std = @import("std");
 const json = std.json;
 const testing = std.testing;
 const agenkit = @import("agenkit");
+const agktime = agenkit.time_compat;
 const Agent = agenkit.Agent;
 const AgentError = agenkit.AgentError;
 const Message = agenkit.Message;
@@ -67,7 +68,7 @@ const MockRateLimiterAgent = struct {
         const msg = Message{
             .role = .agent,
             .content = .{ .text = response_content },
-            .metadata = json.Value{ .object = json.ObjectMap.init(self.allocator) },
+            .metadata = json.Value{ .object = json.ObjectMap.empty },
             .allocator = self.allocator,
         };
 
@@ -84,12 +85,12 @@ const MockRateLimiterAgent = struct {
         _ = ptr;
         return IntrospectionResult{
             .allocator = allocator,
-            .timestamp = std.time.timestamp(),
+            .timestamp = agktime.timestamp(),
             .agent_name = "mock-rate-limiter-agent",
             .capabilities = try allocator.alloc([]const u8, 0),
             .memory_state = null,
-            .internal_state = json.Value{ .object = json.ObjectMap.init(allocator) },
-            .metadata = json.Value{ .object = json.ObjectMap.init(allocator) },
+            .internal_state = json.Value{ .object = json.ObjectMap.empty },
+            .metadata = json.Value{ .object = json.ObjectMap.empty },
         };
     }
 
@@ -99,10 +100,7 @@ const MockRateLimiterAgent = struct {
 /// Load fixtures from JSON file
 fn loadFixtures(allocator: std.mem.Allocator) !json.Parsed(json.Value) {
     const fixtures_path = "../tests/cross_language/fixtures/rate_limiter_behavior.json";
-    const file = try std.fs.cwd().openFile(fixtures_path, .{});
-    defer file.close();
-
-    const content = try file.readToEndAlloc(allocator, 1024 * 1024);
+    const content = try std.Io.Dir.cwd().readFileAlloc(agenkit.io_compat.io(), fixtures_path, allocator, .limited(1024 * 1024));
     defer allocator.free(content);
 
     return try json.parseFromSlice(json.Value, allocator, content, .{});
@@ -173,7 +171,7 @@ test "rate_limiter_allows_within_capacity" {
     var rate_limiter = try RateLimiterDecorator.init(allocator, mock_agent.agent(), config);
     defer rate_limiter.agent().deinit();
 
-    const start = std.time.nanoTimestamp();
+    const start = agktime.nanoTimestamp();
     var successful: usize = 0;
 
     const requests = test_case.object.get("scenario").?.object.get("requests").?.array;
@@ -189,7 +187,7 @@ test "rate_limiter_allows_within_capacity" {
         } else |_| {}
     }
 
-    const elapsed_ns = std.time.nanoTimestamp() - start;
+    const elapsed_ns = agktime.nanoTimestamp() - start;
     const elapsed_ms: u64 = @intCast(@divTrunc(elapsed_ns, 1_000_000));
 
     const expected = test_case.object.get("expected_behavior").?.object;
@@ -229,11 +227,11 @@ test "rate_limiter_waits_for_tokens" {
         var msg = try Message.withText(allocator, .user, "test");
         defer msg.deinit();
 
-        const start = std.time.nanoTimestamp();
+        const start = agktime.nanoTimestamp();
         const result = try rate_limiter.agent().process(msg);
         var response = try result.unwrap();
         defer response.deinit();
-        const elapsed_ns = std.time.nanoTimestamp() - start;
+        const elapsed_ns = agktime.nanoTimestamp() - start;
         const elapsed_ms: u64 = @intCast(@divTrunc(elapsed_ns, 1_000_000));
         try wait_times.append(allocator, elapsed_ms);
     }
@@ -324,7 +322,7 @@ test "rate_limiter_token_refill" {
             defer response.deinit();
         } else if (std.mem.eql(u8, action, "wait")) {
             const duration_ms = @as(u64, @intFromFloat(getJsonNumber(step.object.get("duration_ms").?)));
-            std.Thread.sleep(duration_ms * std.time.ns_per_ms);
+            agktime.sleep(duration_ms * std.time.ns_per_ms);
         }
     }
 
@@ -352,7 +350,7 @@ test "rate_limiter_burst_capacity" {
     var rate_limiter = try RateLimiterDecorator.init(allocator, mock_agent.agent(), config);
     defer rate_limiter.agent().deinit();
 
-    const start = std.time.nanoTimestamp();
+    const start = agktime.nanoTimestamp();
 
     const requests = test_case.object.get("scenario").?.object.get("requests").?.array;
     for (requests.items) |_| {
@@ -363,7 +361,7 @@ test "rate_limiter_burst_capacity" {
         defer response.deinit();
     }
 
-    const elapsed_ns = std.time.nanoTimestamp() - start;
+    const elapsed_ns = agktime.nanoTimestamp() - start;
     const elapsed_ms: u64 = @intCast(@divTrunc(elapsed_ns, 1_000_000));
 
     const expected = test_case.object.get("expected_behavior").?.object;

--- a/agenkit-zig/tests/cross_language/retry_behavior_test.zig
+++ b/agenkit-zig/tests/cross_language/retry_behavior_test.zig
@@ -8,6 +8,7 @@ const json = std.json;
 const testing = std.testing;
 const time = std.time;
 const agenkit = @import("agenkit");
+const agktime = agenkit.time_compat;
 const Agent = agenkit.Agent;
 const AgentError = agenkit.AgentError;
 const Message = agenkit.Message;
@@ -84,7 +85,7 @@ const MockRetryAgent = struct {
             const msg = Message{
                 .role = .agent,
                 .content = .{ .text = response.content },
-                .metadata = json.Value{ .object = json.ObjectMap.init(self.allocator) },
+                .metadata = json.Value{ .object = json.ObjectMap.empty },
                 .allocator = self.allocator,
             };
             return Result{ .ok = msg };
@@ -103,12 +104,12 @@ const MockRetryAgent = struct {
         _ = ptr;
         return IntrospectionResult{
             .allocator = allocator,
-            .timestamp = std.time.timestamp(),
+            .timestamp = agktime.timestamp(),
             .agent_name = "mock-retry-agent",
             .capabilities = try allocator.alloc([]const u8, 0),
             .memory_state = null,
-            .internal_state = json.Value{ .object = json.ObjectMap.init(allocator) },
-            .metadata = json.Value{ .object = json.ObjectMap.init(allocator) },
+            .internal_state = json.Value{ .object = json.ObjectMap.empty },
+            .metadata = json.Value{ .object = json.ObjectMap.empty },
         };
     }
 
@@ -121,10 +122,7 @@ const MockRetryAgent = struct {
 /// Load retry behavior fixtures from JSON file
 fn loadFixtures(allocator: std.mem.Allocator) !json.Parsed(json.Value) {
     const fixtures_path = "../tests/cross_language/fixtures/retry_behavior.json";
-    const file = try std.fs.cwd().openFile(fixtures_path, .{});
-    defer file.close();
-
-    const content = try file.readToEndAlloc(allocator, 1024 * 1024);
+    const content = try std.Io.Dir.cwd().readFileAlloc(agenkit.io_compat.io(), fixtures_path, allocator, .limited(1024 * 1024));
     defer allocator.free(content);
 
     return try json.parseFromSlice(json.Value, allocator, content, .{});
@@ -237,11 +235,11 @@ test "success after retry" {
     defer retry.agent().deinit();
 
     // Measure time
-    const start = time.nanoTimestamp();
+    const start = agktime.nanoTimestamp();
     var msg = try Message.withText(allocator, .user, "test");
     defer msg.deinit();
     const result = try retry.agent().process(msg);
-    const elapsed_ns = time.nanoTimestamp() - start;
+    const elapsed_ns = agktime.nanoTimestamp() - start;
     const elapsed_ms: i64 = @intCast(@divTrunc(elapsed_ns, time.ns_per_ms));
 
     // Verify expected behavior
@@ -313,11 +311,11 @@ test "exponential backoff timing" {
     defer retry.agent().deinit();
 
     // Measure time
-    const start = time.nanoTimestamp();
+    const start = agktime.nanoTimestamp();
     var msg = try Message.withText(allocator, .user, "test");
     defer msg.deinit();
     const result = try retry.agent().process(msg);
-    const elapsed_ns = time.nanoTimestamp() - start;
+    const elapsed_ns = agktime.nanoTimestamp() - start;
     const elapsed_ms: i64 = @intCast(@divTrunc(elapsed_ns, time.ns_per_ms));
 
     // Verify expected behavior
@@ -354,11 +352,11 @@ test "max backoff cap" {
     defer retry.agent().deinit();
 
     // Measure time
-    const start = time.nanoTimestamp();
+    const start = agktime.nanoTimestamp();
     var msg = try Message.withText(allocator, .user, "test");
     defer msg.deinit();
     const result = try retry.agent().process(msg);
-    const elapsed_ns = time.nanoTimestamp() - start;
+    const elapsed_ns = agktime.nanoTimestamp() - start;
     const elapsed_ms: i64 = @intCast(@divTrunc(elapsed_ns, time.ns_per_ms));
 
     // Verify expected behavior

--- a/agenkit-zig/tests/cross_language_api_consistency.zig
+++ b/agenkit-zig/tests/cross_language_api_consistency.zig
@@ -119,7 +119,8 @@ const MockTool = struct {
 
     pub fn parameters(self: *const MockTool, allocator: std.mem.Allocator) !std.json.Value {
         _ = self;
-        return std.json.Value{ .object = std.json.ObjectMap.init(allocator) };
+        _ = allocator;
+        return std.json.Value{ .object = std.json.ObjectMap.empty };
     }
 
     pub fn execute(

--- a/agenkit-zig/tests/cross_language_harness.zig
+++ b/agenkit-zig/tests/cross_language_harness.zig
@@ -2,6 +2,8 @@
 // Implements the JSON protocol for executing pattern tests
 
 const std = @import("std");
+const agenkit = @import("agenkit");
+const agktime = agenkit.time_compat;
 const json = std.json;
 
 // Protocol constants
@@ -137,24 +139,24 @@ fn executeReflection(
     const final_quality_score: f64 = 0.5;
     const total_improvement: f64 = if (has_poem and has_technology) 0.0 else -0.19999999999999996;
 
-    var metadata = std.json.ObjectMap.init(allocator);
-    try metadata.put("iterations", .{ .integer = iterations });
-    try metadata.put("reflection_iterations", .{ .integer = iterations });
-    try metadata.put("final_quality_score", .{ .float = final_quality_score });
-    try metadata.put("initial_quality_score", .{ .float = initial_quality_score });
-    try metadata.put("stop_reason", .{ .string = "minimal_improvement" });
-    try metadata.put("total_improvement", .{ .float = total_improvement });
+    var metadata = std.json.ObjectMap.empty;
+    try metadata.put(allocator, "iterations", .{ .integer = iterations });
+    try metadata.put(allocator, "reflection_iterations", .{ .integer = iterations });
+    try metadata.put(allocator, "final_quality_score", .{ .float = final_quality_score });
+    try metadata.put(allocator, "initial_quality_score", .{ .float = initial_quality_score });
+    try metadata.put(allocator, "stop_reason", .{ .string = "minimal_improvement" });
+    try metadata.put(allocator, "total_improvement", .{ .float = total_improvement });
 
-    var result = std.json.ObjectMap.init(allocator);
-    try result.put("role", .{ .string = "assistant" });
+    var result = std.json.ObjectMap.empty;
+    try result.put(allocator, "role", .{ .string = "assistant" });
 
     const response_content = try std.fmt.allocPrint(
         allocator,
         "Reflected response to: {s}",
         .{content},
     );
-    try result.put("content", .{ .string = response_content });
-    try result.put("metadata", .{ .object = metadata });
+    try result.put(allocator, "content", .{ .string = response_content });
+    try result.put(allocator, "metadata", .{ .object = metadata });
 
     return .{ .object = result };
 }
@@ -200,29 +202,29 @@ fn executeSequential(
 
             try agent_names.append(.{ .string = agent_name });
 
-            var stage_obj = std.json.ObjectMap.init(allocator);
-            try stage_obj.put("agent", .{ .string = agent_name });
-            try stage_obj.put("stage", .{ .integer = @intCast(i) });
+            var stage_obj = std.json.ObjectMap.empty;
+            try stage_obj.put(allocator, "agent", .{ .string = agent_name });
+            try stage_obj.put(allocator, "stage", .{ .integer = @intCast(i) });
             try pipeline_stages.append(.{ .object = stage_obj });
         }
     }
 
-    var metadata = std.json.ObjectMap.init(allocator);
-    try metadata.put("agent_count", .{ .integer = agent_count });
-    try metadata.put("pipeline_length", .{ .integer = agent_count });
-    try metadata.put("execution_order", .{ .array = agent_names });
-    try metadata.put("pipeline_stages", .{ .array = pipeline_stages });
+    var metadata = std.json.ObjectMap.empty;
+    try metadata.put(allocator, "agent_count", .{ .integer = agent_count });
+    try metadata.put(allocator, "pipeline_length", .{ .integer = agent_count });
+    try metadata.put(allocator, "execution_order", .{ .array = agent_names });
+    try metadata.put(allocator, "pipeline_stages", .{ .array = pipeline_stages });
 
-    var result = std.json.ObjectMap.init(allocator);
-    try result.put("role", .{ .string = "assistant" });
+    var result = std.json.ObjectMap.empty;
+    try result.put(allocator, "role", .{ .string = "assistant" });
 
     const response_content = try std.fmt.allocPrint(
         allocator,
         "Sequential result: {s}",
         .{content},
     );
-    try result.put("content", .{ .string = response_content });
-    try result.put("metadata", .{ .object = metadata });
+    try result.put(allocator, "content", .{ .string = response_content });
+    try result.put(allocator, "metadata", .{ .object = metadata });
 
     return .{ .object = result };
 }
@@ -267,22 +269,22 @@ fn executeParallel(
         }
     }
 
-    var metadata = std.json.ObjectMap.init(allocator);
-    try metadata.put("agent_count", .{ .integer = agent_count });
-    try metadata.put("parallel_agents", .{ .integer = agent_count });
-    try metadata.put("successful_agents", .{ .integer = agent_count });
-    try metadata.put("aggregated", .{ .bool = true });
+    var metadata = std.json.ObjectMap.empty;
+    try metadata.put(allocator, "agent_count", .{ .integer = agent_count });
+    try metadata.put(allocator, "parallel_agents", .{ .integer = agent_count });
+    try metadata.put(allocator, "successful_agents", .{ .integer = agent_count });
+    try metadata.put(allocator, "aggregated", .{ .bool = true });
 
-    var result = std.json.ObjectMap.init(allocator);
-    try result.put("role", .{ .string = "assistant" });
+    var result = std.json.ObjectMap.empty;
+    try result.put(allocator, "role", .{ .string = "assistant" });
 
     const response_content = try std.fmt.allocPrint(
         allocator,
         "Parallel result: {s}",
         .{content},
     );
-    try result.put("content", .{ .string = response_content });
-    try result.put("metadata", .{ .object = metadata });
+    try result.put(allocator, "content", .{ .string = response_content });
+    try result.put(allocator, "metadata", .{ .object = metadata });
 
     return .{ .object = result };
 }
@@ -463,15 +465,15 @@ fn executeRouter(
         available_routes += 1;
     }
 
-    var metadata = std.json.ObjectMap.init(allocator);
-    try metadata.put("routed_category", .{ .string = category });
-    try metadata.put("routed_agent", .{ .string = routed_agent });
-    try metadata.put("available_routes", .{ .integer = available_routes });
+    var metadata = std.json.ObjectMap.empty;
+    try metadata.put(allocator, "routed_category", .{ .string = category });
+    try metadata.put(allocator, "routed_agent", .{ .string = routed_agent });
+    try metadata.put(allocator, "available_routes", .{ .integer = available_routes });
 
-    var result = std.json.ObjectMap.init(allocator);
-    try result.put("role", .{ .string = "assistant" });
-    try result.put("content", .{ .string = content });
-    try result.put("metadata", .{ .object = metadata });
+    var result = std.json.ObjectMap.empty;
+    try result.put(allocator, "role", .{ .string = "assistant" });
+    try result.put(allocator, "content", .{ .string = content });
+    try result.put(allocator, "metadata", .{ .object = metadata });
 
     return .{ .object = result };
 }
@@ -527,11 +529,11 @@ fn executeFallback(
         success_agent = agent_name;
         success_index = @as(i64, @intCast(i));
 
-        var metadata = std.json.ObjectMap.init(allocator);
-        try metadata.put("fallback_attempts", .{ .integer = attempts });
-        try metadata.put("fallback_success_index", .{ .integer = success_index });
-        try metadata.put("fallback_success_agent", .{ .string = success_agent });
-        try metadata.put("fallback_total_agents", .{ .integer = @as(i64, @intCast(agents.items.len)) });
+        var metadata = std.json.ObjectMap.empty;
+        try metadata.put(allocator, "fallback_attempts", .{ .integer = attempts });
+        try metadata.put(allocator, "fallback_success_index", .{ .integer = success_index });
+        try metadata.put(allocator, "fallback_success_agent", .{ .string = success_agent });
+        try metadata.put(allocator, "fallback_total_agents", .{ .integer = @as(i64, @intCast(agents.items.len)) });
 
         // Add failures array only if there were any
         if (failure_count > 0) {
@@ -539,13 +541,13 @@ fn executeFallback(
             for (failures[0..failure_count]) |failure_name| {
                 try failures_array.append(.{ .string = failure_name });
             }
-            try metadata.put("failures", .{ .array = failures_array });
+            try metadata.put(allocator, "failures", .{ .array = failures_array });
         }
 
-        var result = std.json.ObjectMap.init(allocator);
-        try result.put("role", .{ .string = "assistant" });
-        try result.put("content", .{ .string = content });
-        try result.put("metadata", .{ .object = metadata });
+        var result = std.json.ObjectMap.empty;
+        try result.put(allocator, "role", .{ .string = "assistant" });
+        try result.put(allocator, "content", .{ .string = content });
+        try result.put(allocator, "metadata", .{ .object = metadata });
 
         return .{ .object = result };
     }
@@ -574,12 +576,12 @@ fn executeTask(
         return error.TaskFailed;
     }
 
-    const metadata = std.json.ObjectMap.init(allocator);
+    const metadata = std.json.ObjectMap.empty;
 
-    var result = std.json.ObjectMap.init(allocator);
-    try result.put("role", .{ .string = "assistant" });
-    try result.put("content", .{ .string = content });
-    try result.put("metadata", .{ .object = metadata });
+    var result = std.json.ObjectMap.empty;
+    try result.put(allocator, "role", .{ .string = "assistant" });
+    try result.put(allocator, "content", .{ .string = content });
+    try result.put(allocator, "metadata", .{ .object = metadata });
 
     return .{ .object = result };
 }
@@ -596,31 +598,31 @@ fn executeSupervisor(
 
     var execution_order = std.json.Array.init(allocator);
 
-    var order_item_1 = std.json.ObjectMap.init(allocator);
-    try order_item_1.put("index", .{ .integer = 0 });
-    try order_item_1.put("type", .{ .string = "default" });
-    try order_item_1.put("specialist", .{ .string = "mock_agent" });
+    var order_item_1 = std.json.ObjectMap.empty;
+    try order_item_1.put(allocator, "index", .{ .integer = 0 });
+    try order_item_1.put(allocator, "type", .{ .string = "default" });
+    try order_item_1.put(allocator, "specialist", .{ .string = "mock_agent" });
     try execution_order.append(.{ .object = order_item_1 });
 
-    var order_item_2 = std.json.ObjectMap.init(allocator);
-    try order_item_2.put("index", .{ .integer = 1 });
-    try order_item_2.put("type", .{ .string = "default" });
-    try order_item_2.put("specialist", .{ .string = "mock_agent" });
+    var order_item_2 = std.json.ObjectMap.empty;
+    try order_item_2.put(allocator, "index", .{ .integer = 1 });
+    try order_item_2.put(allocator, "type", .{ .string = "default" });
+    try order_item_2.put(allocator, "specialist", .{ .string = "mock_agent" });
     try execution_order.append(.{ .object = order_item_2 });
 
-    var metadata = std.json.ObjectMap.init(allocator);
-    try metadata.put("synthesized", .{ .bool = true });
-    try metadata.put("result_count", .{ .integer = 2 });
-    try metadata.put("supervisor_subtasks", .{ .integer = 2 });
-    try metadata.put("supervisor_specialists", .{ .integer = 1 });
-    try metadata.put("execution_order", .{ .array = execution_order });
+    var metadata = std.json.ObjectMap.empty;
+    try metadata.put(allocator, "synthesized", .{ .bool = true });
+    try metadata.put(allocator, "result_count", .{ .integer = 2 });
+    try metadata.put(allocator, "supervisor_subtasks", .{ .integer = 2 });
+    try metadata.put(allocator, "supervisor_specialists", .{ .integer = 1 });
+    try metadata.put(allocator, "execution_order", .{ .array = execution_order });
 
     const response_content = "1. First approach: analyze directly.\n2. Calculate step by step.\n3. Result: 42 - Alternative method: work backwards.\n- Apply the formula.\n- Answer: 42";
 
-    var result = std.json.ObjectMap.init(allocator);
-    try result.put("role", .{ .string = "assistant" });
-    try result.put("content", .{ .string = response_content });
-    try result.put("metadata", .{ .object = metadata });
+    var result = std.json.ObjectMap.empty;
+    try result.put(allocator, "role", .{ .string = "assistant" });
+    try result.put(allocator, "content", .{ .string = response_content });
+    try result.put(allocator, "metadata", .{ .object = metadata });
 
     return .{ .object = result };
 }
@@ -638,37 +640,37 @@ fn executeAgentsAsTools(
     const content_lower = std.ascii.lowerString(&content_lower_buf, content);
 
     var response_content: []const u8 = undefined;
-    var metadata = std.json.ObjectMap.init(allocator);
+    var metadata = std.json.ObjectMap.empty;
 
     if (std.mem.indexOf(u8, content_lower, "calculate") != null and
         std.mem.indexOf(u8, content_lower, "multiply") != null)
     {
         // Scenario 1: Basic agent delegation - calculator operations
-        try metadata.put("agents_called", .{ .integer = 2 });
+        try metadata.put(allocator, "agents_called", .{ .integer = 2 });
         var delegation_chain = std.json.Array.init(allocator);
         try delegation_chain.append(.{ .string = "calculator" });
         try delegation_chain.append(.{ .string = "calculator" });
-        try metadata.put("delegation_chain", .{ .array = delegation_chain });
+        try metadata.put(allocator, "delegation_chain", .{ .array = delegation_chain });
         var sub_agents = std.json.Array.init(allocator);
         try sub_agents.append(.{ .string = "calculator" });
-        try metadata.put("sub_agents", .{ .array = sub_agents });
+        try metadata.put(allocator, "sub_agents", .{ .array = sub_agents });
         response_content = "16";
     } else if (std.mem.indexOf(u8, content_lower, "weather") != null) {
         // Scenario 2: Specialized agent selection - weather query
-        try metadata.put("selection_reason", .{ .string = "weather query" });
+        try metadata.put(allocator, "selection_reason", .{ .string = "weather query" });
         var sub_agents = std.json.Array.init(allocator);
         try sub_agents.append(.{ .string = "weather_agent" });
-        try metadata.put("sub_agents", .{ .array = sub_agents });
+        try metadata.put(allocator, "sub_agents", .{ .array = sub_agents });
         response_content = "The weather in Tokyo is sunny with a temperature of 22°C";
     } else if (std.mem.indexOf(u8, content_lower, "search") != null and
         std.mem.indexOf(u8, content_lower, "summarize") != null)
     {
         // Scenario 3: Multiple delegations in sequence
-        try metadata.put("delegation_count", .{ .integer = 2 });
+        try metadata.put(allocator, "delegation_count", .{ .integer = 2 });
         var sub_agents = std.json.Array.init(allocator);
         try sub_agents.append(.{ .string = "search_agent" });
         try sub_agents.append(.{ .string = "summarizer_agent" });
-        try metadata.put("sub_agents", .{ .array = sub_agents });
+        try metadata.put(allocator, "sub_agents", .{ .array = sub_agents });
         response_content = "Found Python tutorials. Summary: Python is a versatile programming language.";
     } else if (std.mem.indexOf(u8, content_lower, "hello") != null or
         std.mem.indexOf(u8, content_lower, "how are you") != null)
@@ -679,10 +681,10 @@ fn executeAgentsAsTools(
         response_content = content;
     }
 
-    var result = std.json.ObjectMap.init(allocator);
-    try result.put("role", .{ .string = "assistant" });
-    try result.put("content", .{ .string = response_content });
-    try result.put("metadata", .{ .object = metadata });
+    var result = std.json.ObjectMap.empty;
+    try result.put(allocator, "role", .{ .string = "assistant" });
+    try result.put(allocator, "content", .{ .string = response_content });
+    try result.put(allocator, "metadata", .{ .object = metadata });
 
     return .{ .object = result };
 }
@@ -696,12 +698,12 @@ fn executeMultiagent(
     const content_obj = message.object.get("content") orelse return error.MissingContent;
     const content = content_obj.string;
 
-    const metadata = std.json.ObjectMap.init(allocator);
+    const metadata = std.json.ObjectMap.empty;
 
-    var result = std.json.ObjectMap.init(allocator);
-    try result.put("role", .{ .string = "assistant" });
-    try result.put("content", .{ .string = content });
-    try result.put("metadata", .{ .object = metadata });
+    var result = std.json.ObjectMap.empty;
+    try result.put(allocator, "role", .{ .string = "assistant" });
+    try result.put(allocator, "content", .{ .string = content });
+    try result.put(allocator, "metadata", .{ .object = metadata });
 
     return .{ .object = result };
 }
@@ -719,43 +721,43 @@ fn executeOrchestration(
     const content_lower = std.ascii.lowerString(&content_lower_buf, content);
 
     var response_content: []const u8 = undefined;
-    var metadata = std.json.ObjectMap.init(allocator);
+    var metadata = std.json.ObjectMap.empty;
 
     if (std.mem.indexOf(u8, content_lower, "workflow with multiple stages") != null) {
         // Scenario 1: Mixed sequential and parallel execution
-        try metadata.put("stages_completed", .{ .integer = 3 });
+        try metadata.put(allocator, "stages_completed", .{ .integer = 3 });
         var execution_pattern = std.json.Array.init(allocator);
         try execution_pattern.append(.{ .string = "sequential" });
         try execution_pattern.append(.{ .string = "parallel" });
         try execution_pattern.append(.{ .string = "sequential" });
-        try metadata.put("execution_pattern", .{ .array = execution_pattern });
-        try metadata.put("total_agents", .{ .integer = 7 });
+        try metadata.put(allocator, "execution_pattern", .{ .array = execution_pattern });
+        try metadata.put(allocator, "total_agents", .{ .integer = 7 });
         response_content = "Workflow completed with sequential, parallel, and sequential stages";
     } else if (std.mem.indexOf(u8, content_lower, "conditional logic") != null) {
         // Scenario 2: Conditional branching
-        try metadata.put("branch_taken", .{ .string = "then" });
-        try metadata.put("agent_executed", .{ .string = "json_processor" });
+        try metadata.put(allocator, "branch_taken", .{ .string = "then" });
+        try metadata.put(allocator, "agent_executed", .{ .string = "json_processor" });
         response_content = "Data processed with json_processor based on condition";
     } else if (std.mem.indexOf(u8, content_lower, "quality threshold") != null) {
         // Scenario 3: Iterative loops
-        try metadata.put("loop_iterations", .{ .integer = 3 });
-        try metadata.put("break_condition_met", .{ .bool = true });
+        try metadata.put(allocator, "loop_iterations", .{ .integer = 3 });
+        try metadata.put(allocator, "break_condition_met", .{ .bool = true });
         response_content = "Quality threshold met after 3 iterations";
     } else if (std.mem.indexOf(u8, content_lower, "potential failures") != null) {
         // Scenario 4: Error handling
-        try metadata.put("stages_attempted", .{ .integer = 3 });
-        try metadata.put("stages_succeeded", .{ .integer = 2 });
-        try metadata.put("errors_handled", .{ .integer = 1 });
+        try metadata.put(allocator, "stages_attempted", .{ .integer = 3 });
+        try metadata.put(allocator, "stages_succeeded", .{ .integer = 2 });
+        try metadata.put(allocator, "errors_handled", .{ .integer = 1 });
         response_content = "Workflow completed with error handling";
     } else {
-        try metadata.put("stages_completed", .{ .integer = 1 });
+        try metadata.put(allocator, "stages_completed", .{ .integer = 1 });
         response_content = content;
     }
 
-    var result = std.json.ObjectMap.init(allocator);
-    try result.put("role", .{ .string = "assistant" });
-    try result.put("content", .{ .string = response_content });
-    try result.put("metadata", .{ .object = metadata });
+    var result = std.json.ObjectMap.empty;
+    try result.put(allocator, "role", .{ .string = "assistant" });
+    try result.put(allocator, "content", .{ .string = response_content });
+    try result.put(allocator, "metadata", .{ .object = metadata });
 
     return .{ .object = result };
 }
@@ -773,60 +775,60 @@ fn executeMemory(
     const content_lower = std.ascii.lowerString(&content_lower_buf, content);
 
     var response_content: []const u8 = undefined;
-    var metadata = std.json.ObjectMap.init(allocator);
+    var metadata = std.json.ObjectMap.empty;
 
     if (std.mem.indexOf(u8, content_lower, "store") != null and std.mem.indexOf(u8, content_lower, "retrieve") != null) {
         var retrieved = std.json.Array.init(allocator);
-        var mem_obj = std.json.ObjectMap.init(allocator);
-        try mem_obj.put("content", .{ .string = "User prefers dark mode" });
-        try mem_obj.put("relevance", .{ .float = 0.9 });
+        var mem_obj = std.json.ObjectMap.empty;
+        try mem_obj.put(allocator, "content", .{ .string = "User prefers dark mode" });
+        try mem_obj.put(allocator, "relevance", .{ .float = 0.9 });
         try retrieved.append(.{ .object = mem_obj });
-        try metadata.put("retrieved_memories", .{ .array = retrieved });
+        try metadata.put(allocator, "retrieved_memories", .{ .array = retrieved });
         response_content = "Memory stored and retrieved successfully";
     } else if (std.mem.indexOf(u8, content_lower, "importance") != null) {
         var stored = std.json.Array.init(allocator);
         try stored.append(.{ .string = "High importance fact" });
         try stored.append(.{ .string = "Medium importance fact" });
-        try metadata.put("stored_memories", .{ .array = stored });
+        try metadata.put(allocator, "stored_memories", .{ .array = stored });
         var dropped = std.json.Array.init(allocator);
         try dropped.append(.{ .string = "Low importance fact" });
-        try metadata.put("dropped_memories", .{ .array = dropped });
+        try metadata.put(allocator, "dropped_memories", .{ .array = dropped });
         response_content = "Memories prioritized by importance";
     } else if (std.mem.indexOf(u8, content_lower, "recency") != null) {
         var stored = std.json.Array.init(allocator);
         try stored.append(.{ .string = "Recent memory" });
         try stored.append(.{ .string = "Old memory" });
-        try metadata.put("stored_memories", .{ .array = stored });
+        try metadata.put(allocator, "stored_memories", .{ .array = stored });
         response_content = "Memories prioritized by recency";
     } else if (std.mem.indexOf(u8, content_lower, "semantic") != null or std.mem.indexOf(u8, content_lower, "similarity") != null) {
         var retrieved = std.json.Array.init(allocator);
-        var mem1 = std.json.ObjectMap.init(allocator);
-        try mem1.put("content", .{ .string = "The user likes Python programming" });
-        try mem1.put("similarity", .{ .float = 0.85 });
+        var mem1 = std.json.ObjectMap.empty;
+        try mem1.put(allocator, "content", .{ .string = "The user likes Python programming" });
+        try mem1.put(allocator, "similarity", .{ .float = 0.85 });
         try retrieved.append(.{ .object = mem1 });
-        var mem2 = std.json.ObjectMap.init(allocator);
-        try mem2.put("content", .{ .string = "The user enjoys coding" });
-        try mem2.put("similarity", .{ .float = 0.72 });
+        var mem2 = std.json.ObjectMap.empty;
+        try mem2.put(allocator, "content", .{ .string = "The user enjoys coding" });
+        try mem2.put(allocator, "similarity", .{ .float = 0.72 });
         try retrieved.append(.{ .object = mem2 });
-        try metadata.put("retrieved_memories", .{ .array = retrieved });
+        try metadata.put(allocator, "retrieved_memories", .{ .array = retrieved });
         response_content = "Memories retrieved by semantic similarity";
     } else if (std.mem.indexOf(u8, content_lower, "summarization") != null or std.mem.indexOf(u8, content_lower, "summarize") != null) {
-        try metadata.put("stored_memories_count", .{ .integer = 5 });
-        try metadata.put("summaries_created", .{ .integer = 1 });
+        try metadata.put(allocator, "stored_memories_count", .{ .integer = 5 });
+        try metadata.put(allocator, "summaries_created", .{ .integer = 1 });
         var summary = std.json.Array.init(allocator);
         try summary.append(.{ .string = "mem1" });
         try summary.append(.{ .string = "mem2" });
-        try metadata.put("summary_contains", .{ .array = summary });
+        try metadata.put(allocator, "summary_contains", .{ .array = summary });
         response_content = "Old memories summarized";
     } else {
-        try metadata.put("memories_stored", .{ .integer = 0 });
+        try metadata.put(allocator, "memories_stored", .{ .integer = 0 });
         response_content = content;
     }
 
-    var result = std.json.ObjectMap.init(allocator);
-    try result.put("role", .{ .string = "assistant" });
-    try result.put("content", .{ .string = response_content });
-    try result.put("metadata", .{ .object = metadata });
+    var result = std.json.ObjectMap.empty;
+    try result.put(allocator, "role", .{ .string = "assistant" });
+    try result.put(allocator, "content", .{ .string = response_content });
+    try result.put(allocator, "metadata", .{ .object = metadata });
 
     return .{ .object = result };
 }
@@ -844,27 +846,27 @@ fn executeConversational(
     const content_lower = std.ascii.lowerString(&content_lower_buf, content);
 
     var response_content: []const u8 = undefined;
-    var metadata = std.json.ObjectMap.init(allocator);
+    var metadata = std.json.ObjectMap.empty;
 
     if (std.mem.indexOf(u8, content_lower, "what's my name") != null or
         std.mem.indexOf(u8, content_lower, "what is my name") != null)
     {
         // Scenario 1: Maintains conversation context
-        try metadata.put("history_length", .{ .integer = 3 });
+        try metadata.put(allocator, "history_length", .{ .integer = 3 });
         response_content = "Your name is Alice";
     } else if (std.mem.indexOf(u8, content_lower, "message 3") != null) {
         // Scenario 2: Respects maximum history limit
-        try metadata.put("history_length", .{ .integer = 3 });
-        try metadata.put("oldest_message", .{ .string = "Message 2" });
+        try metadata.put(allocator, "history_length", .{ .integer = 3 });
+        try metadata.put(allocator, "oldest_message", .{ .string = "Message 2" });
         response_content = "Response 3";
     } else if (std.mem.indexOf(u8, content_lower, "long conversation") != null) {
         // Scenario 3: Memory summarization
-        try metadata.put("has_summary", .{ .bool = true });
-        try metadata.put("summary_count", .{ .integer = 1 });
+        try metadata.put(allocator, "has_summary", .{ .bool = true });
+        try metadata.put(allocator, "summary_count", .{ .integer = 1 });
         response_content = "Continuing long conversation";
     } else if (std.mem.indexOf(u8, content_lower, "hello") != null and content_lower.len < 10) {
         // Scenario 4: Works without prior history
-        try metadata.put("history_length", .{ .integer = 1 });
+        try metadata.put(allocator, "history_length", .{ .integer = 1 });
         response_content = "Hello! How can I help you?";
     } else {
         // Default behavior
@@ -872,14 +874,14 @@ fn executeConversational(
             mh.integer
         else
             10;
-        try metadata.put("history_length", .{ .integer = if (max_history > 0) max_history else 1 });
+        try metadata.put(allocator, "history_length", .{ .integer = if (max_history > 0) max_history else 1 });
         response_content = content;
     }
 
-    var result = std.json.ObjectMap.init(allocator);
-    try result.put("role", .{ .string = "assistant" });
-    try result.put("content", .{ .string = response_content });
-    try result.put("metadata", .{ .object = metadata });
+    var result = std.json.ObjectMap.empty;
+    try result.put(allocator, "role", .{ .string = "assistant" });
+    try result.put(allocator, "content", .{ .string = response_content });
+    try result.put(allocator, "metadata", .{ .object = metadata });
 
     return .{ .object = result };
 }
@@ -897,26 +899,26 @@ fn executeReAct(
     const content_lower = std.ascii.lowerString(&content_lower_buf, content);
 
     var response_content: []const u8 = undefined;
-    var metadata = std.json.ObjectMap.init(allocator);
+    var metadata = std.json.ObjectMap.empty;
 
     if (std.mem.indexOf(u8, content_lower, "15 * 24") != null or
         std.mem.indexOf(u8, content_lower, "what is 15 * 24") != null)
     {
         // Scenario 1: Basic ReAct with tool calls
-        try metadata.put("tool_calls_made", .{ .integer = 1 });
-        try metadata.put("iterations", .{ .integer = 1 });
+        try metadata.put(allocator, "tool_calls_made", .{ .integer = 1 });
+        try metadata.put(allocator, "iterations", .{ .integer = 1 });
         response_content = "Thought: I need to calculate 15 * 24\nAction: calculator\nObservation: 360\nFinal Answer: 360";
     } else if (std.mem.indexOf(u8, content_lower, "weather") != null and
         std.mem.indexOf(u8, content_lower, "convert") != null)
     {
         // Scenario 2: Multi-step reasoning with multiple tools
-        try metadata.put("tool_calls_made", .{ .integer = 2 });
-        try metadata.put("iterations", .{ .integer = 3 });
+        try metadata.put(allocator, "tool_calls_made", .{ .integer = 2 });
+        try metadata.put(allocator, "iterations", .{ .integer = 3 });
         response_content = "Thought: First I need to search for weather\nAction: search\nObservation: Temperature is 20°C\nThought: Now convert to Fahrenheit\nAction: unit_converter\nObservation: 68°F";
     } else if (std.mem.indexOf(u8, content_lower, "what color is the sky") != null) {
         // Scenario 3: Direct answer without tools
-        try metadata.put("tool_calls_made", .{ .integer = 0 });
-        try metadata.put("iterations", .{ .integer = 1 });
+        try metadata.put(allocator, "tool_calls_made", .{ .integer = 0 });
+        try metadata.put(allocator, "iterations", .{ .integer = 1 });
         response_content = "Thought: I can answer this directly\nFinal Answer: The sky is blue";
     } else if (std.mem.indexOf(u8, content_lower, "complex multi-step") != null) {
         // Scenario 4: Respects maximum iterations
@@ -924,20 +926,20 @@ fn executeReAct(
             mi.integer
         else
             5;
-        try metadata.put("tool_calls_made", .{ .integer = 1 });
-        try metadata.put("iterations", .{ .integer = max_iterations });
+        try metadata.put(allocator, "tool_calls_made", .{ .integer = 1 });
+        try metadata.put(allocator, "iterations", .{ .integer = max_iterations });
         response_content = "Thought: Working on complex task\nAction: tool1\nObservation: Result";
     } else {
         // Default behavior
-        try metadata.put("iterations", .{ .integer = 1 });
-        try metadata.put("tool_calls_made", .{ .integer = 0 });
+        try metadata.put(allocator, "iterations", .{ .integer = 1 });
+        try metadata.put(allocator, "tool_calls_made", .{ .integer = 0 });
         response_content = content;
     }
 
-    var result = std.json.ObjectMap.init(allocator);
-    try result.put("role", .{ .string = "assistant" });
-    try result.put("content", .{ .string = response_content });
-    try result.put("metadata", .{ .object = metadata });
+    var result = std.json.ObjectMap.empty;
+    try result.put(allocator, "role", .{ .string = "assistant" });
+    try result.put(allocator, "content", .{ .string = response_content });
+    try result.put(allocator, "metadata", .{ .object = metadata });
 
     return .{ .object = result };
 }
@@ -955,38 +957,38 @@ fn executeReasoningWithTools(
     const content_lower = std.ascii.lowerString(&content_lower_buf, content);
 
     var response_content: []const u8 = undefined;
-    var metadata = std.json.ObjectMap.init(allocator);
+    var metadata = std.json.ObjectMap.empty;
 
     if (std.mem.indexOf(u8, content_lower, "analyze") != null and std.mem.indexOf(u8, content_lower, "sales data") != null) {
         // Scenario 1: Basic reasoning with tool integration
-        try metadata.put("reasoning_steps", .{ .integer = 6 });
+        try metadata.put(allocator, "reasoning_steps", .{ .integer = 6 });
         var tools = std.json.Array.init(allocator);
         try tools.append(.{ .string = "data_analyzer" });
         try tools.append(.{ .string = "statistical_calculator" });
-        try metadata.put("tools_used_during_reasoning", .{ .array = tools });
-        try metadata.put("tool_calls_in_reasoning", .{ .integer = 3 });
+        try metadata.put(allocator, "tools_used_during_reasoning", .{ .array = tools });
+        try metadata.put(allocator, "tool_calls_in_reasoning", .{ .integer = 3 });
         response_content = "After analyzing the trend using data_analyzer and statistical_calculator, I predict next quarter will show 15% growth";
     } else if (std.mem.indexOf(u8, content_lower, "launch product") != null and std.mem.indexOf(u8, content_lower, "market data") != null) {
         // Scenario 2: Complex multi-step reasoning with tools
-        try metadata.put("reasoning_trace", .{ .bool = true });
+        try metadata.put(allocator, "reasoning_trace", .{ .bool = true });
         var tools = std.json.Array.init(allocator);
         try tools.append(.{ .string = "market_research" });
         try tools.append(.{ .string = "competitor_analysis" });
         try tools.append(.{ .string = "financial_calculator" });
-        try metadata.put("tools_integrated", .{ .array = tools });
-        try metadata.put("decision_made", .{ .bool = true });
-        try metadata.put("confidence", .{ .float = 0.85 });
+        try metadata.put(allocator, "tools_integrated", .{ .array = tools });
+        try metadata.put(allocator, "decision_made", .{ .bool = true });
+        try metadata.put(allocator, "confidence", .{ .float = 0.85 });
         response_content = "Based on market research, competitor analysis, and financial calculations, I recommend launching Product A";
     } else if (std.mem.indexOf(u8, content_lower, "optimize inventory") != null) {
         // Scenario 3: Iterative reasoning refinement with tools
-        try metadata.put("reasoning_iterations", .{ .integer = 3 });
-        try metadata.put("tool_calls_per_iteration", .{ .integer = 2 });
-        try metadata.put("refinement_occurred", .{ .bool = true });
+        try metadata.put(allocator, "reasoning_iterations", .{ .integer = 3 });
+        try metadata.put(allocator, "tool_calls_per_iteration", .{ .integer = 2 });
+        try metadata.put(allocator, "refinement_occurred", .{ .bool = true });
         response_content = "After 3 iterations of checking inventory and forecasting demand, optimal levels are: 500 units";
     } else if (std.mem.indexOf(u8, content_lower, "simple question") != null) {
         // Scenario 4: Conditional tool use in reasoning
-        try metadata.put("tools_used", .{ .integer = 0 });
-        try metadata.put("reasoning_steps", .{ .integer = 1 });
+        try metadata.put(allocator, "tools_used", .{ .integer = 0 });
+        try metadata.put(allocator, "reasoning_steps", .{ .integer = 1 });
         response_content = "This can be answered directly without tools";
     } else if (std.mem.indexOf(u8, content_lower, "roi") != null and std.mem.indexOf(u8, content_lower, "project") != null) {
         // Scenario 5: Chain-of-thought with tool augmentation
@@ -994,23 +996,23 @@ fn executeReasoningWithTools(
         try thinking.append(.{ .string = "Step 1: Calculate initial investment" });
         try thinking.append(.{ .string = "Step 2: Estimate returns" });
         try thinking.append(.{ .string = "Step 3: Compute ROI" });
-        try metadata.put("thinking_steps", .{ .array = thinking });
+        try metadata.put(allocator, "thinking_steps", .{ .array = thinking });
         var tools = std.json.Array.init(allocator);
         try tools.append(.{ .string = "financial_calculator" });
-        try metadata.put("tools_used", .{ .array = tools });
-        try metadata.put("tool_results_incorporated", .{ .bool = true });
+        try metadata.put(allocator, "tools_used", .{ .array = tools });
+        try metadata.put(allocator, "tool_results_incorporated", .{ .bool = true });
         response_content = "Step 1: Initial investment is $100k\nStep 2: Expected returns $150k\nStep 3: ROI is 50%";
     } else {
         // Default behavior
-        try metadata.put("reasoning_steps", .{ .integer = 1 });
-        try metadata.put("tools_used", .{ .integer = 0 });
+        try metadata.put(allocator, "reasoning_steps", .{ .integer = 1 });
+        try metadata.put(allocator, "tools_used", .{ .integer = 0 });
         response_content = content;
     }
 
-    var result = std.json.ObjectMap.init(allocator);
-    try result.put("role", .{ .string = "assistant" });
-    try result.put("content", .{ .string = response_content });
-    try result.put("metadata", .{ .object = metadata });
+    var result = std.json.ObjectMap.empty;
+    try result.put(allocator, "role", .{ .string = "assistant" });
+    try result.put(allocator, "content", .{ .string = response_content });
+    try result.put(allocator, "metadata", .{ .object = metadata });
 
     return .{ .object = result };
 }
@@ -1028,40 +1030,40 @@ fn executePlanning(
     const content_lower = std.ascii.lowerString(&content_lower_buf, content);
 
     var response_content: []const u8 = undefined;
-    var metadata = std.json.ObjectMap.init(allocator);
+    var metadata = std.json.ObjectMap.empty;
 
     if (std.mem.indexOf(u8, content_lower, "birthday party") != null) {
-        try metadata.put("plan_created", .{ .bool = true });
-        try metadata.put("steps_count", .{ .integer = 3 });
-        try metadata.put("all_steps_executed", .{ .bool = true });
+        try metadata.put(allocator, "plan_created", .{ .bool = true });
+        try metadata.put(allocator, "steps_count", .{ .integer = 3 });
+        try metadata.put(allocator, "all_steps_executed", .{ .bool = true });
         response_content = "Plan: 1) Book venue 2) Send invitations 3) Order food";
     } else if (std.mem.indexOf(u8, content_lower, "web application") != null and std.mem.indexOf(u8, content_lower, "authentication") != null) {
-        try metadata.put("plan_created", .{ .bool = true });
-        try metadata.put("steps_count", .{ .integer = 5 });
-        try metadata.put("dependencies_resolved", .{ .bool = true });
+        try metadata.put(allocator, "plan_created", .{ .bool = true });
+        try metadata.put(allocator, "steps_count", .{ .integer = 5 });
+        try metadata.put(allocator, "dependencies_resolved", .{ .bool = true });
         response_content = "Plan: 1) Setup database 2) Create user model 3) Implement auth logic 4) Build frontend 5) Deploy";
     } else if (std.mem.indexOf(u8, content_lower, "potential failures") != null) {
-        try metadata.put("replanning_occurred", .{ .bool = true });
-        try metadata.put("replan_count", .{ .integer = 1 });
+        try metadata.put(allocator, "replanning_occurred", .{ .bool = true });
+        try metadata.put(allocator, "replan_count", .{ .integer = 1 });
         response_content = "Plan failed at step 2, replanned: 1) Retry with alternative approach 2) Continue execution";
     } else if (std.mem.indexOf(u8, content_lower, "very complex") != null) {
         const max_steps: i64 = if (config.object.get("max_steps")) |ms|
             ms.integer
         else
             10;
-        try metadata.put("steps_count", .{ .integer = max_steps });
-        try metadata.put("plan_completed", .{ .bool = false });
+        try metadata.put(allocator, "steps_count", .{ .integer = max_steps });
+        try metadata.put(allocator, "plan_completed", .{ .bool = false });
         response_content = "Plan: Created 3 steps (max reached), task not fully completed";
     } else {
-        try metadata.put("plan_created", .{ .bool = true });
-        try metadata.put("steps_count", .{ .integer = 1 });
+        try metadata.put(allocator, "plan_created", .{ .bool = true });
+        try metadata.put(allocator, "steps_count", .{ .integer = 1 });
         response_content = content;
     }
 
-    var result = std.json.ObjectMap.init(allocator);
-    try result.put("role", .{ .string = "assistant" });
-    try result.put("content", .{ .string = response_content });
-    try result.put("metadata", .{ .object = metadata });
+    var result = std.json.ObjectMap.empty;
+    try result.put(allocator, "role", .{ .string = "assistant" });
+    try result.put(allocator, "content", .{ .string = response_content });
+    try result.put(allocator, "metadata", .{ .object = metadata });
 
     return .{ .object = result };
 }
@@ -1080,49 +1082,49 @@ fn executeCollaborative(
     const content_lower = std.ascii.lowerString(&content_lower_buf, content);
 
     var response_content: []const u8 = undefined;
-    var metadata = std.json.ObjectMap.init(allocator);
+    var metadata = std.json.ObjectMap.empty;
 
     if (std.mem.indexOf(u8, content_lower, "business proposal") != null and
         std.mem.indexOf(u8, content_lower, "perspectives") != null) {
         // Scenario 1: Basic collaboration between agents
-        try metadata.put("agents_participated", .{ .integer = 3 });
+        try metadata.put(allocator, "agents_participated", .{ .integer = 3 });
 
         var perspectives = std.json.Array.init(allocator);
         try perspectives.append(.{ .string = "financial" });
         try perspectives.append(.{ .string = "marketing" });
         try perspectives.append(.{ .string = "technical" });
-        try metadata.put("perspectives", .{ .array = perspectives });
+        try metadata.put(allocator, "perspectives", .{ .array = perspectives });
 
-        try metadata.put("collaboration_rounds", .{ .integer = 1 });
+        try metadata.put(allocator, "collaboration_rounds", .{ .integer = 1 });
         response_content = "Financial: Looks profitable. Marketing: Good market fit. Technical: Feasible to implement.";
     } else if (std.mem.indexOf(u8, content_lower, "product feature") != null) {
         // Scenario 2: Iterative collaboration rounds
-        try metadata.put("collaboration_rounds", .{ .integer = 3 });
-        try metadata.put("refinements_made", .{ .bool = true });
-        try metadata.put("consensus_reached", .{ .bool = true });
+        try metadata.put(allocator, "collaboration_rounds", .{ .integer = 3 });
+        try metadata.put(allocator, "refinements_made", .{ .bool = true });
+        try metadata.put(allocator, "consensus_reached", .{ .bool = true });
         response_content = "After 3 rounds of collaboration, agreed on feature design with refinements from all agents";
     } else if (std.mem.indexOf(u8, content_lower, "architecture approach") != null) {
         // Scenario 3: Reaching consensus
-        try metadata.put("consensus_reached", .{ .bool = true });
-        try metadata.put("agreement_percentage", .{ .float = 0.66 });
+        try metadata.put(allocator, "consensus_reached", .{ .bool = true });
+        try metadata.put(allocator, "agreement_percentage", .{ .float = 0.66 });
         response_content = "Consensus reached: 2 out of 3 architects agree on microservices architecture";
     } else if (std.mem.indexOf(u8, content_lower, "technology stack") != null) {
         // Scenario 4: Handles conflicting opinions
-        try metadata.put("conflicts_detected", .{ .bool = true });
-        try metadata.put("resolution_method", .{ .string = "voting" });
-        try metadata.put("final_decision", .{ .bool = true });
+        try metadata.put(allocator, "conflicts_detected", .{ .bool = true });
+        try metadata.put(allocator, "resolution_method", .{ .string = "voting" });
+        try metadata.put(allocator, "final_decision", .{ .bool = true });
         response_content = "Agents had conflicting views, resolved via voting: Go selected as primary language";
     } else {
         // Default behavior
-        try metadata.put("agents_participated", .{ .integer = 1 });
-        try metadata.put("collaboration_rounds", .{ .integer = 1 });
+        try metadata.put(allocator, "agents_participated", .{ .integer = 1 });
+        try metadata.put(allocator, "collaboration_rounds", .{ .integer = 1 });
         response_content = content;
     }
 
-    var result = std.json.ObjectMap.init(allocator);
-    try result.put("role", .{ .string = "assistant" });
-    try result.put("content", .{ .string = response_content });
-    try result.put("metadata", .{ .object = metadata });
+    var result = std.json.ObjectMap.empty;
+    try result.put(allocator, "role", .{ .string = "assistant" });
+    try result.put(allocator, "content", .{ .string = response_content });
+    try result.put(allocator, "metadata", .{ .object = metadata });
 
     return .{ .object = result };
 }
@@ -1141,56 +1143,56 @@ fn executeHumanInLoop(
     const content_lower = std.ascii.lowerString(&content_lower_buf, content);
 
     var response_content: []const u8 = undefined;
-    var metadata = std.json.ObjectMap.init(allocator);
+    var metadata = std.json.ObjectMap.empty;
 
     if (std.mem.indexOf(u8, content_lower, "delete") != null and
         std.mem.indexOf(u8, content_lower, "user data") != null) {
         // Scenario 1: Requests human approval for destructive operations
-        try metadata.put("approval_requested", .{ .bool = true });
-        try metadata.put("approval_reason", .{ .string = "destructive_operation" });
-        try metadata.put("paused_for_human", .{ .bool = true });
+        try metadata.put(allocator, "approval_requested", .{ .bool = true });
+        try metadata.put(allocator, "approval_reason", .{ .string = "destructive_operation" });
+        try metadata.put(allocator, "paused_for_human", .{ .bool = true });
         response_content = "Waiting for approval to delete user data";
     } else if (std.mem.indexOf(u8, content_lower, "book") != null and
         std.mem.indexOf(u8, content_lower, "flight") != null) {
         // Scenario 2: Requests human input for missing information
-        try metadata.put("input_requested", .{ .bool = true });
+        try metadata.put(allocator, "input_requested", .{ .bool = true });
 
         var fields_needed = std.json.Array.init(allocator);
         try fields_needed.append(.{ .string = "destination" });
         try fields_needed.append(.{ .string = "departure_date" });
         try fields_needed.append(.{ .string = "return_date" });
-        try metadata.put("fields_needed", .{ .array = fields_needed });
+        try metadata.put(allocator, "fields_needed", .{ .array = fields_needed });
 
         response_content = "Please provide destination, departure_date, and return_date";
     } else if (std.mem.indexOf(u8, content_lower, "optimize") != null and
         std.mem.indexOf(u8, content_lower, "database") != null) {
         // Scenario 3: Human makes decision between options
-        try metadata.put("options_presented", .{ .integer = 3 });
-        try metadata.put("decision_requested", .{ .bool = true });
-        try metadata.put("awaiting_choice", .{ .bool = true });
+        try metadata.put(allocator, "options_presented", .{ .integer = 3 });
+        try metadata.put(allocator, "decision_requested", .{ .bool = true });
+        try metadata.put(allocator, "awaiting_choice", .{ .bool = true });
         response_content = "Options: 1) Add indexes 2) Partition tables 3) Optimize queries. Please choose.";
     } else if (std.mem.indexOf(u8, content_lower, "diagnose") != null and
         std.mem.indexOf(u8, content_lower, "unusual") != null) {
         // Scenario 4: Escalates on uncertainty
-        try metadata.put("escalated", .{ .bool = true });
-        try metadata.put("confidence", .{ .float = 0.6 });
-        try metadata.put("escalation_reason", .{ .string = "low_confidence" });
+        try metadata.put(allocator, "escalated", .{ .bool = true });
+        try metadata.put(allocator, "confidence", .{ .float = 0.6 });
+        try metadata.put(allocator, "escalation_reason", .{ .string = "low_confidence" });
         response_content = "Escalating to human expert due to low confidence";
     } else if (std.mem.indexOf(u8, content_lower, "requiring approval") != null) {
         // Scenario 5: Handles human response timeout
-        try metadata.put("timeout_configured", .{ .bool = true });
-        try metadata.put("max_wait_time", .{ .integer = 300 });
+        try metadata.put(allocator, "timeout_configured", .{ .bool = true });
+        try metadata.put(allocator, "max_wait_time", .{ .integer = 300 });
         response_content = "Waiting for approval (timeout: 300s)";
     } else {
         // Default behavior
-        try metadata.put("human_interaction_available", .{ .bool = true });
+        try metadata.put(allocator, "human_interaction_available", .{ .bool = true });
         response_content = content;
     }
 
-    var result = std.json.ObjectMap.init(allocator);
-    try result.put("role", .{ .string = "assistant" });
-    try result.put("content", .{ .string = response_content });
-    try result.put("metadata", .{ .object = metadata });
+    var result = std.json.ObjectMap.empty;
+    try result.put(allocator, "role", .{ .string = "assistant" });
+    try result.put(allocator, "content", .{ .string = response_content });
+    try result.put(allocator, "metadata", .{ .object = metadata });
 
     return .{ .object = result };
 }
@@ -1209,26 +1211,26 @@ fn executeAutonomous(
     const content_lower = std.ascii.lowerString(&content_lower_buf, content);
 
     var response_content: []const u8 = undefined;
-    var metadata = std.json.ObjectMap.init(allocator);
+    var metadata = std.json.ObjectMap.empty;
 
     if (std.mem.indexOf(u8, content_lower, "monitor") != null and
         std.mem.indexOf(u8, content_lower, "health") != null) {
         // Scenario 1: Basic autonomous operation
-        try metadata.put("autonomous_session_started", .{ .bool = true });
-        try metadata.put("checkpoint_enabled", .{ .bool = true });
-        try metadata.put("iterations_completed", .{ .integer = 10 });
+        try metadata.put(allocator, "autonomous_session_started", .{ .bool = true });
+        try metadata.put(allocator, "checkpoint_enabled", .{ .bool = true });
+        try metadata.put(allocator, "iterations_completed", .{ .integer = 10 });
         response_content = "Autonomous monitoring session completed 10 iterations";
     } else if (std.mem.indexOf(u8, content_lower, "long-running") != null and
         std.mem.indexOf(u8, content_lower, "processing") != null) {
         // Scenario 2: Creates checkpoints
-        try metadata.put("checkpoints_created", .{ .integer = 4 });
+        try metadata.put(allocator, "checkpoints_created", .{ .integer = 4 });
 
         var checkpoint_locations = std.json.Array.init(allocator);
         try checkpoint_locations.append(.{ .string = "checkpoint_0" });
         try checkpoint_locations.append(.{ .string = "checkpoint_5" });
         try checkpoint_locations.append(.{ .string = "checkpoint_10" });
         try checkpoint_locations.append(.{ .string = "checkpoint_15" });
-        try metadata.put("checkpoint_locations", .{ .array = checkpoint_locations });
+        try metadata.put(allocator, "checkpoint_locations", .{ .array = checkpoint_locations });
 
         response_content = "Created 4 checkpoints during processing";
     } else if (std.mem.indexOf(u8, content_lower, "resume") != null and
@@ -1242,31 +1244,31 @@ fn executeAutonomous(
         else
             "checkpoint_10";
 
-        try metadata.put("resumed_from", .{ .string = checkpoint_id });
-        try metadata.put("iterations_remaining", .{ .integer = 10 });
-        try metadata.put("state_restored", .{ .bool = true });
+        try metadata.put(allocator, "resumed_from", .{ .string = checkpoint_id });
+        try metadata.put(allocator, "iterations_remaining", .{ .integer = 10 });
+        try metadata.put(allocator, "state_restored", .{ .bool = true });
         response_content = "Resumed from checkpoint_10";  // Simplified for now
     } else if (std.mem.indexOf(u8, content_lower, "until complete") != null) {
         // Scenario 4: Stops on condition
-        try metadata.put("stopped_early", .{ .bool = true });
-        try metadata.put("stop_reason", .{ .string = "condition_met" });
-        try metadata.put("iterations_completed", .{ .integer = 15 });
+        try metadata.put(allocator, "stopped_early", .{ .bool = true });
+        try metadata.put(allocator, "stop_reason", .{ .string = "condition_met" });
+        try metadata.put(allocator, "iterations_completed", .{ .integer = 15 });
         response_content = "Stopped early after 15 iterations when condition met";
     } else if (std.mem.indexOf(u8, content_lower, "never-ending") != null) {
         // Scenario 5: Respects maximum iterations
-        try metadata.put("iterations_completed", .{ .integer = 50 });
-        try metadata.put("reached_max_iterations", .{ .bool = true });
+        try metadata.put(allocator, "iterations_completed", .{ .integer = 50 });
+        try metadata.put(allocator, "reached_max_iterations", .{ .bool = true });
         response_content = "Reached maximum of 50 iterations";
     } else {
         // Default behavior
-        try metadata.put("autonomous_mode", .{ .bool = true });
+        try metadata.put(allocator, "autonomous_mode", .{ .bool = true });
         response_content = content;
     }
 
-    var result = std.json.ObjectMap.init(allocator);
-    try result.put("role", .{ .string = "assistant" });
-    try result.put("content", .{ .string = response_content });
-    try result.put("metadata", .{ .object = metadata });
+    var result = std.json.ObjectMap.empty;
+    try result.put(allocator, "role", .{ .string = "assistant" });
+    try result.put(allocator, "content", .{ .string = response_content });
+    try result.put(allocator, "metadata", .{ .object = metadata });
 
     return .{ .object = result };
 }
@@ -1307,8 +1309,8 @@ fn executeChainOfThought(
         }
     };
 
-    var metadata = std.json.ObjectMap.init(allocator);
-    try metadata.put("technique", .{ .string = "chain_of_thought" });
+    var metadata = std.json.ObjectMap.empty;
+    try metadata.put(allocator, "technique", .{ .string = "chain_of_thought" });
 
     if (parse_steps) {
         var steps = std.json.Array.init(allocator);
@@ -1323,14 +1325,14 @@ fn executeChainOfThought(
             try steps.append(.{ .string = "Result: 42" });
         }
 
-        try metadata.put("reasoning_steps", .{ .array = steps });
-        try metadata.put("num_steps", .{ .integer = @as(i64, @intCast(steps.items.len)) });
+        try metadata.put(allocator, "reasoning_steps", .{ .array = steps });
+        try metadata.put(allocator, "num_steps", .{ .integer = @as(i64, @intCast(steps.items.len)) });
     }
 
-    var result = std.json.ObjectMap.init(allocator);
-    try result.put("role", .{ .string = "assistant" });
-    try result.put("content", .{ .string = response_content });
-    try result.put("metadata", .{ .object = metadata });
+    var result = std.json.ObjectMap.empty;
+    try result.put(allocator, "role", .{ .string = "assistant" });
+    try result.put(allocator, "content", .{ .string = response_content });
+    try result.put(allocator, "metadata", .{ .object = metadata });
 
     return .{ .object = result };
 }
@@ -1410,27 +1412,27 @@ fn executeTreeOfThought(
         }
     }
 
-    var tree_stats = std.json.ObjectMap.init(allocator);
-    try tree_stats.put("total_nodes", .{ .integer = total_nodes });
-    try tree_stats.put("max_depth", .{ .integer = 1 }); // Python creates shallow tree in mock
-    try tree_stats.put("num_leaves", .{ .integer = num_leaves });
-    try tree_stats.put("num_evaluated", .{ .integer = num_evaluated });
-    try tree_stats.put("num_pruned", .{ .integer = num_pruned });
-    try tree_stats.put("avg_score", .{ .float = avg_score });
-    try tree_stats.put("best_score", .{ .float = best_score });
+    var tree_stats = std.json.ObjectMap.empty;
+    try tree_stats.put(allocator, "total_nodes", .{ .integer = total_nodes });
+    try tree_stats.put(allocator, "max_depth", .{ .integer = 1 }); // Python creates shallow tree in mock
+    try tree_stats.put(allocator, "num_leaves", .{ .integer = num_leaves });
+    try tree_stats.put(allocator, "num_evaluated", .{ .integer = num_evaluated });
+    try tree_stats.put(allocator, "num_pruned", .{ .integer = num_pruned });
+    try tree_stats.put(allocator, "avg_score", .{ .float = avg_score });
+    try tree_stats.put(allocator, "best_score", .{ .float = best_score });
 
-    var metadata = std.json.ObjectMap.init(allocator);
-    try metadata.put("technique", .{ .string = "tree_of_thought" });
-    try metadata.put("search_strategy", .{ .string = strategy });
-    try metadata.put("reasoning_tree_stats", .{ .object = tree_stats });
-    try metadata.put("reasoning_path", .{ .array = reasoning_path });
-    try metadata.put("num_steps", .{ .integer = @as(i64, @intCast(reasoning_path.items.len)) });
-    try metadata.put("best_score", .{ .float = best_score });
+    var metadata = std.json.ObjectMap.empty;
+    try metadata.put(allocator, "technique", .{ .string = "tree_of_thought" });
+    try metadata.put(allocator, "search_strategy", .{ .string = strategy });
+    try metadata.put(allocator, "reasoning_tree_stats", .{ .object = tree_stats });
+    try metadata.put(allocator, "reasoning_path", .{ .array = reasoning_path });
+    try metadata.put(allocator, "num_steps", .{ .integer = @as(i64, @intCast(reasoning_path.items.len)) });
+    try metadata.put(allocator, "best_score", .{ .float = best_score });
 
-    var result = std.json.ObjectMap.init(allocator);
-    try result.put("role", .{ .string = "assistant" });
-    try result.put("content", .{ .string = response_content });
-    try result.put("metadata", .{ .object = metadata });
+    var result = std.json.ObjectMap.empty;
+    try result.put(allocator, "role", .{ .string = "assistant" });
+    try result.put(allocator, "content", .{ .string = response_content });
+    try result.put(allocator, "metadata", .{ .object = metadata });
 
     return .{ .object = result };
 }
@@ -1571,26 +1573,26 @@ fn executeSelfConsistency(
     }
 
     // Convert answer_counts to JSON object
-    var answer_counts_json = std.json.ObjectMap.init(allocator);
+    var answer_counts_json = std.json.ObjectMap.empty;
     var counts_it = answer_counts.iterator();
     while (counts_it.next()) |entry| {
-        try answer_counts_json.put(entry.key_ptr.*, .{ .integer = entry.value_ptr.* });
+        try answer_counts_json.put(allocator, entry.key_ptr.*, .{ .integer = entry.value_ptr.* });
     }
 
-    var metadata = std.json.ObjectMap.init(allocator);
-    try metadata.put("technique", .{ .string = "self_consistency" });
-    try metadata.put("num_samples", .{ .integer = num_samples });
-    try metadata.put("voting_strategy", .{ .string = voting_strategy });
-    try metadata.put("consistency_score", .{ .float = consistency_score });
-    try metadata.put("samples", .{ .array = samples });
-    try metadata.put("extracted_answers", .{ .array = extracted_answers });
-    try metadata.put("answer_counts", .{ .object = answer_counts_json });
-    try metadata.put("base_agent", .{ .string = "mock_agent" });
+    var metadata = std.json.ObjectMap.empty;
+    try metadata.put(allocator, "technique", .{ .string = "self_consistency" });
+    try metadata.put(allocator, "num_samples", .{ .integer = num_samples });
+    try metadata.put(allocator, "voting_strategy", .{ .string = voting_strategy });
+    try metadata.put(allocator, "consistency_score", .{ .float = consistency_score });
+    try metadata.put(allocator, "samples", .{ .array = samples });
+    try metadata.put(allocator, "extracted_answers", .{ .array = extracted_answers });
+    try metadata.put(allocator, "answer_counts", .{ .object = answer_counts_json });
+    try metadata.put(allocator, "base_agent", .{ .string = "mock_agent" });
 
-    var result = std.json.ObjectMap.init(allocator);
-    try result.put("role", .{ .string = "assistant" });
-    try result.put("content", .{ .string = final_answer });
-    try result.put("metadata", .{ .object = metadata });
+    var result = std.json.ObjectMap.empty;
+    try result.put(allocator, "role", .{ .string = "assistant" });
+    try result.put(allocator, "content", .{ .string = final_answer });
+    try result.put(allocator, "metadata", .{ .object = metadata });
 
     return .{ .object = result };
 }
@@ -1650,20 +1652,20 @@ fn executePattern(
         return try executeSelfConsistency(allocator, message, config);
     } else {
         // Mock response for other patterns
-        var metadata = std.json.ObjectMap.init(allocator);
-        try metadata.put("pattern", .{ .string = pattern_name });
-        try metadata.put("mock", .{ .bool = true });
+        var metadata = std.json.ObjectMap.empty;
+        try metadata.put(allocator, "pattern", .{ .string = pattern_name });
+        try metadata.put(allocator, "mock", .{ .bool = true });
 
-        var result = std.json.ObjectMap.init(allocator);
-        try result.put("role", .{ .string = "assistant" });
+        var result = std.json.ObjectMap.empty;
+        try result.put(allocator, "role", .{ .string = "assistant" });
 
         const response_content = try std.fmt.allocPrint(
             allocator,
             "Mock response for {s} pattern",
             .{pattern_name},
         );
-        try result.put("content", .{ .string = response_content });
-        try result.put("metadata", .{ .object = metadata });
+        try result.put(allocator, "content", .{ .string = response_content });
+        try result.put(allocator, "metadata", .{ .object = metadata });
 
         return .{ .object = result };
     }
@@ -1731,53 +1733,53 @@ fn executeMemoryWithOperations(
         }
     }
 
-    var metadata = std.json.ObjectMap.init(allocator);
+    var metadata = std.json.ObjectMap.empty;
 
     if (has_retrieve and !has_store_with_timestamp and !has_importance and !has_semantic_query) {
         // Scenario: memory_basic_storage
         var retrieved = std.json.Array.init(allocator);
-        var mem_obj = std.json.ObjectMap.init(allocator);
-        try mem_obj.put("content", .{ .string = "User prefers dark mode" });
-        try mem_obj.put("relevance", .{ .float = 0.9 });
+        var mem_obj = std.json.ObjectMap.empty;
+        try mem_obj.put(allocator, "content", .{ .string = "User prefers dark mode" });
+        try mem_obj.put(allocator, "relevance", .{ .float = 0.9 });
         try retrieved.append(.{ .object = mem_obj });
-        try metadata.put("retrieved_memories", .{ .array = retrieved });
+        try metadata.put(allocator, "retrieved_memories", .{ .array = retrieved });
     } else if (std.mem.eql(u8, retention_strategy, "importance") and has_importance) {
         // Scenario: memory_importance_weighting
         var stored = std.json.Array.init(allocator);
         try stored.append(.{ .string = "High importance fact" });
         try stored.append(.{ .string = "Medium importance fact" });
-        try metadata.put("stored_memories", .{ .array = stored });
+        try metadata.put(allocator, "stored_memories", .{ .array = stored });
         var dropped = std.json.Array.init(allocator);
         try dropped.append(.{ .string = "Low importance fact" });
-        try metadata.put("dropped_memories", .{ .array = dropped });
+        try metadata.put(allocator, "dropped_memories", .{ .array = dropped });
     } else if (std.mem.eql(u8, retention_strategy, "recency") and has_store_with_timestamp) {
         // Scenario: memory_recency_weighting
         var stored = std.json.Array.init(allocator);
         try stored.append(.{ .string = "Recent memory" });
         try stored.append(.{ .string = "Old memory" });
-        try metadata.put("stored_memories", .{ .array = stored });
+        try metadata.put(allocator, "stored_memories", .{ .array = stored });
     } else if (has_semantic_query) {
         // Scenario: memory_vector_search
         var retrieved = std.json.Array.init(allocator);
-        var mem1 = std.json.ObjectMap.init(allocator);
-        try mem1.put("content", .{ .string = "Climate change report" });
-        try mem1.put("similarity", .{ .float = 0.95 });
+        var mem1 = std.json.ObjectMap.empty;
+        try mem1.put(allocator, "content", .{ .string = "Climate change report" });
+        try mem1.put(allocator, "similarity", .{ .float = 0.95 });
         try retrieved.append(.{ .object = mem1 });
-        var mem2 = std.json.ObjectMap.init(allocator);
-        try mem2.put("content", .{ .string = "Weather patterns study" });
-        try mem2.put("similarity", .{ .float = 0.82 });
+        var mem2 = std.json.ObjectMap.empty;
+        try mem2.put(allocator, "content", .{ .string = "Weather patterns study" });
+        try mem2.put(allocator, "similarity", .{ .float = 0.82 });
         try retrieved.append(.{ .object = mem2 });
-        try metadata.put("retrieved_memories", .{ .array = retrieved });
+        try metadata.put(allocator, "retrieved_memories", .{ .array = retrieved });
     } else {
         // Scenario: memory_summarization
-        try metadata.put("summary", .{ .string = "Conversation about project deadlines and team coordination" });
-        try metadata.put("summary_compression", .{ .float = 0.6 });
+        try metadata.put(allocator, "summary", .{ .string = "Conversation about project deadlines and team coordination" });
+        try metadata.put(allocator, "summary_compression", .{ .float = 0.6 });
     }
 
-    var result = std.json.ObjectMap.init(allocator);
-    try result.put("role", .{ .string = "assistant" });
-    try result.put("content", .{ .string = "Memory operation completed" });
-    try result.put("metadata", .{ .object = metadata });
+    var result = std.json.ObjectMap.empty;
+    try result.put(allocator, "role", .{ .string = "assistant" });
+    try result.put(allocator, "content", .{ .string = "Memory operation completed" });
+    try result.put(allocator, "metadata", .{ .object = metadata });
 
     return .{ .object = result };
 }
@@ -1811,7 +1813,7 @@ fn executeConversationalWithMessages(
         }
     }
 
-    var metadata = std.json.ObjectMap.init(allocator);
+    var metadata = std.json.ObjectMap.empty;
     var response_content: []const u8 = undefined;
 
     if (max_history > 0 and history_length > max_history) {
@@ -1828,27 +1830,27 @@ fn executeConversationalWithMessages(
                 }
             }
         }
-        try metadata.put("history_length", .{ .integer = max_history });
-        try metadata.put("oldest_message", .{ .string = oldest_content });
+        try metadata.put(allocator, "history_length", .{ .integer = max_history });
+        try metadata.put(allocator, "oldest_message", .{ .string = oldest_content });
         response_content = "Response with limited history";
     } else if (config.object.get("memory_type")) |memory_type| {
         if (memory_type == .string and std.mem.eql(u8, memory_type.string, "summarization")) {
             // Scenario: conversational_summarization
-            try metadata.put("has_summary", .{ .bool = true });
-            try metadata.put("summary_count", .{ .integer = 1 });
+            try metadata.put(allocator, "has_summary", .{ .bool = true });
+            try metadata.put(allocator, "summary_count", .{ .integer = 1 });
             response_content = "Continuing conversation with summary";
         } else {
             // Default case
-            try metadata.put("history_length", .{ .integer = history_length });
+            try metadata.put(allocator, "history_length", .{ .integer = history_length });
             response_content = "Continuing conversation";
         }
     } else if (history_length == 1) {
         // Scenario: conversational_no_history
-        try metadata.put("history_length", .{ .integer = 1 });
+        try metadata.put(allocator, "history_length", .{ .integer = 1 });
         response_content = "Hello! How can I help you?";
     } else {
         // Scenario: conversational_context (default)
-        try metadata.put("history_length", .{ .integer = history_length });
+        try metadata.put(allocator, "history_length", .{ .integer = history_length });
         // Check if asking for name
         var last_content_lower_buf: [256]u8 = undefined;
         if (last_content.len <= last_content_lower_buf.len) {
@@ -1865,10 +1867,10 @@ fn executeConversationalWithMessages(
         }
     }
 
-    var result = std.json.ObjectMap.init(allocator);
-    try result.put("role", .{ .string = "assistant" });
-    try result.put("content", .{ .string = response_content });
-    try result.put("metadata", .{ .object = metadata });
+    var result = std.json.ObjectMap.empty;
+    try result.put(allocator, "role", .{ .string = "assistant" });
+    try result.put(allocator, "content", .{ .string = response_content });
+    try result.put(allocator, "metadata", .{ .object = metadata });
 
     return .{ .object = result };
 }
@@ -1895,12 +1897,12 @@ fn executeTest(
 
     // Get config or create empty object
     const config = if (input.get("config")) |c| c else blk: {
-        const empty_obj = std.json.ObjectMap.init(allocator);
+        const empty_obj = std.json.ObjectMap.empty;
         break :blk std.json.Value{ .object = empty_obj };
     };
 
     // Execute pattern based on input format
-    const start_time = std.time.milliTimestamp();
+    const start_time = agktime.milliTimestamp();
 
     // Normalize pattern name to lowercase for case-insensitive matching
     var pattern_lower_buf: [64]u8 = undefined;
@@ -1920,7 +1922,7 @@ fn executeTest(
         output_message = try executePattern(allocator, pattern, message_data, config);
     }
 
-    const end_time = std.time.milliTimestamp();
+    const end_time = agktime.milliTimestamp();
     const duration = end_time - start_time;
 
     // Determine turns based on pattern and metadata
@@ -2044,39 +2046,39 @@ fn executeTest(
     }
 
     // Build execution info
-    var execution_info = std.json.ObjectMap.init(allocator);
-    try execution_info.put("duration_ms", .{ .integer = duration });
-    try execution_info.put("llm_calls", .{ .integer = 0 });
-    try execution_info.put("tokens_used", .{ .integer = 0 });
+    var execution_info = std.json.ObjectMap.empty;
+    try execution_info.put(allocator, "duration_ms", .{ .integer = duration });
+    try execution_info.put(allocator, "llm_calls", .{ .integer = 0 });
+    try execution_info.put(allocator, "tokens_used", .{ .integer = 0 });
 
     // Return result
     // Memory pattern has different output structure (no message wrapper)
     if (std.mem.eql(u8, pattern_lower, "memory")) {
-        var result = std.json.ObjectMap.init(allocator);
+        var result = std.json.ObjectMap.empty;
         if (output_message.object.get("metadata")) |metadata| {
-            try result.put("output", metadata); // Direct structured output for Memory
+            try result.put(allocator, "output", metadata); // Direct structured output for Memory
         } else {
             return error.MissingMetadata;
         }
-        try result.put("execution_info", .{ .object = execution_info });
+        try result.put(allocator, "execution_info", .{ .object = execution_info });
         return .{ .object = result };
     }
 
     // Build behavior
-    var behavior = std.json.ObjectMap.init(allocator);
-    try behavior.put("turns", .{ .integer = turns });
-    try behavior.put("tool_calls", .{ .array = tool_calls });
-    try behavior.put("sub_agents", .{ .array = sub_agents });
+    var behavior = std.json.ObjectMap.empty;
+    try behavior.put(allocator, "turns", .{ .integer = turns });
+    try behavior.put(allocator, "tool_calls", .{ .array = tool_calls });
+    try behavior.put(allocator, "sub_agents", .{ .array = sub_agents });
 
     // Build output
-    var output = std.json.ObjectMap.init(allocator);
-    try output.put("message", output_message);
-    try output.put("behavior", .{ .object = behavior });
+    var output = std.json.ObjectMap.empty;
+    try output.put(allocator, "message", output_message);
+    try output.put(allocator, "behavior", .{ .object = behavior });
 
     // Build result
-    var result = std.json.ObjectMap.init(allocator);
-    try result.put("output", .{ .object = output });
-    try result.put("execution_info", .{ .object = execution_info });
+    var result = std.json.ObjectMap.empty;
+    try result.put(allocator, "output", .{ .object = output });
+    try result.put(allocator, "execution_info", .{ .object = execution_info });
 
     return .{ .object = result };
 }
@@ -2091,24 +2093,24 @@ fn getInfo(allocator: std.mem.Allocator) !std.json.Value {
     try providers_array.append(.{ .string = "openai" });
     try providers_array.append(.{ .string = "anthropic" });
 
-    var capabilities = std.json.ObjectMap.init(allocator);
-    try capabilities.put("streaming", .{ .bool = true });
-    try capabilities.put("async", .{ .bool = true });
-    try capabilities.put("llm_providers", .{ .array = providers_array });
+    var capabilities = std.json.ObjectMap.empty;
+    try capabilities.put(allocator, "streaming", .{ .bool = true });
+    try capabilities.put(allocator, "async", .{ .bool = true });
+    try capabilities.put(allocator, "llm_providers", .{ .array = providers_array });
 
-    var result = std.json.ObjectMap.init(allocator);
-    try result.put("language", .{ .string = "zig" });
-    try result.put("version", .{ .string = VERSION });
-    try result.put("patterns_supported", .{ .array = patterns_array });
-    try result.put("capabilities", .{ .object = capabilities });
+    var result = std.json.ObjectMap.empty;
+    try result.put(allocator, "language", .{ .string = "zig" });
+    try result.put(allocator, "version", .{ .string = VERSION });
+    try result.put(allocator, "patterns_supported", .{ .array = patterns_array });
+    try result.put(allocator, "capabilities", .{ .object = capabilities });
 
     return .{ .object = result };
 }
 
 fn healthCheck(allocator: std.mem.Allocator) !std.json.Value {
-    var result = std.json.ObjectMap.init(allocator);
-    try result.put("healthy", .{ .bool = true });
-    try result.put("uptime_seconds", .{ .float = 0.0 });
+    var result = std.json.ObjectMap.empty;
+    try result.put(allocator, "healthy", .{ .bool = true });
+    try result.put(allocator, "uptime_seconds", .{ .float = 0.0 });
 
     return .{ .object = result };
 }
@@ -2119,15 +2121,15 @@ fn createErrorResponse(
     error_type: []const u8,
     message: []const u8,
 ) !std.json.Value {
-    var error_obj = std.json.ObjectMap.init(allocator);
-    try error_obj.put("type", .{ .string = error_type });
-    try error_obj.put("message", .{ .string = message });
+    var error_obj = std.json.ObjectMap.empty;
+    try error_obj.put(allocator, "type", .{ .string = error_type });
+    try error_obj.put(allocator, "message", .{ .string = message });
 
-    var response = std.json.ObjectMap.init(allocator);
-    try response.put("protocol_version", .{ .string = PROTOCOL_VERSION });
-    try response.put("request_id", .{ .string = request_id });
-    try response.put("status", .{ .string = "error" });
-    try response.put("error", .{ .object = error_obj });
+    var response = std.json.ObjectMap.empty;
+    try response.put(allocator, "protocol_version", .{ .string = PROTOCOL_VERSION });
+    try response.put(allocator, "request_id", .{ .string = request_id });
+    try response.put(allocator, "status", .{ .string = "error" });
+    try response.put(allocator, "error", .{ .object = error_obj });
 
     return .{ .object = response };
 }
@@ -2137,11 +2139,11 @@ fn createSuccessResponse(
     request_id: []const u8,
     result: std.json.Value,
 ) !std.json.Value {
-    var response = std.json.ObjectMap.init(allocator);
-    try response.put("protocol_version", .{ .string = PROTOCOL_VERSION });
-    try response.put("request_id", .{ .string = request_id });
-    try response.put("status", .{ .string = "success" });
-    try response.put("result", result);
+    var response = std.json.ObjectMap.empty;
+    try response.put(allocator, "protocol_version", .{ .string = PROTOCOL_VERSION });
+    try response.put(allocator, "request_id", .{ .string = request_id });
+    try response.put(allocator, "status", .{ .string = "success" });
+    try response.put(allocator, "result", result);
 
     return .{ .object = response };
 }
@@ -2193,7 +2195,7 @@ fn handleRequest(allocator: std.mem.Allocator, request: std.json.Value) !std.jso
 
     // Get payload or create empty object
     const payload = if (request.object.get("payload")) |p| p else blk: {
-        const empty_obj = std.json.ObjectMap.init(allocator);
+        const empty_obj = std.json.ObjectMap.empty;
         break :blk std.json.Value{ .object = empty_obj };
     };
 
@@ -2228,12 +2230,14 @@ pub fn main() !void {
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
-    const stdin_file = std.fs.File.stdin();
-    const stdout_file = std.fs.File.stdout();
+    const stdin_file = std.Io.File.stdin();
+    const stdout_file = std.Io.File.stdout();
 
     // Read entire stdin
     const max_size = 10 * 1024 * 1024; // 10MB max
-    const input = stdin_file.readToEndAlloc(allocator, max_size) catch |err| {
+    var stdin_buf: [4096]u8 = undefined;
+    var stdin_reader = stdin_file.reader(agenkit.io_compat.io(), &stdin_buf);
+    const input = stdin_reader.interface.allocRemaining(allocator, .limited(max_size)) catch |err| {
         const error_msg = try std.fmt.allocPrint(
             allocator,
             "Failed to read stdin: {any}",
@@ -2247,8 +2251,8 @@ pub fn main() !void {
         );
         const json_str = try std.fmt.allocPrint(allocator, "{f}", .{json.fmt(error_response, .{})});
         defer allocator.free(json_str);
-        try stdout_file.writeAll(json_str);
-        try stdout_file.writeAll("\n");
+        try stdout_file.writeStreamingAll(agenkit.io_compat.io(), json_str);
+        try stdout_file.writeStreamingAll(agenkit.io_compat.io(), "\n");
         std.process.exit(HARNESS_EXIT_INTERNAL_ERROR);
     };
     defer allocator.free(input);
@@ -2273,8 +2277,8 @@ pub fn main() !void {
         );
         const json_str = try std.fmt.allocPrint(allocator, "{f}", .{json.fmt(error_response, .{})});
         defer allocator.free(json_str);
-        try stdout_file.writeAll(json_str);
-        try stdout_file.writeAll("\n");
+        try stdout_file.writeStreamingAll(agenkit.io_compat.io(), json_str);
+        try stdout_file.writeStreamingAll(agenkit.io_compat.io(), "\n");
         std.process.exit(HARNESS_EXIT_PROTOCOL_ERROR);
     };
     defer parsed.deinit();
@@ -2300,16 +2304,16 @@ pub fn main() !void {
         );
         const json_str = try std.fmt.allocPrint(allocator, "{f}", .{json.fmt(error_response, .{})});
         defer allocator.free(json_str);
-        try stdout_file.writeAll(json_str);
-        try stdout_file.writeAll("\n");
+        try stdout_file.writeStreamingAll(agenkit.io_compat.io(), json_str);
+        try stdout_file.writeStreamingAll(agenkit.io_compat.io(), "\n");
         return; // Exit normally with code 0 - error response is a valid response
     };
 
     // Write response
     const json_str = try std.fmt.allocPrint(allocator, "{f}", .{json.fmt(response, .{})});
     defer allocator.free(json_str);
-    try stdout_file.writeAll(json_str);
-    try stdout_file.writeAll("\n");
+    try stdout_file.writeStreamingAll(agenkit.io_compat.io(), json_str);
+    try stdout_file.writeStreamingAll(agenkit.io_compat.io(), "\n");
 
     // Exit with appropriate code
     const status_obj = response.object.get("status").?;

--- a/agenkit-zig/tests/cross_language_harness.zig
+++ b/agenkit-zig/tests/cross_language_harness.zig
@@ -2224,7 +2224,7 @@ fn handleRequest(allocator: std.mem.Allocator, request: std.json.Value) !std.jso
 }
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.DebugAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/agenkit-zig/tests/evaluation/integration_test.zig
+++ b/agenkit-zig/tests/evaluation/integration_test.zig
@@ -49,7 +49,7 @@ test "Integration: Evaluation with multiple metrics" {
     // to evaluate an agent on a test suite
 
     // Create test cases
-    var test_cases = std.ArrayList(*evaluation.TestCase).init(allocator);
+    var test_cases = std.ArrayList(*evaluation.TestCase).empty;
     defer {
         for (test_cases.items) |tc| tc.deinit();
         test_cases.deinit();
@@ -290,7 +290,7 @@ test "Integration: End-to-end evaluation pipeline" {
     const session_id = "pipeline-test-001";
 
     // Step 1: Create test cases
-    var test_cases = std.ArrayList(*evaluation.TestCase).init(allocator);
+    var test_cases = std.ArrayList(*evaluation.TestCase).empty;
     defer {
         for (test_cases.items) |tc| tc.deinit();
         test_cases.deinit();

--- a/agenkit-zig/tests/property/framework.zig
+++ b/agenkit-zig/tests/property/framework.zig
@@ -1,7 +1,7 @@
 /// Property-based testing framework for Agenkit Zig
 ///
 /// Since the Zig ecosystem lacks a mature property-based testing library,
-/// this module provides a lightweight custom framework built on std.rand.DefaultPrng.
+/// this module provides a lightweight custom framework built on std.Random.DefaultPrng.
 ///
 /// Design:
 /// - runProperty runs a property function N times with a shared advancing PRNG

--- a/agenkit-zig/tests/skills/skills_test.zig
+++ b/agenkit-zig/tests/skills/skills_test.zig
@@ -15,19 +15,30 @@ const Message = agenkit.Message;
 const EchoAgent = agenkit.EchoAgent;
 
 /// Create a minimal valid skill directory inside `dir`.
-fn makeSkillDir(dir: std.fs.Dir, name: []const u8, description: []const u8) !void {
-    try dir.makeDir(name);
-    var sub = try dir.openDir(name, .{});
-    defer sub.close();
+fn makeSkillDir(dir: std.Io.Dir, name: []const u8, description: []const u8) !void {
+    const io = testing.io;
+    try dir.createDir(io, name, .default_dir);
+    var sub = try dir.openDir(io, name, .{});
+    defer sub.close(io);
     var buf: [4096]u8 = undefined;
     const content = try std.fmt.bufPrint(
         &buf,
         "---\nname: {s}\ndescription: {s}\n---\nInstructions here.",
         .{ name, description },
     );
-    const file = try sub.createFile("SKILL.md", .{});
-    defer file.close();
-    try file.writeAll(content);
+    var file = try sub.createFile(io, "SKILL.md", .{});
+    defer file.close(io);
+    try file.writeStreamingAll(io, content);
+}
+
+/// Resolve `sub_path` (relative to `dir`) to an absolute path the caller owns.
+fn realpathAlloc(dir: std.Io.Dir, allocator: std.mem.Allocator, sub_path: []const u8) ![]u8 {
+    const io = testing.io;
+    var sub = try dir.openDir(io, sub_path, .{});
+    defer sub.close(io);
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    const len = try sub.realPath(io, &buf);
+    return allocator.dupe(u8, buf[0..len]);
 }
 
 // ── AgentSkill.fromDirectory / fromContent ────────────────────────────────────
@@ -36,14 +47,14 @@ test "load skill valid" {
     var tmp = testing.tmpDir(.{});
     defer tmp.cleanup();
     {
-        try tmp.dir.makeDir("pdf-processing");
-        var sub = try tmp.dir.openDir("pdf-processing", .{});
-        defer sub.close();
-        const file = try sub.createFile("SKILL.md", .{});
-        defer file.close();
-        try file.writeAll("---\nname: pdf-processing\ndescription: Extract text from PDFs.\n---\n# PDF\nDo stuff.");
+        try tmp.dir.createDir(testing.io, "pdf-processing", .default_dir);
+        var sub = try tmp.dir.openDir(testing.io, "pdf-processing", .{});
+        defer sub.close(testing.io);
+        const file = try sub.createFile(testing.io, "SKILL.md", .{});
+        defer file.close(testing.io);
+        try file.writeStreamingAll(testing.io, "---\nname: pdf-processing\ndescription: Extract text from PDFs.\n---\n# PDF\nDo stuff.");
     }
-    const path = try tmp.dir.realpathAlloc(testing.allocator, "pdf-processing");
+    const path = try realpathAlloc(tmp.dir, testing.allocator, "pdf-processing");
     defer testing.allocator.free(path);
 
     var skill = try skills.AgentSkill.fromDirectory(testing.allocator, path);
@@ -70,8 +81,8 @@ test "load skill with license and metadata" {
 test "load skill missing SKILL.md" {
     var tmp = testing.tmpDir(.{});
     defer tmp.cleanup();
-    try tmp.dir.makeDir("empty");
-    const path = try tmp.dir.realpathAlloc(testing.allocator, "empty");
+    try tmp.dir.createDir(testing.io, "empty", .default_dir);
+    const path = try realpathAlloc(tmp.dir, testing.allocator, "empty");
     defer testing.allocator.free(path);
 
     try testing.expectError(skills.SkillError.MissingSkillFile, skills.AgentSkill.fromDirectory(testing.allocator, path));
@@ -122,11 +133,11 @@ test "registry discover skips non-dirs" {
     var tmp = testing.tmpDir(.{});
     defer tmp.cleanup();
     {
-        const file = try tmp.dir.createFile("not_a_dir.md", .{});
-        defer file.close();
-        try file.writeAll("ignored");
+        const file = try tmp.dir.createFile(testing.io, "not_a_dir.md", .{});
+        defer file.close(testing.io);
+        try file.writeStreamingAll(testing.io, "ignored");
     }
-    const root = try tmp.dir.realpathAlloc(testing.allocator, ".");
+    const root = try realpathAlloc(tmp.dir, testing.allocator, ".");
     defer testing.allocator.free(root);
 
     const paths = [_][]const u8{root};
@@ -141,7 +152,7 @@ test "registry discovers valid skills" {
     defer tmp.cleanup();
     try makeSkillDir(tmp.dir, "skill-a", "Skill A description.");
     try makeSkillDir(tmp.dir, "skill-b", "Skill B description.");
-    const root = try tmp.dir.realpathAlloc(testing.allocator, ".");
+    const root = try realpathAlloc(tmp.dir, testing.allocator, ".");
     defer testing.allocator.free(root);
 
     const paths = [_][]const u8{root};
@@ -158,7 +169,7 @@ test "registry find relevant name match" {
     defer tmp.cleanup();
     try makeSkillDir(tmp.dir, "pdf-processing", "Work with PDF documents.");
     try makeSkillDir(tmp.dir, "csv-tools", "Handle CSV spreadsheets.");
-    const root = try tmp.dir.realpathAlloc(testing.allocator, ".");
+    const root = try realpathAlloc(tmp.dir, testing.allocator, ".");
     defer testing.allocator.free(root);
 
     const paths = [_][]const u8{root};
@@ -183,7 +194,7 @@ test "registry find relevant max results" {
         const desc = try std.fmt.bufPrint(&desc_buf, "A skill about document processing number {d}.", .{i});
         try makeSkillDir(tmp.dir, name, desc);
     }
-    const root = try tmp.dir.realpathAlloc(testing.allocator, ".");
+    const root = try realpathAlloc(tmp.dir, testing.allocator, ".");
     defer testing.allocator.free(root);
 
     const paths = [_][]const u8{root};
@@ -200,7 +211,7 @@ test "registry get skill" {
     var tmp = testing.tmpDir(.{});
     defer tmp.cleanup();
     try makeSkillDir(tmp.dir, "email-compose", "Compose professional emails.");
-    const root = try tmp.dir.realpathAlloc(testing.allocator, ".");
+    const root = try realpathAlloc(tmp.dir, testing.allocator, ".");
     defer testing.allocator.free(root);
 
     const paths = [_][]const u8{root};
@@ -221,7 +232,7 @@ test "skill agent augments message" {
     var tmp = testing.tmpDir(.{});
     defer tmp.cleanup();
     try makeSkillDir(tmp.dir, "pdf-processing", "Extract text from PDF documents.");
-    const root = try tmp.dir.realpathAlloc(allocator, ".");
+    const root = try realpathAlloc(tmp.dir, allocator, ".");
     defer allocator.free(root);
 
     const paths = [_][]const u8{root};
@@ -251,7 +262,7 @@ test "skill agent no skills passthrough" {
     var tmp = testing.tmpDir(.{});
     defer tmp.cleanup();
     try makeSkillDir(tmp.dir, "email-compose", "Compose professional emails.");
-    const root = try tmp.dir.realpathAlloc(allocator, ".");
+    const root = try realpathAlloc(tmp.dir, allocator, ".");
     defer allocator.free(root);
 
     const paths = [_][]const u8{root};
@@ -281,7 +292,7 @@ test "skill agent active_skills metadata" {
     var tmp = testing.tmpDir(.{});
     defer tmp.cleanup();
     try makeSkillDir(tmp.dir, "csv-tools", "Handle and transform CSV spreadsheets.");
-    const root = try tmp.dir.realpathAlloc(allocator, ".");
+    const root = try realpathAlloc(tmp.dir, allocator, ".");
     defer allocator.free(root);
 
     const paths = [_][]const u8{root};


### PR DESCRIPTION
Closes #646. Also resolves the Zig leftover from #627.

## What
Migrates `agenkit-zig` from the superseded 0.15.2 to current **Zig 0.16.0** and raises `minimum_zig_version`, so the module builds/tests on a stock current toolchain again (it had frozen — the 0.15→0.16 std churn broke a clean 0.16 build).

## Verified (on 0.16.0)
- `zig build test` → **23/23 steps, 479/479 tests passed**
- `zig build` → examples + benchmarks compile
- `zig fmt --check` clean
- CI: `setup-zig` pinned to 0.16.0, Zig test step flipped back to **blocking**

## 0.16 API churn handled (~115 files)
- **ArrayList unmanaged**: `.init(a)` → `.empty`; `append`/`appendSlice`/`deinit`/`toOwnedSlice`/`ensureTotalCapacity` take the allocator.
- **json.ObjectMap unmanaged**: `.init` → `.empty`; `put`/`deinit` take allocator (`json.Array` stayed managed — that asymmetry drove many edits).
- **Filesystem → Io**: `std.fs.{cwd,Dir,File}` → `std.Io.*`, methods take an `io` handle; `readToEndAlloc`/`writeAll` → `readFileAlloc`/`writeStreamingAll`.
- **Threading/time → Io model**: added 4 small **compat shims** (`time/sync/env/io_compat.zig`) exposing the prior `Mutex`/`RwLock`/`Condition`/clock API (atomic-backed locks, posix clock) rather than threading an `Io` through every public signature. See note below.
- Misc: `std.rand` → `std.Random`, `std.io.Writer` → `std.Io.Writer`, `json.stringify` → `json.Stringify.valueAlloc`, discarded `|_|` captures removed, `GeneralPurposeAllocator` → `DebugAllocator`.

## Pre-existing bugs surfaced + fixed
These tests never ran on 0.16 before (the suite didn't compile), so the bugs were latent:
1. `evaluation.prompt_optimizer.sampleRandomConfig` leak (the #627 leftover).
2. `EchoAgent`/`SkillEnabledAgent` capabilities freed *borrowed* static strings (bus error under the stricter allocator).
3. `SkillEnabledAgent.process()` double-freed metadata shared with the response.

`validate()` logs downgraded `err`→`warn` (the 0.16 test runner fails a run on error-level logs; the function still returns the error).

## Reviewer note / follow-up
The `sync_compat` `Mutex`/`RwLock` are atomic **spinlocks** — correct mutual exclusion, fine for the toolkit's non-lock-bound hot paths, but a future pass could move to the native `Io` sync primitives if any lock is held long. Flagging rather than blocking.