### PR TITLE
ci: add Redis service container to run RedisMemory tests (closes #648)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -204,3 +204,52 @@ jobs:
         working-directory: agenkit-zig
         run: zig build test
 
+  # Redis-backed tests (Python + TypeScript RedisMemory). These suites skip
+  # themselves when no Redis server is reachable, so they never gated anything
+  # in CI. A redis:7-alpine service container makes them actually run. Hosted
+  # ubuntu only (both push and PR): keeps untrusted PR code off the LAN runners
+  # and the hosted image has Docker for the service container. Separate job so
+  # the smoke/lang jobs stay fast and unaffected. (#648)
+  redis-tests:
+    name: Redis Tests (Python + TS)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    services:
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 5
+    env:
+      REDIS_URL: redis://localhost:6379
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      # --- Python RedisMemory tests ---
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+      - name: Install Python 3.12 + redis extra
+        run: |
+          uv python install 3.12
+          uv sync --extra test --extra redis --python 3.12
+      - name: Run Python RedisMemory tests
+        run: uv run pytest tests/memory/test_redis_memory.py -v
+        env:
+          PYTHONPATH: ${{ github.workspace }}
+
+      # --- TypeScript RedisMemory tests ---
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - name: TypeScript RedisMemory tests
+        working-directory: agenkit-ts
+        run: |
+          npm ci
+          npx vitest run src/__tests__/memory/redis.test.ts
+


### PR DESCRIPTION
Closes #648. First increment of the Docker-for-service-dependency-tests direction.

## Problem
The `RedisMemory` suites (Python `tests/memory/test_redis_memory.py`, TS `src/__tests__/memory/redis.test.ts`) **skip themselves** when no Redis server is reachable — so they never gated anything in CI.

## Change
A `redis:7-alpine` **service container** + a dedicated `redis-tests` job that runs both suites against it:
- **Hosted `ubuntu-latest` (push + PR)** — keeps untrusted PR code off the LAN runners and provides Docker for the service container.
- **Python**: `uv sync --extra test --extra redis` (redis is an optional extra, not in `test`), run with `REDIS_URL` set.
- **TypeScript**: `npm ci` + vitest the redis suite.
- **Separate job** so the smoke/lang jobs stay fast and unaffected — no change to existing jobs.
- Service has a `redis-cli ping` healthcheck so the job waits until Redis is ready.

## Verified locally
Against a real `redis:7-alpine` container: **Python 17 + TS 18 tests run and pass** (previously all skipped). The suites needed no code changes — both already honor `REDIS_URL`/default to `localhost:6379`.

## Follow-ons (separate issues, not here)
Ollama adapter tests, real ws/grpc/http transport round-trips.