### PR TITLE
feat(eval): ErrorTracker — per-step error rate + failure compounding (#321)

### DIFF
--- a/agenkit/evaluation/__init__.py
+++ b/agenkit/evaluation/__init__.py
@@ -56,6 +56,7 @@ except ImportError:
 from .benchmarks import Benchmark, BenchmarkSuite
 from .context_metrics import CompressionMetrics, ContextMetrics, LatencyMetric
 from .core import EvaluationResult, Evaluator, Metric
+from .error_tracker import ErrorTracker, StepResult
 from .optimizer import OptimizationResult, Optimizer, RandomSearchOptimizer, SearchSpace
 from .pattern_benchmarks import PatternBenchmark, PatternBenchmarkSuite, YAMLBenchmarkLoader
 from .prompt_optimizer import OptimizationStrategy, PromptOptimizationResult, PromptOptimizer
@@ -78,6 +79,8 @@ __all__ = [
     "CompressionMetrics",
     # Context tracking
     "ContextMetrics",
+    # Error tracking
+    "ErrorTracker",
     "EvaluationResult",
     "Evaluator",
     "LatencyMetric",
@@ -105,6 +108,7 @@ __all__ = [
     "SessionReplay",
     "SignificanceLevel",
     "StatisticalTestType",
+    "StepResult",
     "YAMLBenchmarkLoader",
     "calculate_sample_size",
 ]

--- a/agenkit/evaluation/error_tracker.py
+++ b/agenkit/evaluation/error_tracker.py
@@ -1,0 +1,121 @@
+"""
+Error tracking infrastructure — per-step error rate and failure compounding.
+
+Long-running agents execute many steps; even a small per-step error rate
+compounds into a high probability of at least one failure over a long run.
+``ErrorTracker`` records the outcome of each step and exposes the two core
+quantities from the agent-failure-rate analysis:
+
+- ``p_a`` (:meth:`ErrorTracker.per_step_error_rate`) — the per-step error rate,
+  ``failed_steps / total_steps``.
+- ``P_error`` (:meth:`ErrorTracker.cumulative_failure_probability`) — the
+  probability of at least one failure across ``n`` independent steps,
+  ``1 - (1 - p_a) ** n``. With no argument, ``n`` is the number of recorded
+  steps (observed cumulative failure probability); pass ``steps=N`` to project
+  the compounding over a planned run of ``N`` steps.
+
+Tracking is opt-in: construct an ``ErrorTracker(enabled=True)`` (or pass
+``enable_error_tracking=True`` to a component that owns one) and call
+:meth:`record_step` as steps complete. When disabled, ``record_step`` is a
+no-op and the metrics report zero, so the tracker is cheap to leave wired in.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class StepResult:
+    """Outcome of a single agent step.
+
+    Attributes:
+        success: Whether the step completed without error.
+        name: Optional step label (useful for per-step breakdowns later).
+        error: Optional error description when ``success`` is ``False``.
+    """
+
+    success: bool
+    name: str | None = None
+    error: str | None = None
+
+
+@dataclass
+class ErrorTracker:
+    """Records step outcomes and computes error-rate / compounding metrics.
+
+    Args:
+        enabled: When ``False`` (the default), :meth:`record_step` is a no-op
+            and all metrics report ``0.0``/``0`` — tracking is strictly opt-in.
+
+    Example:
+        >>> tracker = ErrorTracker(enabled=True)
+        >>> tracker.record_step(True)
+        >>> tracker.record_step(False, error="timeout")
+        >>> tracker.per_step_error_rate()
+        0.5
+        >>> round(tracker.cumulative_failure_probability(steps=10), 4)
+        0.999
+    """
+
+    enabled: bool = False
+    step_results: list[StepResult] = field(default_factory=list)
+
+    def record_step(
+        self, success: bool, *, name: str | None = None, error: str | None = None
+    ) -> None:
+        """Record the outcome of one step (no-op when disabled).
+
+        Args:
+            success: Whether the step succeeded.
+            name: Optional step label.
+            error: Optional error description for a failed step.
+        """
+        if not self.enabled:
+            return
+        self.step_results.append(StepResult(success=success, name=name, error=error))
+
+    @property
+    def total_steps(self) -> int:
+        """Number of recorded steps."""
+        return len(self.step_results)
+
+    @property
+    def failed_steps(self) -> int:
+        """Number of recorded steps that failed."""
+        return sum(1 for r in self.step_results if not r.success)
+
+    def per_step_error_rate(self) -> float:
+        """Per-step error rate ``p_a`` = failed_steps / total_steps.
+
+        Returns ``0.0`` when no steps have been recorded.
+        """
+        if self.total_steps == 0:
+            return 0.0
+        return self.failed_steps / self.total_steps
+
+    def cumulative_failure_probability(self, steps: int | None = None) -> float:
+        """Probability of at least one failure over ``steps`` steps.
+
+        ``P_error = 1 - (1 - p_a) ** n`` where ``n`` is ``steps`` if given,
+        otherwise the number of recorded steps. Models error compounding:
+        independent steps each succeed with probability ``1 - p_a``, so the run
+        succeeds only if all ``n`` succeed.
+
+        Args:
+            steps: Project the compounding over this many steps. Defaults to the
+                number of recorded steps (observed cumulative probability).
+
+        Returns:
+            A probability in ``[0.0, 1.0]``. Returns ``0.0`` if ``p_a`` is 0 or
+            ``n <= 0``.
+        """
+        n = self.total_steps if steps is None else steps
+        if n <= 0:
+            return 0.0
+        p_a = self.per_step_error_rate()
+        return 1.0 - (1.0 - p_a) ** n
+
+    def reset(self) -> None:
+        """Clear all recorded step results."""
+        self.step_results.clear()

--- a/tests/evaluation/test_error_tracker.py
+++ b/tests/evaluation/test_error_tracker.py
@@ -1,0 +1,171 @@
+"""Tests for ErrorTracker — per-step error rate (p_a) and compounding (P_error)."""
+
+import math
+
+import pytest
+
+from agenkit.evaluation import ErrorTracker, StepResult
+
+# ---------------------------------------------------------------------------
+# StepResult
+# ---------------------------------------------------------------------------
+
+
+def test_step_result_defaults() -> None:
+    r = StepResult(success=True)
+    assert r.success is True
+    assert r.name is None
+    assert r.error is None
+
+
+def test_step_result_failure_fields() -> None:
+    r = StepResult(success=False, name="fetch", error="timeout")
+    assert r.success is False
+    assert r.name == "fetch"
+    assert r.error == "timeout"
+
+
+# ---------------------------------------------------------------------------
+# Opt-in / disabled behavior
+# ---------------------------------------------------------------------------
+
+
+def test_disabled_by_default_records_nothing() -> None:
+    tracker = ErrorTracker()
+    assert tracker.enabled is False
+    tracker.record_step(False, error="boom")
+    assert tracker.total_steps == 0
+    assert tracker.failed_steps == 0
+    assert tracker.per_step_error_rate() == 0.0
+    assert tracker.cumulative_failure_probability() == 0.0
+
+
+def test_enabled_records_steps() -> None:
+    tracker = ErrorTracker(enabled=True)
+    tracker.record_step(True)
+    tracker.record_step(False, error="x")
+    assert tracker.total_steps == 2
+    assert tracker.failed_steps == 1
+
+
+# ---------------------------------------------------------------------------
+# per_step_error_rate (p_a)
+# ---------------------------------------------------------------------------
+
+
+def test_per_step_error_rate_empty_is_zero() -> None:
+    assert ErrorTracker(enabled=True).per_step_error_rate() == 0.0
+
+
+def test_per_step_error_rate_all_success() -> None:
+    t = ErrorTracker(enabled=True)
+    for _ in range(5):
+        t.record_step(True)
+    assert t.per_step_error_rate() == 0.0
+
+
+def test_per_step_error_rate_all_fail() -> None:
+    t = ErrorTracker(enabled=True)
+    for _ in range(4):
+        t.record_step(False)
+    assert t.per_step_error_rate() == 1.0
+
+
+def test_per_step_error_rate_mixed() -> None:
+    t = ErrorTracker(enabled=True)
+    # 2 failures out of 8 -> 0.25
+    outcomes = [True, False, True, True, False, True, True, True]
+    for ok in outcomes:
+        t.record_step(ok)
+    assert t.per_step_error_rate() == pytest.approx(0.25)
+
+
+# ---------------------------------------------------------------------------
+# cumulative_failure_probability (P_error = 1 - (1 - p_a) ** n)
+# ---------------------------------------------------------------------------
+
+
+def test_cumulative_empty_is_zero() -> None:
+    assert ErrorTracker(enabled=True).cumulative_failure_probability() == 0.0
+
+
+def test_cumulative_observed_uses_recorded_step_count() -> None:
+    t = ErrorTracker(enabled=True)
+    t.record_step(True)
+    t.record_step(False)
+    # p_a = 0.5, n = 2 -> 1 - 0.5^2 = 0.75
+    assert t.cumulative_failure_probability() == pytest.approx(0.75)
+
+
+def test_cumulative_projected_steps() -> None:
+    t = ErrorTracker(enabled=True)
+    t.record_step(True)
+    t.record_step(False)  # p_a = 0.5
+    # project over 10 steps: 1 - 0.5^10
+    assert t.cumulative_failure_probability(steps=10) == pytest.approx(1 - 0.5**10)
+
+
+def test_cumulative_compounding_small_rate() -> None:
+    # The motivating case: a small per-step rate compounds over a long run.
+    t = ErrorTracker(enabled=True)
+    # p_a = 0.01 (1 failure in 100)
+    t.record_step(False)
+    for _ in range(99):
+        t.record_step(True)
+    assert t.per_step_error_rate() == pytest.approx(0.01)
+    # Over 100 steps: 1 - 0.99^100 ~= 0.634
+    p_error = t.cumulative_failure_probability(steps=100)
+    assert p_error == pytest.approx(1 - 0.99**100)
+    assert 0.63 < p_error < 0.64
+
+
+def test_cumulative_zero_rate_is_zero() -> None:
+    t = ErrorTracker(enabled=True)
+    for _ in range(10):
+        t.record_step(True)
+    assert t.cumulative_failure_probability(steps=1000) == 0.0
+
+
+def test_cumulative_full_rate_is_one() -> None:
+    t = ErrorTracker(enabled=True)
+    t.record_step(False)
+    assert t.cumulative_failure_probability(steps=5) == pytest.approx(1.0)
+
+
+def test_cumulative_nonpositive_steps_is_zero() -> None:
+    t = ErrorTracker(enabled=True)
+    t.record_step(False)
+    assert t.cumulative_failure_probability(steps=0) == 0.0
+    assert t.cumulative_failure_probability(steps=-3) == 0.0
+
+
+def test_cumulative_in_unit_interval() -> None:
+    t = ErrorTracker(enabled=True)
+    for ok in [True, False, True, False, False]:
+        t.record_step(ok)
+    for n in range(1, 50):
+        p = t.cumulative_failure_probability(steps=n)
+        assert 0.0 <= p <= 1.0
+        assert not math.isnan(p)
+
+
+# ---------------------------------------------------------------------------
+# reset + docstring example
+# ---------------------------------------------------------------------------
+
+
+def test_reset_clears_steps() -> None:
+    t = ErrorTracker(enabled=True)
+    t.record_step(True)
+    t.record_step(False)
+    t.reset()
+    assert t.total_steps == 0
+    assert t.per_step_error_rate() == 0.0
+
+
+def test_docstring_example_values() -> None:
+    tracker = ErrorTracker(enabled=True)
+    tracker.record_step(True)
+    tracker.record_step(False, error="timeout")
+    assert tracker.per_step_error_rate() == 0.5
+    assert round(tracker.cumulative_failure_probability(steps=10), 4) == 0.999


### PR DESCRIPTION
Part of #321 (ErrorTracker API). **Python reference implementation** — the foundation the rest of the evaluation cluster builds on (#322 OTel metrics, #324/#325 error breakdown, #327 failure predictor).

Landing as staged PRs per the issue's 6-language scope ([scoping note on the issue](https://github.com/scttfrdmn/agenkit/issues/321#issuecomment-4736533254)); Go/TS/Rust/C++/Zig + cross-language equivalence follow.

## API (`agenkit/evaluation/error_tracker.py`)
- `StepResult(success, name?, error?)` — one step's outcome.
- `ErrorTracker(enabled=False)` — **opt-in**; `record_step()` is a no-op when disabled, so it's cheap to leave wired in.
  - `per_step_error_rate()` → **p_a** = `failed_steps / total_steps`
  - `cumulative_failure_probability(steps=None)` → **P_error** = `1 - (1 - p_a)^n`; `n` defaults to recorded steps (observed) or projects over a planned run when `steps=N`.
  - `total_steps` / `failed_steps` properties; `reset()`.

Spec taken from the issue (the referenced docs don't exist in-repo).

## Tests
18 unit tests: the math (incl. the motivating 1%-per-step-over-100-steps ≈ 0.63 compounding case), opt-in/disabled behavior, `[0,1]` invariants, and edge cases (empty, all-pass, all-fail, non-positive n).

## Verified
- `pytest tests/evaluation/test_error_tracker.py` → 18 passed
- ruff clean; full evaluation suite → 134 passed