### PR TITLE
feat(eval): ErrorTracker in Go/TS/Rust/C++/Zig + equivalence fixture (#321)

### DIFF
--- a/agenkit-cpp/CMakeLists.txt
+++ b/agenkit-cpp/CMakeLists.txt
@@ -150,6 +150,7 @@ add_library(agenkit
     src/evaluation/benchmarks.cpp
     src/evaluation/bayesian_optimizer.cpp
     src/evaluation/prompt_optimizer.cpp
+    src/evaluation/error_tracker.cpp
     src/techniques/reasoning/self_consistency.cpp
     src/techniques/reasoning/chain_of_thought.cpp
     src/techniques/reasoning/least_to_most.cpp

--- a/agenkit-cpp/include/agenkit/evaluation/error_tracker.hpp
+++ b/agenkit-cpp/include/agenkit/evaluation/error_tracker.hpp
@@ -1,0 +1,127 @@
+/**
+ * @file error_tracker.hpp
+ * @brief Error tracking — per-step error rate and failure compounding.
+ *
+ * Long-running agents execute many steps; even a small per-step error rate
+ * compounds into a high probability of at least one failure over a long run.
+ * ErrorTracker records the outcome of each step and exposes the two core
+ * quantities from the agent-failure-rate analysis:
+ *
+ * - p_a (per_step_error_rate) — the per-step error rate,
+ *   failed_steps / total_steps.
+ * - P_error (cumulative_failure_probability) — the probability of at least one
+ *   failure across n independent steps, 1 - (1 - p_a)^n. With no argument, n is
+ *   the number of recorded steps (observed cumulative failure probability);
+ *   pass steps=N to project the compounding over a planned run of N steps.
+ *
+ * Tracking is opt-in: construct an ErrorTracker(true) and call record_step as
+ * steps complete. When disabled (the default), record_step is a no-op and the
+ * metrics report zero, so the tracker is cheap to leave wired in.
+ *
+ * Mirrors the Python reference implementation (agenkit/evaluation/error_tracker.py).
+ */
+
+#ifndef AGENKIT_EVALUATION_ERROR_TRACKER_HPP
+#define AGENKIT_EVALUATION_ERROR_TRACKER_HPP
+
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace agenkit {
+namespace evaluation {
+
+/**
+ * @brief Outcome of a single agent step.
+ */
+struct StepResult {
+    /** Whether the step completed without error. */
+    bool success;
+
+    /** Optional step label (useful for per-step breakdowns later). */
+    std::optional<std::string> name;
+
+    /** Optional error description when success is false. */
+    std::optional<std::string> error;
+};
+
+/**
+ * @brief Records step outcomes and computes error-rate / compounding metrics.
+ *
+ * @details
+ * When disabled (the default), record_step is a no-op and all metrics report
+ * 0.0 / 0 — tracking is strictly opt-in.
+ *
+ * @example
+ * @code
+ * ErrorTracker tracker(true);
+ * tracker.record_step(true);
+ * tracker.record_step(false, std::nullopt, "timeout");
+ * tracker.per_step_error_rate();                       // 0.5
+ * tracker.cumulative_failure_probability(10);          // ~0.999
+ * @endcode
+ */
+class ErrorTracker {
+public:
+    /**
+     * @brief Construct an error tracker.
+     * @param enabled When false (the default), record_step is a no-op and all
+     *        metrics report 0.0 / 0.
+     */
+    explicit ErrorTracker(bool enabled = false) : enabled_(enabled) {}
+
+    /** @brief Whether tracking is enabled. */
+    bool enabled() const { return enabled_; }
+
+    /**
+     * @brief Record the outcome of one step (no-op when disabled).
+     * @param success Whether the step succeeded.
+     * @param name Optional step label.
+     * @param error Optional error description for a failed step.
+     */
+    void record_step(bool success,
+                     std::optional<std::string> name = std::nullopt,
+                     std::optional<std::string> error = std::nullopt);
+
+    /** @brief Number of recorded steps. */
+    std::size_t total_steps() const { return step_results_.size(); }
+
+    /** @brief Number of recorded steps that failed. */
+    std::size_t failed_steps() const;
+
+    /**
+     * @brief Per-step error rate p_a = failed_steps / total_steps.
+     * @return 0.0 when no steps have been recorded.
+     */
+    double per_step_error_rate() const;
+
+    /**
+     * @brief Probability of at least one failure over n steps.
+     *
+     * P_error = 1 - (1 - p_a)^n where n is steps if given, otherwise the number
+     * of recorded steps. Models error compounding: independent steps each
+     * succeed with probability 1 - p_a, so the run succeeds only if all n
+     * succeed.
+     *
+     * @param steps Project the compounding over this many steps. Defaults to the
+     *        number of recorded steps (observed cumulative probability).
+     * @return A probability in [0.0, 1.0]. Returns 0.0 if p_a is 0 or n <= 0.
+     */
+    double cumulative_failure_probability(
+        std::optional<int> steps = std::nullopt) const;
+
+    /** @brief Clear all recorded step results. */
+    void reset();
+
+    /** @brief Read-only access to the recorded step results. */
+    const std::vector<StepResult>& step_results() const { return step_results_; }
+
+private:
+    bool enabled_;
+    std::vector<StepResult> step_results_;
+};
+
+} // namespace evaluation
+} // namespace agenkit
+
+#endif // AGENKIT_EVALUATION_ERROR_TRACKER_HPP

--- a/agenkit-cpp/src/evaluation/error_tracker.cpp
+++ b/agenkit-cpp/src/evaluation/error_tracker.cpp
@@ -1,0 +1,54 @@
+/**
+ * @file error_tracker.cpp
+ * @brief Implementation of per-step error rate and failure compounding.
+ */
+
+#include "agenkit/evaluation/error_tracker.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+namespace agenkit {
+namespace evaluation {
+
+void ErrorTracker::record_step(bool success,
+                               std::optional<std::string> name,
+                               std::optional<std::string> error) {
+    if (!enabled_) {
+        return;
+    }
+    step_results_.push_back(
+        StepResult{success, std::move(name), std::move(error)});
+}
+
+std::size_t ErrorTracker::failed_steps() const {
+    return static_cast<std::size_t>(
+        std::count_if(step_results_.begin(), step_results_.end(),
+                      [](const StepResult& r) { return !r.success; }));
+}
+
+double ErrorTracker::per_step_error_rate() const {
+    const std::size_t total = step_results_.size();
+    if (total == 0) {
+        return 0.0;
+    }
+    return static_cast<double>(failed_steps()) / static_cast<double>(total);
+}
+
+double ErrorTracker::cumulative_failure_probability(
+    std::optional<int> steps) const {
+    const int n =
+        steps.has_value() ? *steps : static_cast<int>(step_results_.size());
+    if (n <= 0) {
+        return 0.0;
+    }
+    const double p_a = per_step_error_rate();
+    return 1.0 - std::pow(1.0 - p_a, n);
+}
+
+void ErrorTracker::reset() {
+    step_results_.clear();
+}
+
+} // namespace evaluation
+} // namespace agenkit

--- a/agenkit-cpp/tests/CMakeLists.txt
+++ b/agenkit-cpp/tests/CMakeLists.txt
@@ -237,6 +237,11 @@ add_executable(test_prompt_optimizer unit/test_prompt_optimizer.cpp)
 target_link_libraries(test_prompt_optimizer agenkit gtest_main)
 add_test(NAME prompt_optimizer_tests COMMAND test_prompt_optimizer)
 
+# Evaluation tests - Error Tracker
+add_executable(test_error_tracker unit/test_error_tracker.cpp)
+target_link_libraries(test_error_tracker agenkit gtest_main)
+add_test(NAME error_tracker_tests COMMAND test_error_tracker)
+
 # Technique tests - Chain-of-Thought
 add_executable(test_chain_of_thought techniques/reasoning/test_chain_of_thought.cpp)
 target_link_libraries(test_chain_of_thought agenkit gtest_main)

--- a/agenkit-cpp/tests/unit/test_error_tracker.cpp
+++ b/agenkit-cpp/tests/unit/test_error_tracker.cpp
@@ -1,0 +1,193 @@
+/**
+ * @file test_error_tracker.cpp
+ * @brief Tests for ErrorTracker — per-step error rate (p_a) and compounding
+ *        (P_error). Ported from tests/evaluation/test_error_tracker.py.
+ */
+
+#include "agenkit/evaluation/error_tracker.hpp"
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+using agenkit::evaluation::ErrorTracker;
+using agenkit::evaluation::StepResult;
+
+namespace {
+
+constexpr double kEps = 1e-9;
+
+} // namespace
+
+// ============================================================================
+// StepResult
+// ============================================================================
+
+TEST(StepResultTest, Defaults) {
+    StepResult r{true, std::nullopt, std::nullopt};
+    EXPECT_TRUE(r.success);
+    EXPECT_FALSE(r.name.has_value());
+    EXPECT_FALSE(r.error.has_value());
+}
+
+TEST(StepResultTest, FailureFields) {
+    StepResult r{false, std::string("fetch"), std::string("timeout")};
+    EXPECT_FALSE(r.success);
+    ASSERT_TRUE(r.name.has_value());
+    EXPECT_EQ(*r.name, "fetch");
+    ASSERT_TRUE(r.error.has_value());
+    EXPECT_EQ(*r.error, "timeout");
+}
+
+// ============================================================================
+// Opt-in / disabled behavior
+// ============================================================================
+
+TEST(ErrorTrackerTest, DisabledByDefaultRecordsNothing) {
+    ErrorTracker tracker;
+    EXPECT_FALSE(tracker.enabled());
+    tracker.record_step(false, std::nullopt, std::string("boom"));
+    EXPECT_EQ(tracker.total_steps(), 0u);
+    EXPECT_EQ(tracker.failed_steps(), 0u);
+    EXPECT_NEAR(tracker.per_step_error_rate(), 0.0, kEps);
+    EXPECT_NEAR(tracker.cumulative_failure_probability(), 0.0, kEps);
+}
+
+TEST(ErrorTrackerTest, EnabledRecordsSteps) {
+    ErrorTracker tracker(true);
+    tracker.record_step(true);
+    tracker.record_step(false, std::nullopt, std::string("x"));
+    EXPECT_EQ(tracker.total_steps(), 2u);
+    EXPECT_EQ(tracker.failed_steps(), 1u);
+}
+
+// ============================================================================
+// per_step_error_rate (p_a)
+// ============================================================================
+
+TEST(ErrorTrackerTest, PerStepErrorRateEmptyIsZero) {
+    EXPECT_NEAR(ErrorTracker(true).per_step_error_rate(), 0.0, kEps);
+}
+
+TEST(ErrorTrackerTest, PerStepErrorRateAllSuccess) {
+    ErrorTracker t(true);
+    for (int i = 0; i < 5; ++i) {
+        t.record_step(true);
+    }
+    EXPECT_NEAR(t.per_step_error_rate(), 0.0, kEps);
+}
+
+TEST(ErrorTrackerTest, PerStepErrorRateAllFail) {
+    ErrorTracker t(true);
+    for (int i = 0; i < 4; ++i) {
+        t.record_step(false);
+    }
+    EXPECT_NEAR(t.per_step_error_rate(), 1.0, kEps);
+}
+
+TEST(ErrorTrackerTest, PerStepErrorRateMixed) {
+    ErrorTracker t(true);
+    // 2 failures out of 8 -> 0.25
+    const bool outcomes[] = {true, false, true, true, false, true, true, true};
+    for (bool ok : outcomes) {
+        t.record_step(ok);
+    }
+    EXPECT_NEAR(t.per_step_error_rate(), 0.25, kEps);
+}
+
+// ============================================================================
+// cumulative_failure_probability (P_error = 1 - (1 - p_a)^n)
+// ============================================================================
+
+TEST(ErrorTrackerTest, CumulativeEmptyIsZero) {
+    EXPECT_NEAR(ErrorTracker(true).cumulative_failure_probability(), 0.0, kEps);
+}
+
+TEST(ErrorTrackerTest, CumulativeObservedUsesRecordedStepCount) {
+    ErrorTracker t(true);
+    t.record_step(true);
+    t.record_step(false);
+    // p_a = 0.5, n = 2 -> 1 - 0.5^2 = 0.75
+    EXPECT_NEAR(t.cumulative_failure_probability(), 0.75, kEps);
+}
+
+TEST(ErrorTrackerTest, CumulativeProjectedSteps) {
+    ErrorTracker t(true);
+    t.record_step(true);
+    t.record_step(false); // p_a = 0.5
+    // project over 10 steps: 1 - 0.5^10
+    EXPECT_NEAR(t.cumulative_failure_probability(10),
+                1.0 - std::pow(0.5, 10), kEps);
+}
+
+TEST(ErrorTrackerTest, CumulativeCompoundingSmallRate) {
+    // The motivating case: a small per-step rate compounds over a long run.
+    ErrorTracker t(true);
+    // p_a = 0.01 (1 failure in 100)
+    t.record_step(false);
+    for (int i = 0; i < 99; ++i) {
+        t.record_step(true);
+    }
+    EXPECT_NEAR(t.per_step_error_rate(), 0.01, kEps);
+    // Over 100 steps: 1 - 0.99^100 ~= 0.634
+    const double p_error = t.cumulative_failure_probability(100);
+    EXPECT_NEAR(p_error, 1.0 - std::pow(0.99, 100), kEps);
+    EXPECT_GT(p_error, 0.63);
+    EXPECT_LT(p_error, 0.64);
+}
+
+TEST(ErrorTrackerTest, CumulativeZeroRateIsZero) {
+    ErrorTracker t(true);
+    for (int i = 0; i < 10; ++i) {
+        t.record_step(true);
+    }
+    EXPECT_NEAR(t.cumulative_failure_probability(1000), 0.0, kEps);
+}
+
+TEST(ErrorTrackerTest, CumulativeFullRateIsOne) {
+    ErrorTracker t(true);
+    t.record_step(false);
+    EXPECT_NEAR(t.cumulative_failure_probability(5), 1.0, kEps);
+}
+
+TEST(ErrorTrackerTest, CumulativeNonPositiveStepsIsZero) {
+    ErrorTracker t(true);
+    t.record_step(false);
+    EXPECT_NEAR(t.cumulative_failure_probability(0), 0.0, kEps);
+    EXPECT_NEAR(t.cumulative_failure_probability(-3), 0.0, kEps);
+}
+
+TEST(ErrorTrackerTest, CumulativeInUnitInterval) {
+    ErrorTracker t(true);
+    const bool outcomes[] = {true, false, true, false, false};
+    for (bool ok : outcomes) {
+        t.record_step(ok);
+    }
+    for (int n = 1; n < 50; ++n) {
+        const double p = t.cumulative_failure_probability(n);
+        EXPECT_GE(p, 0.0);
+        EXPECT_LE(p, 1.0);
+        EXPECT_FALSE(std::isnan(p));
+    }
+}
+
+// ============================================================================
+// reset + docstring example
+// ============================================================================
+
+TEST(ErrorTrackerTest, ResetClearsSteps) {
+    ErrorTracker t(true);
+    t.record_step(true);
+    t.record_step(false);
+    t.reset();
+    EXPECT_EQ(t.total_steps(), 0u);
+    EXPECT_NEAR(t.per_step_error_rate(), 0.0, kEps);
+}
+
+TEST(ErrorTrackerTest, DocstringExampleValues) {
+    ErrorTracker tracker(true);
+    tracker.record_step(true);
+    tracker.record_step(false, std::nullopt, std::string("timeout"));
+    EXPECT_NEAR(tracker.per_step_error_rate(), 0.5, kEps);
+    EXPECT_NEAR(tracker.cumulative_failure_probability(10), 0.999, 1e-4);
+}

--- a/agenkit-go/evaluation/error_tracker.go
+++ b/agenkit-go/evaluation/error_tracker.go
@@ -1,0 +1,134 @@
+// Error tracking infrastructure — per-step error rate and failure compounding.
+//
+// Long-running agents execute many steps; even a small per-step error rate
+// compounds into a high probability of at least one failure over a long run.
+// ErrorTracker records the outcome of each step and exposes the two core
+// quantities from the agent-failure-rate analysis:
+//
+//   - p_a (PerStepErrorRate) — the per-step error rate, failedSteps / totalSteps.
+//   - P_error (CumulativeFailureProbability) — the probability of at least one
+//     failure across n independent steps, 1 - (1 - p_a)^n. With no argument, n is
+//     the number of recorded steps (observed cumulative failure probability); use
+//     CumulativeFailureProbabilityOver(n) to project the compounding over a
+//     planned run of n steps.
+//
+// Tracking is opt-in: construct an ErrorTracker with Enabled set to true and
+// call RecordStep as steps complete. When disabled (the zero value), RecordStep
+// is a no-op and the metrics report zero, so the tracker is cheap to leave
+// wired in.
+
+package evaluation
+
+import "math"
+
+// StepResult captures the outcome of a single agent step.
+type StepResult struct {
+	// Success reports whether the step completed without error.
+	Success bool
+	// Name is an optional step label (useful for per-step breakdowns later).
+	Name string
+	// Error is an optional error description when Success is false.
+	Error string
+}
+
+// ErrorTracker records step outcomes and computes error-rate / compounding
+// metrics. The zero value is a disabled tracker: RecordStep is a no-op and all
+// metrics report 0.0/0. Tracking is strictly opt-in — set Enabled to true.
+//
+// Example:
+//
+//	tracker := &evaluation.ErrorTracker{Enabled: true}
+//	tracker.RecordStep(true)
+//	tracker.RecordStep(false, evaluation.WithStepError("timeout"))
+//	tracker.PerStepErrorRate() // 0.5
+//	tracker.CumulativeFailureProbabilityOver(10) // ≈ 0.999
+type ErrorTracker struct {
+	// Enabled gates recording. When false (the default), RecordStep is a no-op
+	// and all metrics report 0.0/0.
+	Enabled bool
+
+	stepResults []StepResult
+}
+
+// RecordStepOption configures the optional fields of a recorded step.
+type RecordStepOption func(*StepResult)
+
+// WithStepName sets an optional step label.
+func WithStepName(name string) RecordStepOption {
+	return func(r *StepResult) { r.Name = name }
+}
+
+// WithStepError sets an optional error description for a failed step.
+func WithStepError(errMsg string) RecordStepOption {
+	return func(r *StepResult) { r.Error = errMsg }
+}
+
+// RecordStep records the outcome of one step (a no-op when disabled).
+//
+// Optional step metadata (name, error) can be supplied via WithStepName and
+// WithStepError, mirroring the keyword-only arguments of the Python reference.
+func (t *ErrorTracker) RecordStep(success bool, opts ...RecordStepOption) {
+	if !t.Enabled {
+		return
+	}
+	result := StepResult{Success: success}
+	for _, opt := range opts {
+		opt(&result)
+	}
+	t.stepResults = append(t.stepResults, result)
+}
+
+// TotalSteps returns the number of recorded steps.
+func (t *ErrorTracker) TotalSteps() int {
+	return len(t.stepResults)
+}
+
+// FailedSteps returns the number of recorded steps that failed.
+func (t *ErrorTracker) FailedSteps() int {
+	failed := 0
+	for _, r := range t.stepResults {
+		if !r.Success {
+			failed++
+		}
+	}
+	return failed
+}
+
+// PerStepErrorRate returns the per-step error rate p_a = failedSteps /
+// totalSteps. It returns 0.0 when no steps have been recorded.
+func (t *ErrorTracker) PerStepErrorRate() float64 {
+	total := t.TotalSteps()
+	if total == 0 {
+		return 0.0
+	}
+	return float64(t.FailedSteps()) / float64(total)
+}
+
+// CumulativeFailureProbability returns the probability of at least one failure
+// over the number of recorded steps (the observed cumulative probability). It
+// returns 0.0 if no steps have been recorded or p_a is 0.
+//
+// To project the compounding over a planned run of n steps, use
+// CumulativeFailureProbabilityOver.
+func (t *ErrorTracker) CumulativeFailureProbability() float64 {
+	return t.CumulativeFailureProbabilityOver(t.TotalSteps())
+}
+
+// CumulativeFailureProbabilityOver returns the probability of at least one
+// failure over n steps: P_error = 1 - (1 - p_a)^n. It models error compounding:
+// independent steps each succeed with probability 1 - p_a, so the run succeeds
+// only if all n succeed.
+//
+// It returns 0.0 if n <= 0 or p_a is 0. The result lies in [0.0, 1.0].
+func (t *ErrorTracker) CumulativeFailureProbabilityOver(n int) float64 {
+	if n <= 0 {
+		return 0.0
+	}
+	pA := t.PerStepErrorRate()
+	return 1.0 - math.Pow(1.0-pA, float64(n))
+}
+
+// Reset clears all recorded step results.
+func (t *ErrorTracker) Reset() {
+	t.stepResults = nil
+}

--- a/agenkit-go/evaluation/error_tracker_test.go
+++ b/agenkit-go/evaluation/error_tracker_test.go
@@ -1,0 +1,261 @@
+package evaluation
+
+import (
+	"math"
+	"testing"
+)
+
+const epsilon = 1e-9
+
+func approxEqual(a, b float64) bool {
+	return math.Abs(a-b) < epsilon
+}
+
+// ---------------------------------------------------------------------------
+// StepResult
+// ---------------------------------------------------------------------------
+
+func TestStepResultDefaults(t *testing.T) {
+	r := StepResult{Success: true}
+	if !r.Success {
+		t.Errorf("Success = %v, want true", r.Success)
+	}
+	if r.Name != "" {
+		t.Errorf("Name = %q, want empty", r.Name)
+	}
+	if r.Error != "" {
+		t.Errorf("Error = %q, want empty", r.Error)
+	}
+}
+
+func TestStepResultFailureFields(t *testing.T) {
+	r := StepResult{Success: false, Name: "fetch", Error: "timeout"}
+	if r.Success {
+		t.Errorf("Success = %v, want false", r.Success)
+	}
+	if r.Name != "fetch" {
+		t.Errorf("Name = %q, want %q", r.Name, "fetch")
+	}
+	if r.Error != "timeout" {
+		t.Errorf("Error = %q, want %q", r.Error, "timeout")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Opt-in / disabled behavior
+// ---------------------------------------------------------------------------
+
+func TestDisabledByDefaultRecordsNothing(t *testing.T) {
+	tracker := &ErrorTracker{}
+	if tracker.Enabled {
+		t.Errorf("Enabled = %v, want false (zero value)", tracker.Enabled)
+	}
+	tracker.RecordStep(false, WithStepError("boom"))
+	if tracker.TotalSteps() != 0 {
+		t.Errorf("TotalSteps = %d, want 0", tracker.TotalSteps())
+	}
+	if tracker.FailedSteps() != 0 {
+		t.Errorf("FailedSteps = %d, want 0", tracker.FailedSteps())
+	}
+	if got := tracker.PerStepErrorRate(); got != 0.0 {
+		t.Errorf("PerStepErrorRate = %v, want 0.0", got)
+	}
+	if got := tracker.CumulativeFailureProbability(); got != 0.0 {
+		t.Errorf("CumulativeFailureProbability = %v, want 0.0", got)
+	}
+}
+
+func TestEnabledRecordsSteps(t *testing.T) {
+	tracker := &ErrorTracker{Enabled: true}
+	tracker.RecordStep(true)
+	tracker.RecordStep(false, WithStepError("x"))
+	if tracker.TotalSteps() != 2 {
+		t.Errorf("TotalSteps = %d, want 2", tracker.TotalSteps())
+	}
+	if tracker.FailedSteps() != 1 {
+		t.Errorf("FailedSteps = %d, want 1", tracker.FailedSteps())
+	}
+}
+
+func TestRecordStepNameOption(t *testing.T) {
+	tracker := &ErrorTracker{Enabled: true}
+	tracker.RecordStep(false, WithStepName("fetch"), WithStepError("timeout"))
+	if got := tracker.stepResults[0].Name; got != "fetch" {
+		t.Errorf("Name = %q, want %q", got, "fetch")
+	}
+	if got := tracker.stepResults[0].Error; got != "timeout" {
+		t.Errorf("Error = %q, want %q", got, "timeout")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PerStepErrorRate (p_a)
+// ---------------------------------------------------------------------------
+
+func TestPerStepErrorRateEmptyIsZero(t *testing.T) {
+	tracker := &ErrorTracker{Enabled: true}
+	if got := tracker.PerStepErrorRate(); got != 0.0 {
+		t.Errorf("PerStepErrorRate = %v, want 0.0", got)
+	}
+}
+
+func TestPerStepErrorRateAllSuccess(t *testing.T) {
+	tracker := &ErrorTracker{Enabled: true}
+	for i := 0; i < 5; i++ {
+		tracker.RecordStep(true)
+	}
+	if got := tracker.PerStepErrorRate(); got != 0.0 {
+		t.Errorf("PerStepErrorRate = %v, want 0.0", got)
+	}
+}
+
+func TestPerStepErrorRateAllFail(t *testing.T) {
+	tracker := &ErrorTracker{Enabled: true}
+	for i := 0; i < 4; i++ {
+		tracker.RecordStep(false)
+	}
+	if got := tracker.PerStepErrorRate(); got != 1.0 {
+		t.Errorf("PerStepErrorRate = %v, want 1.0", got)
+	}
+}
+
+func TestPerStepErrorRateMixed(t *testing.T) {
+	tracker := &ErrorTracker{Enabled: true}
+	// 2 failures out of 8 -> 0.25
+	outcomes := []bool{true, false, true, true, false, true, true, true}
+	for _, ok := range outcomes {
+		tracker.RecordStep(ok)
+	}
+	if got := tracker.PerStepErrorRate(); !approxEqual(got, 0.25) {
+		t.Errorf("PerStepErrorRate = %v, want 0.25", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CumulativeFailureProbability (P_error = 1 - (1 - p_a)^n)
+// ---------------------------------------------------------------------------
+
+func TestCumulativeEmptyIsZero(t *testing.T) {
+	tracker := &ErrorTracker{Enabled: true}
+	if got := tracker.CumulativeFailureProbability(); got != 0.0 {
+		t.Errorf("CumulativeFailureProbability = %v, want 0.0", got)
+	}
+}
+
+func TestCumulativeObservedUsesRecordedStepCount(t *testing.T) {
+	tracker := &ErrorTracker{Enabled: true}
+	tracker.RecordStep(true)
+	tracker.RecordStep(false)
+	// p_a = 0.5, n = 2 -> 1 - 0.5^2 = 0.75
+	if got := tracker.CumulativeFailureProbability(); !approxEqual(got, 0.75) {
+		t.Errorf("CumulativeFailureProbability = %v, want 0.75", got)
+	}
+}
+
+func TestCumulativeProjectedSteps(t *testing.T) {
+	tracker := &ErrorTracker{Enabled: true}
+	tracker.RecordStep(true)
+	tracker.RecordStep(false) // p_a = 0.5
+	want := 1 - math.Pow(0.5, 10)
+	if got := tracker.CumulativeFailureProbabilityOver(10); !approxEqual(got, want) {
+		t.Errorf("CumulativeFailureProbabilityOver(10) = %v, want %v", got, want)
+	}
+}
+
+func TestCumulativeCompoundingSmallRate(t *testing.T) {
+	// The motivating case: a small per-step rate compounds over a long run.
+	tracker := &ErrorTracker{Enabled: true}
+	// p_a = 0.01 (1 failure in 100)
+	tracker.RecordStep(false)
+	for i := 0; i < 99; i++ {
+		tracker.RecordStep(true)
+	}
+	if got := tracker.PerStepErrorRate(); !approxEqual(got, 0.01) {
+		t.Errorf("PerStepErrorRate = %v, want 0.01", got)
+	}
+	// Over 100 steps: 1 - 0.99^100 ~= 0.634
+	pError := tracker.CumulativeFailureProbabilityOver(100)
+	want := 1 - math.Pow(0.99, 100)
+	if !approxEqual(pError, want) {
+		t.Errorf("CumulativeFailureProbabilityOver(100) = %v, want %v", pError, want)
+	}
+	if pError <= 0.63 || pError >= 0.64 {
+		t.Errorf("P_error = %v, want 0.63 < P_error < 0.64", pError)
+	}
+}
+
+func TestCumulativeZeroRateIsZero(t *testing.T) {
+	tracker := &ErrorTracker{Enabled: true}
+	for i := 0; i < 10; i++ {
+		tracker.RecordStep(true)
+	}
+	if got := tracker.CumulativeFailureProbabilityOver(1000); got != 0.0 {
+		t.Errorf("CumulativeFailureProbabilityOver(1000) = %v, want 0.0", got)
+	}
+}
+
+func TestCumulativeFullRateIsOne(t *testing.T) {
+	tracker := &ErrorTracker{Enabled: true}
+	tracker.RecordStep(false)
+	if got := tracker.CumulativeFailureProbabilityOver(5); !approxEqual(got, 1.0) {
+		t.Errorf("CumulativeFailureProbabilityOver(5) = %v, want 1.0", got)
+	}
+}
+
+func TestCumulativeNonpositiveStepsIsZero(t *testing.T) {
+	tracker := &ErrorTracker{Enabled: true}
+	tracker.RecordStep(false)
+	if got := tracker.CumulativeFailureProbabilityOver(0); got != 0.0 {
+		t.Errorf("CumulativeFailureProbabilityOver(0) = %v, want 0.0", got)
+	}
+	if got := tracker.CumulativeFailureProbabilityOver(-3); got != 0.0 {
+		t.Errorf("CumulativeFailureProbabilityOver(-3) = %v, want 0.0", got)
+	}
+}
+
+func TestCumulativeInUnitInterval(t *testing.T) {
+	tracker := &ErrorTracker{Enabled: true}
+	for _, ok := range []bool{true, false, true, false, false} {
+		tracker.RecordStep(ok)
+	}
+	for n := 1; n < 50; n++ {
+		p := tracker.CumulativeFailureProbabilityOver(n)
+		if p < 0.0 || p > 1.0 {
+			t.Errorf("CumulativeFailureProbabilityOver(%d) = %v, out of [0,1]", n, p)
+		}
+		if math.IsNaN(p) {
+			t.Errorf("CumulativeFailureProbabilityOver(%d) = NaN", n)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Reset + docstring example
+// ---------------------------------------------------------------------------
+
+func TestResetClearsSteps(t *testing.T) {
+	tracker := &ErrorTracker{Enabled: true}
+	tracker.RecordStep(true)
+	tracker.RecordStep(false)
+	tracker.Reset()
+	if tracker.TotalSteps() != 0 {
+		t.Errorf("TotalSteps = %d, want 0", tracker.TotalSteps())
+	}
+	if got := tracker.PerStepErrorRate(); got != 0.0 {
+		t.Errorf("PerStepErrorRate = %v, want 0.0", got)
+	}
+}
+
+func TestDocstringExampleValues(t *testing.T) {
+	tracker := &ErrorTracker{Enabled: true}
+	tracker.RecordStep(true)
+	tracker.RecordStep(false, WithStepError("timeout"))
+	if got := tracker.PerStepErrorRate(); got != 0.5 {
+		t.Errorf("PerStepErrorRate = %v, want 0.5", got)
+	}
+	// round(P_error over 10, 4) == 0.999
+	got := math.Round(tracker.CumulativeFailureProbabilityOver(10)*10000) / 10000
+	if got != 0.999 {
+		t.Errorf("rounded CumulativeFailureProbabilityOver(10) = %v, want 0.999", got)
+	}
+}

--- a/agenkit-rust/src/evaluation/error_tracker.rs
+++ b/agenkit-rust/src/evaluation/error_tracker.rs
@@ -1,0 +1,326 @@
+//! Error Tracking — per-step error rate and failure compounding.
+//!
+//! Long-running agents execute many steps; even a small per-step error rate
+//! compounds into a high probability of at least one failure over a long run.
+//! [`ErrorTracker`] records the outcome of each step and exposes the two core
+//! quantities from the agent-failure-rate analysis:
+//!
+//! - `p_a` ([`ErrorTracker::per_step_error_rate`]) — the per-step error rate,
+//!   `failed_steps / total_steps`.
+//! - `P_error` ([`ErrorTracker::cumulative_failure_probability`]) — the
+//!   probability of at least one failure across `n` independent steps,
+//!   `1 - (1 - p_a).powi(n)`. With `None`, `n` is the number of recorded steps
+//!   (observed cumulative failure probability); pass `Some(N)` to project the
+//!   compounding over a planned run of `N` steps.
+//!
+//! Tracking is opt-in: construct an `ErrorTracker::new(true)` and call
+//! [`ErrorTracker::record_step`] as steps complete. When disabled (the
+//! default), `record_step` is a no-op and the metrics report zero, so the
+//! tracker is cheap to leave wired in.
+//!
+//! # Example
+//!
+//! ```
+//! use agenkit::evaluation::error_tracker::ErrorTracker;
+//!
+//! let mut tracker = ErrorTracker::new(true);
+//! tracker.record_step(true);
+//! tracker.record_step(false);
+//! assert_eq!(tracker.per_step_error_rate(), 0.5);
+//! ```
+
+/// Outcome of a single agent step.
+#[derive(Debug, Clone)]
+pub struct StepResult {
+    /// Whether the step completed without error.
+    pub success: bool,
+    /// Optional step label (useful for per-step breakdowns later).
+    pub name: Option<String>,
+    /// Optional error description when `success` is `false`.
+    pub error: Option<String>,
+}
+
+impl StepResult {
+    /// Creates a step result with optional `name` and `error`.
+    pub fn new(success: bool, name: Option<String>, error: Option<String>) -> Self {
+        Self {
+            success,
+            name,
+            error,
+        }
+    }
+}
+
+/// Records step outcomes and computes error-rate / compounding metrics.
+///
+/// When `enabled` is `false` (the default), [`record_step`](Self::record_step)
+/// is a no-op and all metrics report `0.0` / `0` — tracking is strictly opt-in.
+#[derive(Debug, Clone, Default)]
+pub struct ErrorTracker {
+    enabled: bool,
+    step_results: Vec<StepResult>,
+}
+
+impl ErrorTracker {
+    /// Creates a new tracker.
+    ///
+    /// # Arguments
+    ///
+    /// * `enabled` - When `false`, [`record_step`](Self::record_step) is a
+    ///   no-op and all metrics report zero.
+    pub fn new(enabled: bool) -> Self {
+        Self {
+            enabled,
+            step_results: Vec::new(),
+        }
+    }
+
+    /// Records the outcome of one step (no-op when disabled).
+    ///
+    /// Convenience for the common case of recording only success/failure. To
+    /// attach a step label or error description, use [`record`](Self::record).
+    pub fn record_step(&mut self, success: bool) {
+        self.record(StepResult::new(success, None, None));
+    }
+
+    /// Records a fully-specified step result (no-op when disabled).
+    ///
+    /// Mirrors the Python `record_step(success, *, name, error)` signature via
+    /// a [`StepResult`] argument.
+    pub fn record(&mut self, result: StepResult) {
+        if !self.enabled {
+            return;
+        }
+        self.step_results.push(result);
+    }
+
+    /// Number of recorded steps.
+    pub fn total_steps(&self) -> usize {
+        self.step_results.len()
+    }
+
+    /// Number of recorded steps that failed.
+    pub fn failed_steps(&self) -> usize {
+        self.step_results.iter().filter(|r| !r.success).count()
+    }
+
+    /// Per-step error rate `p_a` = `failed_steps / total_steps`.
+    ///
+    /// Returns `0.0` when no steps have been recorded.
+    pub fn per_step_error_rate(&self) -> f64 {
+        let total = self.total_steps();
+        if total == 0 {
+            return 0.0;
+        }
+        self.failed_steps() as f64 / total as f64
+    }
+
+    /// Probability of at least one failure over `steps` steps.
+    ///
+    /// `P_error = 1 - (1 - p_a).powi(n)` where `n` is `steps` if given,
+    /// otherwise the number of recorded steps. Models error compounding:
+    /// independent steps each succeed with probability `1 - p_a`, so the run
+    /// succeeds only if all `n` succeed.
+    ///
+    /// # Arguments
+    ///
+    /// * `steps` - Project the compounding over this many steps. Defaults
+    ///   (`None`) to the number of recorded steps (observed cumulative
+    ///   probability).
+    ///
+    /// Returns a probability in `[0.0, 1.0]`. Returns `0.0` if `p_a` is 0 or
+    /// `n == 0`.
+    pub fn cumulative_failure_probability(&self, steps: Option<usize>) -> f64 {
+        let n = steps.unwrap_or_else(|| self.total_steps());
+        if n == 0 {
+            return 0.0;
+        }
+        let p_a = self.per_step_error_rate();
+        1.0 - (1.0 - p_a).powi(n as i32)
+    }
+
+    /// Clears all recorded step results.
+    pub fn reset(&mut self) {
+        self.step_results.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const EPSILON: f64 = 1e-9;
+
+    fn approx(a: f64, b: f64) {
+        assert!((a - b).abs() < EPSILON, "expected {b}, got {a}");
+    }
+
+    #[test]
+    fn test_default_disabled() {
+        let mut tracker = ErrorTracker::default();
+        tracker.record_step(false);
+        tracker.record_step(true);
+        // Disabled: nothing recorded.
+        assert_eq!(tracker.total_steps(), 0);
+        assert_eq!(tracker.failed_steps(), 0);
+        approx(tracker.per_step_error_rate(), 0.0);
+    }
+
+    #[test]
+    fn test_disabled_no_op() {
+        let mut tracker = ErrorTracker::new(false);
+        for _ in 0..10 {
+            tracker.record_step(false);
+        }
+        assert_eq!(tracker.total_steps(), 0);
+        approx(tracker.cumulative_failure_probability(Some(100)), 0.0);
+    }
+
+    #[test]
+    fn test_per_step_error_rate_empty() {
+        let tracker = ErrorTracker::new(true);
+        approx(tracker.per_step_error_rate(), 0.0);
+    }
+
+    #[test]
+    fn test_per_step_error_rate_all_pass() {
+        let mut tracker = ErrorTracker::new(true);
+        for _ in 0..4 {
+            tracker.record_step(true);
+        }
+        approx(tracker.per_step_error_rate(), 0.0);
+    }
+
+    #[test]
+    fn test_per_step_error_rate_all_fail() {
+        let mut tracker = ErrorTracker::new(true);
+        for _ in 0..4 {
+            tracker.record_step(false);
+        }
+        approx(tracker.per_step_error_rate(), 1.0);
+    }
+
+    #[test]
+    fn test_per_step_error_rate_mixed() {
+        let mut tracker = ErrorTracker::new(true);
+        tracker.record_step(true);
+        tracker.record_step(false);
+        tracker.record_step(true);
+        tracker.record_step(true);
+        // 1 failure out of 4 => 0.25
+        approx(tracker.per_step_error_rate(), 0.25);
+    }
+
+    #[test]
+    fn test_compounding_one_percent_over_hundred() {
+        // p_a = 0.01 observed over 100 steps -> ~0.634.
+        let mut tracker = ErrorTracker::new(true);
+        tracker.record(StepResult::new(false, None, Some("boom".to_string())));
+        for _ in 0..99 {
+            tracker.record_step(true);
+        }
+        approx(tracker.per_step_error_rate(), 0.01);
+        let p = tracker.cumulative_failure_probability(None);
+        assert!((p - 0.634).abs() < 1e-3, "expected ~0.634, got {p}");
+    }
+
+    #[test]
+    fn test_compounding_projected() {
+        // p_a = 0.01, project over 100 steps.
+        let mut tracker = ErrorTracker::new(true);
+        tracker.record_step(false);
+        for _ in 0..99 {
+            tracker.record_step(true);
+        }
+        let projected = tracker.cumulative_failure_probability(Some(100));
+        approx(projected, 1.0 - 0.99_f64.powi(100));
+        assert!((projected - 0.634).abs() < 1e-3);
+    }
+
+    #[test]
+    fn test_compounding_observed() {
+        // Observed: n = total recorded steps (2), p_a = 0.5.
+        let mut tracker = ErrorTracker::new(true);
+        tracker.record_step(true);
+        tracker.record_step(false);
+        let observed = tracker.cumulative_failure_probability(None);
+        approx(observed, 1.0 - 0.5_f64.powi(2)); // 0.75
+    }
+
+    #[test]
+    fn test_compounding_zero_rate() {
+        let mut tracker = ErrorTracker::new(true);
+        for _ in 0..10 {
+            tracker.record_step(true);
+        }
+        approx(tracker.cumulative_failure_probability(None), 0.0);
+        approx(tracker.cumulative_failure_probability(Some(1000)), 0.0);
+    }
+
+    #[test]
+    fn test_compounding_full_rate() {
+        let mut tracker = ErrorTracker::new(true);
+        for _ in 0..3 {
+            tracker.record_step(false);
+        }
+        // p_a = 1.0 -> 1 - 0^n = 1.0
+        approx(tracker.cumulative_failure_probability(None), 1.0);
+        approx(tracker.cumulative_failure_probability(Some(5)), 1.0);
+    }
+
+    #[test]
+    fn test_compounding_n_zero() {
+        let mut tracker = ErrorTracker::new(true);
+        tracker.record_step(false);
+        // Explicit n == 0 short-circuits to 0.0 even with p_a > 0.
+        approx(tracker.cumulative_failure_probability(Some(0)), 0.0);
+        // Observed n == 0 when nothing recorded.
+        let empty = ErrorTracker::new(true);
+        approx(empty.cumulative_failure_probability(None), 0.0);
+    }
+
+    #[test]
+    fn test_compounding_in_unit_interval() {
+        // Invariant: P_error is always within [0.0, 1.0].
+        let mut tracker = ErrorTracker::new(true);
+        tracker.record_step(false);
+        tracker.record_step(true);
+        tracker.record_step(false);
+        tracker.record_step(true);
+        tracker.record_step(true);
+        for n in [0usize, 1, 5, 10, 100, 10_000] {
+            let p = tracker.cumulative_failure_probability(Some(n));
+            assert!(
+                (0.0..=1.0).contains(&p),
+                "P_error {p} out of [0,1] for n={n}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_record_with_name_and_error() {
+        let mut tracker = ErrorTracker::new(true);
+        tracker.record(StepResult::new(
+            false,
+            Some("fetch".to_string()),
+            Some("timeout".to_string()),
+        ));
+        assert_eq!(tracker.total_steps(), 1);
+        assert_eq!(tracker.failed_steps(), 1);
+    }
+
+    #[test]
+    fn test_reset() {
+        let mut tracker = ErrorTracker::new(true);
+        tracker.record_step(false);
+        tracker.record_step(true);
+        assert_eq!(tracker.total_steps(), 2);
+        tracker.reset();
+        assert_eq!(tracker.total_steps(), 0);
+        assert_eq!(tracker.failed_steps(), 0);
+        approx(tracker.per_step_error_rate(), 0.0);
+        // Still enabled after reset.
+        tracker.record_step(false);
+        assert_eq!(tracker.total_steps(), 1);
+    }
+}

--- a/agenkit-rust/src/evaluation/mod.rs
+++ b/agenkit-rust/src/evaluation/mod.rs
@@ -40,6 +40,7 @@ pub mod ab_testing;
 pub mod benchmarks;
 pub mod context_metrics;
 pub mod core;
+pub mod error_tracker;
 pub mod metrics;
 pub mod optimizer;
 pub mod prompt_optimizer;
@@ -55,6 +56,7 @@ pub use benchmarks::{
 };
 pub use context_metrics::{CompressionMetrics, CompressionStats, ContextMetrics, LatencyMetric};
 pub use core::{EvaluationResult, Evaluator, Metric};
+pub use error_tracker::{ErrorTracker, StepResult};
 pub use metrics::{
     ErrorRecord, MetricMeasurement, MetricType, MetricsCollector, SessionResult, SessionStatus,
 };

--- a/agenkit-ts/src/__tests__/error-tracker.test.ts
+++ b/agenkit-ts/src/__tests__/error-tracker.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Tests for ErrorTracker — per-step error rate and failure compounding.
+ */
+
+import { ErrorTracker } from '../evaluation/error-tracker';
+
+describe('ErrorTracker', () => {
+  describe('perStepErrorRate (p_a)', () => {
+    it('returns 0 when no steps recorded', () => {
+      const tracker = new ErrorTracker(true);
+      expect(tracker.perStepErrorRate()).toBeCloseTo(0.0);
+      expect(tracker.totalSteps).toBe(0);
+      expect(tracker.failedSteps).toBe(0);
+    });
+
+    it('returns 0 when all steps pass', () => {
+      const tracker = new ErrorTracker(true);
+      for (let i = 0; i < 4; i++) {
+        tracker.recordStep(true);
+      }
+      expect(tracker.perStepErrorRate()).toBeCloseTo(0.0);
+      expect(tracker.totalSteps).toBe(4);
+      expect(tracker.failedSteps).toBe(0);
+    });
+
+    it('returns 1 when all steps fail', () => {
+      const tracker = new ErrorTracker(true);
+      for (let i = 0; i < 4; i++) {
+        tracker.recordStep(false, { error: 'boom' });
+      }
+      expect(tracker.perStepErrorRate()).toBeCloseTo(1.0);
+      expect(tracker.totalSteps).toBe(4);
+      expect(tracker.failedSteps).toBe(4);
+    });
+
+    it('returns 0.25 for a mixed run (1 of 4 failed)', () => {
+      const tracker = new ErrorTracker(true);
+      tracker.recordStep(true);
+      tracker.recordStep(false, { error: 'timeout' });
+      tracker.recordStep(true);
+      tracker.recordStep(true);
+      expect(tracker.perStepErrorRate()).toBeCloseTo(0.25);
+      expect(tracker.totalSteps).toBe(4);
+      expect(tracker.failedSteps).toBe(1);
+    });
+  });
+
+  describe('cumulativeFailureProbability (P_error)', () => {
+    it('compounds a 1% per-step rate over 100 steps to ~0.634', () => {
+      const tracker = new ErrorTracker(true);
+      // 1 failure out of 100 steps -> p_a = 0.01
+      tracker.recordStep(false);
+      for (let i = 0; i < 99; i++) {
+        tracker.recordStep(true);
+      }
+      expect(tracker.perStepErrorRate()).toBeCloseTo(0.01);
+      // observed over the 100 recorded steps
+      expect(tracker.cumulativeFailureProbability()).toBeCloseTo(0.6340, 3);
+    });
+
+    it('projects compounding over a planned number of steps', () => {
+      const tracker = new ErrorTracker(true);
+      tracker.recordStep(true);
+      tracker.recordStep(false);
+      // p_a = 0.5, projected over 10 steps -> 1 - 0.5^10 = 0.999023...
+      expect(tracker.perStepErrorRate()).toBeCloseTo(0.5);
+      expect(tracker.cumulativeFailureProbability(10)).toBeCloseTo(0.999023, 5);
+    });
+
+    it('uses recorded step count as n when no argument given (observed)', () => {
+      const tracker = new ErrorTracker(true);
+      tracker.recordStep(true);
+      tracker.recordStep(false);
+      tracker.recordStep(true);
+      tracker.recordStep(false);
+      // p_a = 0.5, n = 4 -> 1 - 0.5^4 = 0.9375
+      expect(tracker.cumulativeFailureProbability()).toBeCloseTo(0.9375);
+    });
+
+    it('returns 0 when p_a is 0', () => {
+      const tracker = new ErrorTracker(true);
+      tracker.recordStep(true);
+      tracker.recordStep(true);
+      expect(tracker.cumulativeFailureProbability()).toBeCloseTo(0.0);
+      expect(tracker.cumulativeFailureProbability(1000)).toBeCloseTo(0.0);
+    });
+
+    it('returns 1 when p_a is 1 (full failure)', () => {
+      const tracker = new ErrorTracker(true);
+      tracker.recordStep(false);
+      tracker.recordStep(false);
+      expect(tracker.cumulativeFailureProbability()).toBeCloseTo(1.0);
+      expect(tracker.cumulativeFailureProbability(5)).toBeCloseTo(1.0);
+    });
+
+    it('returns 0 for non-positive n', () => {
+      const tracker = new ErrorTracker(true);
+      tracker.recordStep(false);
+      tracker.recordStep(true);
+      expect(tracker.cumulativeFailureProbability(0)).toBeCloseTo(0.0);
+      expect(tracker.cumulativeFailureProbability(-5)).toBeCloseTo(0.0);
+    });
+
+    it('returns 0 when nothing recorded and no steps given', () => {
+      const tracker = new ErrorTracker(true);
+      expect(tracker.cumulativeFailureProbability()).toBeCloseTo(0.0);
+    });
+
+    it('stays within [0, 1] across a range of rates and step counts', () => {
+      for (const failures of [0, 1, 3, 7, 10]) {
+        const tracker = new ErrorTracker(true);
+        for (let i = 0; i < failures; i++) {
+          tracker.recordStep(false);
+        }
+        for (let i = failures; i < 10; i++) {
+          tracker.recordStep(true);
+        }
+        for (const n of [1, 5, 50, 500]) {
+          const p = tracker.cumulativeFailureProbability(n);
+          expect(p).toBeGreaterThanOrEqual(0.0);
+          expect(p).toBeLessThanOrEqual(1.0);
+        }
+      }
+    });
+  });
+
+  describe('disabled tracker', () => {
+    it('is a no-op by default (recordStep records nothing, metrics are 0)', () => {
+      const tracker = new ErrorTracker();
+      expect(tracker.enabled).toBe(false);
+      tracker.recordStep(false, { error: 'ignored' });
+      tracker.recordStep(true);
+      expect(tracker.totalSteps).toBe(0);
+      expect(tracker.failedSteps).toBe(0);
+      expect(tracker.perStepErrorRate()).toBeCloseTo(0.0);
+      expect(tracker.cumulativeFailureProbability(100)).toBeCloseTo(0.0);
+    });
+  });
+
+  describe('reset', () => {
+    it('clears all recorded step results', () => {
+      const tracker = new ErrorTracker(true);
+      tracker.recordStep(false);
+      tracker.recordStep(true);
+      expect(tracker.totalSteps).toBe(2);
+
+      tracker.reset();
+      expect(tracker.totalSteps).toBe(0);
+      expect(tracker.failedSteps).toBe(0);
+      expect(tracker.perStepErrorRate()).toBeCloseTo(0.0);
+      expect(tracker.cumulativeFailureProbability()).toBeCloseTo(0.0);
+
+      // still enabled and usable after reset
+      tracker.recordStep(false);
+      expect(tracker.totalSteps).toBe(1);
+      expect(tracker.perStepErrorRate()).toBeCloseTo(1.0);
+    });
+  });
+});

--- a/agenkit-ts/src/evaluation/error-tracker.ts
+++ b/agenkit-ts/src/evaluation/error-tracker.ts
@@ -1,0 +1,134 @@
+/**
+ * Error tracking infrastructure — per-step error rate and failure compounding.
+ *
+ * Long-running agents execute many steps; even a small per-step error rate
+ * compounds into a high probability of at least one failure over a long run.
+ * `ErrorTracker` records the outcome of each step and exposes the two core
+ * quantities from the agent-failure-rate analysis:
+ *
+ * - `p_a` ({@link ErrorTracker.perStepErrorRate}) — the per-step error rate,
+ *   `failedSteps / totalSteps`.
+ * - `P_error` ({@link ErrorTracker.cumulativeFailureProbability}) — the
+ *   probability of at least one failure across `n` independent steps,
+ *   `1 - (1 - p_a) ** n`. With no argument, `n` is the number of recorded
+ *   steps (observed cumulative failure probability); pass `steps=N` to project
+ *   the compounding over a planned run of `N` steps.
+ *
+ * Tracking is opt-in: construct an `ErrorTracker(true)` and call
+ * {@link ErrorTracker.recordStep} as steps complete. When disabled,
+ * `recordStep` is a no-op and the metrics report zero, so the tracker is cheap
+ * to leave wired in.
+ *
+ * Example:
+ * ```typescript
+ * const tracker = new ErrorTracker(true);
+ * tracker.recordStep(true);
+ * tracker.recordStep(false, { error: 'timeout' });
+ * tracker.perStepErrorRate(); // 0.5
+ * tracker.cumulativeFailureProbability(10); // ~0.999
+ * ```
+ */
+
+/**
+ * Outcome of a single agent step.
+ */
+export interface StepResult {
+  /** Whether the step completed without error. */
+  success: boolean;
+  /** Optional step label (useful for per-step breakdowns later). */
+  name?: string;
+  /** Optional error description when `success` is `false`. */
+  error?: string;
+}
+
+/**
+ * Options for recording a step outcome.
+ */
+export interface RecordStepOptions {
+  /** Optional step label. */
+  name?: string;
+  /** Optional error description for a failed step. */
+  error?: string;
+}
+
+/**
+ * Records step outcomes and computes error-rate / compounding metrics.
+ *
+ * When disabled (the default), {@link ErrorTracker.recordStep} is a no-op and
+ * all metrics report `0` / `0.0` — tracking is strictly opt-in.
+ */
+export class ErrorTracker {
+  private readonly stepResults: StepResult[] = [];
+
+  /**
+   * @param enabled When `false` (the default), `recordStep` is a no-op and all
+   *   metrics report `0`/`0.0`.
+   */
+  constructor(public readonly enabled: boolean = false) {}
+
+  /**
+   * Record the outcome of one step (no-op when disabled).
+   *
+   * @param success Whether the step succeeded.
+   * @param options Optional step label and error description.
+   */
+  recordStep(success: boolean, options: RecordStepOptions = {}): void {
+    if (!this.enabled) {
+      return;
+    }
+    this.stepResults.push({
+      success,
+      name: options.name,
+      error: options.error,
+    });
+  }
+
+  /** Number of recorded steps. */
+  get totalSteps(): number {
+    return this.stepResults.length;
+  }
+
+  /** Number of recorded steps that failed. */
+  get failedSteps(): number {
+    return this.stepResults.filter((r) => !r.success).length;
+  }
+
+  /**
+   * Per-step error rate `p_a` = failedSteps / totalSteps.
+   *
+   * @returns `0.0` when no steps have been recorded.
+   */
+  perStepErrorRate(): number {
+    if (this.totalSteps === 0) {
+      return 0.0;
+    }
+    return this.failedSteps / this.totalSteps;
+  }
+
+  /**
+   * Probability of at least one failure over `steps` steps.
+   *
+   * `P_error = 1 - (1 - p_a) ** n` where `n` is `steps` if given, otherwise the
+   * number of recorded steps. Models error compounding: independent steps each
+   * succeed with probability `1 - p_a`, so the run succeeds only if all `n`
+   * succeed.
+   *
+   * @param steps Project the compounding over this many steps. Defaults to the
+   *   number of recorded steps (observed cumulative probability).
+   * @returns A probability in `[0.0, 1.0]`. Returns `0.0` if `p_a` is 0 or
+   *   `n <= 0`.
+   */
+  cumulativeFailureProbability(steps?: number): number {
+    const n = steps === undefined ? this.totalSteps : steps;
+    if (n <= 0) {
+      return 0.0;
+    }
+    const pA = this.perStepErrorRate();
+    return 1.0 - (1.0 - pA) ** n;
+  }
+
+  /** Clear all recorded step results. */
+  reset(): void {
+    this.stepResults.length = 0;
+  }
+}

--- a/agenkit-ts/src/evaluation/index.ts
+++ b/agenkit-ts/src/evaluation/index.ts
@@ -200,6 +200,13 @@ export {
   CompressionMetrics,
 } from './context-metrics';
 
+// Error tracking
+export {
+  type StepResult,
+  type RecordStepOptions,
+  ErrorTracker,
+} from './error-tracker';
+
 // A/B testing
 export {
   SignificanceLevel,

--- a/agenkit-ts/src/index.ts
+++ b/agenkit-ts/src/index.ts
@@ -250,6 +250,11 @@ export {
   compressionStatsToDict,
 } from './evaluation/context-metrics';
 export {
+  ErrorTracker,
+  StepResult,
+  RecordStepOptions,
+} from './evaluation/error-tracker';
+export {
   SessionRecorder,
   SessionReplay,
   RecordingStorage,

--- a/agenkit-zig/src/evaluation/error_tracker.zig
+++ b/agenkit-zig/src/evaluation/error_tracker.zig
@@ -1,0 +1,231 @@
+//! Error tracking — per-step error rate and failure compounding.
+//!
+//! Long-running agents execute many steps; even a small per-step error rate
+//! compounds into a high probability of at least one failure over a long run.
+//! `ErrorTracker` records each step's outcome and exposes:
+//!
+//! - `p_a` (`perStepErrorRate`) — per-step error rate, failed/total.
+//! - `P_error` (`cumulativeFailureProbability`) — probability of at least one
+//!   failure across `n` independent steps, `1 - (1 - p_a)^n`. With `null`, `n`
+//!   is the number of recorded steps (observed); pass a value to project the
+//!   compounding over a planned run.
+//!
+//! Tracking is opt-in: a tracker with `enabled = false` (the default) treats
+//! `recordStep` as a no-op and reports zero, so it is cheap to leave wired in.
+//!
+//! Mirrors the Python reference (agenkit/evaluation/error_tracker.py).
+
+const std = @import("std");
+
+/// Outcome of a single agent step.
+///
+/// `name`/`err` are borrowed slices: the caller owns their backing memory and
+/// must keep it alive for the tracker's lifetime (the tracker does not dupe).
+/// (`err` rather than `error`, which is a Zig keyword.)
+pub const StepResult = struct {
+    success: bool,
+    name: ?[]const u8 = null,
+    err: ?[]const u8 = null,
+};
+
+/// Records step outcomes and computes error-rate / compounding metrics.
+pub const ErrorTracker = struct {
+    enabled: bool,
+    step_results: std.ArrayList(StepResult),
+    allocator: std.mem.Allocator,
+
+    /// Initialize a tracker. `enabled = false` makes `recordStep` a no-op.
+    pub fn init(allocator: std.mem.Allocator, enabled: bool) ErrorTracker {
+        return .{
+            .enabled = enabled,
+            .step_results = std.ArrayList(StepResult).empty,
+            .allocator = allocator,
+        };
+    }
+
+    pub fn deinit(self: *ErrorTracker) void {
+        self.step_results.deinit(self.allocator);
+    }
+
+    /// Record one step's outcome. No-op when disabled. Returns an error only if
+    /// the backing append allocation fails.
+    pub fn recordStep(
+        self: *ErrorTracker,
+        success: bool,
+        name: ?[]const u8,
+        err: ?[]const u8,
+    ) !void {
+        if (!self.enabled) return;
+        try self.step_results.append(self.allocator, .{
+            .success = success,
+            .name = name,
+            .err = err,
+        });
+    }
+
+    /// Number of recorded steps.
+    pub fn totalSteps(self: *const ErrorTracker) usize {
+        return self.step_results.items.len;
+    }
+
+    /// Number of recorded steps that failed.
+    pub fn failedSteps(self: *const ErrorTracker) usize {
+        var count: usize = 0;
+        for (self.step_results.items) |r| {
+            if (!r.success) count += 1;
+        }
+        return count;
+    }
+
+    /// Per-step error rate `p_a` = failed/total. 0.0 when no steps recorded.
+    pub fn perStepErrorRate(self: *const ErrorTracker) f64 {
+        const total = self.totalSteps();
+        if (total == 0) return 0.0;
+        return @as(f64, @floatFromInt(self.failedSteps())) / @as(f64, @floatFromInt(total));
+    }
+
+    /// Probability of at least one failure over `steps` steps:
+    /// `P_error = 1 - (1 - p_a)^n`, where `n` is `steps` if given, otherwise the
+    /// number of recorded steps. Returns 0.0 if `p_a` is 0 or `n == 0`.
+    pub fn cumulativeFailureProbability(self: *const ErrorTracker, steps: ?usize) f64 {
+        const n = steps orelse self.totalSteps();
+        if (n == 0) return 0.0;
+        const p_a = self.perStepErrorRate();
+        if (p_a == 0.0) return 0.0;
+        return 1.0 - std.math.pow(f64, 1.0 - p_a, @floatFromInt(n));
+    }
+
+    /// Clear all recorded step results.
+    pub fn reset(self: *ErrorTracker) void {
+        self.step_results.clearRetainingCapacity();
+    }
+};
+
+// ---------------------------------------------------------------------------
+// Tests (ported from tests/evaluation/test_error_tracker.py)
+// ---------------------------------------------------------------------------
+
+const testing = std.testing;
+
+test "StepResult defaults" {
+    const r = StepResult{ .success = true };
+    try testing.expect(r.success);
+    try testing.expect(r.name == null);
+    try testing.expect(r.err == null);
+}
+
+test "disabled by default records nothing" {
+    var t = ErrorTracker.init(testing.allocator, false);
+    defer t.deinit();
+    try testing.expect(!t.enabled);
+    try t.recordStep(false, null, "boom");
+    try testing.expectEqual(@as(usize, 0), t.totalSteps());
+    try testing.expectEqual(@as(usize, 0), t.failedSteps());
+    try testing.expectEqual(@as(f64, 0.0), t.perStepErrorRate());
+    try testing.expectEqual(@as(f64, 0.0), t.cumulativeFailureProbability(null));
+}
+
+test "enabled records steps" {
+    var t = ErrorTracker.init(testing.allocator, true);
+    defer t.deinit();
+    try t.recordStep(true, null, null);
+    try t.recordStep(false, null, "x");
+    try testing.expectEqual(@as(usize, 2), t.totalSteps());
+    try testing.expectEqual(@as(usize, 1), t.failedSteps());
+}
+
+test "per_step_error_rate empty/all-pass/all-fail/mixed" {
+    var empty = ErrorTracker.init(testing.allocator, true);
+    defer empty.deinit();
+    try testing.expectEqual(@as(f64, 0.0), empty.perStepErrorRate());
+
+    var pass = ErrorTracker.init(testing.allocator, true);
+    defer pass.deinit();
+    for (0..5) |_| try pass.recordStep(true, null, null);
+    try testing.expectEqual(@as(f64, 0.0), pass.perStepErrorRate());
+
+    var fail = ErrorTracker.init(testing.allocator, true);
+    defer fail.deinit();
+    for (0..4) |_| try fail.recordStep(false, null, null);
+    try testing.expectEqual(@as(f64, 1.0), fail.perStepErrorRate());
+
+    var mixed = ErrorTracker.init(testing.allocator, true);
+    defer mixed.deinit();
+    const outcomes = [_]bool{ true, false, true, true, false, true, true, true };
+    for (outcomes) |ok| try mixed.recordStep(ok, null, null);
+    try testing.expectApproxEqAbs(@as(f64, 0.25), mixed.perStepErrorRate(), 1e-9);
+}
+
+test "cumulative observed uses recorded step count" {
+    var t = ErrorTracker.init(testing.allocator, true);
+    defer t.deinit();
+    try t.recordStep(true, null, null);
+    try t.recordStep(false, null, null);
+    // p_a = 0.5, n = 2 -> 1 - 0.5^2 = 0.75
+    try testing.expectApproxEqAbs(@as(f64, 0.75), t.cumulativeFailureProbability(null), 1e-9);
+}
+
+test "cumulative projected steps" {
+    var t = ErrorTracker.init(testing.allocator, true);
+    defer t.deinit();
+    try t.recordStep(true, null, null);
+    try t.recordStep(false, null, null);
+    const expected = 1.0 - std.math.pow(f64, 0.5, 10);
+    try testing.expectApproxEqAbs(expected, t.cumulativeFailureProbability(10), 1e-9);
+}
+
+test "cumulative compounding small rate (1% over 100 ~= 0.634)" {
+    var t = ErrorTracker.init(testing.allocator, true);
+    defer t.deinit();
+    try t.recordStep(false, null, null);
+    for (0..99) |_| try t.recordStep(true, null, null);
+    try testing.expectApproxEqAbs(@as(f64, 0.01), t.perStepErrorRate(), 1e-9);
+    const p_error = t.cumulativeFailureProbability(100);
+    try testing.expect(p_error > 0.63 and p_error < 0.64);
+}
+
+test "cumulative zero rate is zero / full rate is one / non-positive n" {
+    var zero = ErrorTracker.init(testing.allocator, true);
+    defer zero.deinit();
+    for (0..10) |_| try zero.recordStep(true, null, null);
+    try testing.expectEqual(@as(f64, 0.0), zero.cumulativeFailureProbability(1000));
+
+    var full = ErrorTracker.init(testing.allocator, true);
+    defer full.deinit();
+    try full.recordStep(false, null, null);
+    try testing.expectApproxEqAbs(@as(f64, 1.0), full.cumulativeFailureProbability(5), 1e-9);
+    // n == 0 -> 0.0
+    try testing.expectEqual(@as(f64, 0.0), full.cumulativeFailureProbability(0));
+}
+
+test "cumulative stays in [0,1]" {
+    var t = ErrorTracker.init(testing.allocator, true);
+    defer t.deinit();
+    const outcomes = [_]bool{ true, false, true, false, false };
+    for (outcomes) |ok| try t.recordStep(ok, null, null);
+    var n: usize = 1;
+    while (n < 50) : (n += 1) {
+        const p = t.cumulativeFailureProbability(n);
+        try testing.expect(p >= 0.0 and p <= 1.0);
+    }
+}
+
+test "reset clears steps" {
+    var t = ErrorTracker.init(testing.allocator, true);
+    defer t.deinit();
+    try t.recordStep(true, null, null);
+    try t.recordStep(false, null, null);
+    t.reset();
+    try testing.expectEqual(@as(usize, 0), t.totalSteps());
+    try testing.expectEqual(@as(f64, 0.0), t.perStepErrorRate());
+}
+
+test "docstring example values" {
+    var t = ErrorTracker.init(testing.allocator, true);
+    defer t.deinit();
+    try t.recordStep(true, null, null);
+    try t.recordStep(false, null, "timeout");
+    try testing.expectEqual(@as(f64, 0.5), t.perStepErrorRate());
+    // 1 - 0.5^10 rounds to 0.999
+    try testing.expectApproxEqAbs(@as(f64, 0.999), t.cumulativeFailureProbability(10), 1e-3);
+}

--- a/agenkit-zig/src/evaluation/mod.zig
+++ b/agenkit-zig/src/evaluation/mod.zig
@@ -116,6 +116,11 @@ pub const AgentFactory = prompt_optimizer.AgentFactory;
 pub const EvaluationFn = prompt_optimizer.EvaluationFn;
 pub const PromptOptimizer = prompt_optimizer.PromptOptimizer;
 
+// Error tracking (per-step error rate + failure compounding)
+pub const error_tracker = @import("error_tracker.zig");
+pub const StepResult = error_tracker.StepResult;
+pub const ErrorTracker = error_tracker.ErrorTracker;
+
 test {
     std.testing.refAllDecls(@This());
 }

--- a/tests/cross_language/fixtures/error_tracker_behavior.json
+++ b/tests/cross_language/fixtures/error_tracker_behavior.json
@@ -1,0 +1,78 @@
+{
+  "version": "1.0",
+  "description": "Cross-language ErrorTracker behavior fixtures (#321). p_a = failed/total; P_error = 1 - (1 - p_a)^n. Each language's ErrorTracker must produce these exact values for the given step sequence, confirming behavioral parity.",
+  "test_cases": [
+    {
+      "id": "empty",
+      "name": "No steps recorded",
+      "steps": [],
+      "expected": {
+        "total_steps": 0,
+        "failed_steps": 0,
+        "per_step_error_rate": 0.0,
+        "cumulative_failure_probability_observed": 0.0,
+        "cumulative_failure_probability_steps": { "10": 0.0 }
+      }
+    },
+    {
+      "id": "all_success",
+      "name": "Five successful steps",
+      "steps": [true, true, true, true, true],
+      "expected": {
+        "total_steps": 5,
+        "failed_steps": 0,
+        "per_step_error_rate": 0.0,
+        "cumulative_failure_probability_observed": 0.0,
+        "cumulative_failure_probability_steps": { "1000": 0.0 }
+      }
+    },
+    {
+      "id": "all_fail",
+      "name": "Four failed steps",
+      "steps": [false, false, false, false],
+      "expected": {
+        "total_steps": 4,
+        "failed_steps": 4,
+        "per_step_error_rate": 1.0,
+        "cumulative_failure_probability_observed": 1.0,
+        "cumulative_failure_probability_steps": { "5": 1.0 }
+      }
+    },
+    {
+      "id": "mixed_quarter",
+      "name": "2 of 8 fail -> p_a = 0.25",
+      "steps": [true, false, true, true, false, true, true, true],
+      "expected": {
+        "total_steps": 8,
+        "failed_steps": 2,
+        "per_step_error_rate": 0.25,
+        "cumulative_failure_probability_observed": 0.8998870849609375,
+        "cumulative_failure_probability_steps": { "8": 0.8998870849609375 }
+      }
+    },
+    {
+      "id": "half_two_steps",
+      "name": "1 of 2 fail -> p_a = 0.5, observed n=2",
+      "steps": [true, false],
+      "expected": {
+        "total_steps": 2,
+        "failed_steps": 1,
+        "per_step_error_rate": 0.5,
+        "cumulative_failure_probability_observed": 0.75,
+        "cumulative_failure_probability_steps": { "10": 0.9990234375 }
+      }
+    },
+    {
+      "id": "compounding_one_percent",
+      "name": "1 fail in 100 -> p_a = 0.01, compounds over 100 steps ~= 0.634",
+      "steps_spec": { "fail": 1, "success": 99 },
+      "expected": {
+        "total_steps": 100,
+        "failed_steps": 1,
+        "per_step_error_rate": 0.01,
+        "cumulative_failure_probability_steps": { "100": 0.6339676587267709 },
+        "tolerance": 1e-9
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Part of #321 — the cross-language fan-out of the Python ErrorTracker reference (#650). Brings the API to **all 6 languages** with the same error-compounding math.

## Per language (mirrors agenkit/evaluation/error_tracker.py)
| Lang | Location | Tests | Verified |
|------|----------|-------|----------|
| Go | agenkit-go/evaluation/error_tracker.go | 19 | go build/vet/test green |
| TypeScript | agenkit-ts/src/evaluation/error-tracker.ts | 14 | tsc clean + vitest |
| Rust | agenkit-rust/src/evaluation/error_tracker.rs | 15 | cargo build + test |
| C++ | agenkit-cpp include/src evaluation/error_tracker.{hpp,cpp} | 18 | cmake build (-Werror) + ctest |
| Zig | agenkit-zig/src/evaluation/error_tracker.zig | 11 | `zig build test` 490/490 |

Each exposes the same API — opt-in `enabled`, record_step, per_step_error_rate (p_a), cumulative_failure_probability(steps?) (P_error = 1-(1-p_a)^n), total/failed steps, reset — adapted to each language's idioms (functional options in Go, options object in TS, Option/overloads in Rust/C++, `err` for the keyword clash in Zig). All verified on the branch.

## Cross-language equivalence
Added tests/cross_language/fixtures/error_tracker_behavior.json — the canonical expected values (total/failed, p_a, P_error observed + projected, incl. the 1%-over-100 ~= 0.634 anchor), **verified against the Python reference**. Same fixture pattern as retry_behavior.json.

## Remaining on #321
- Wire the fixture into the per-language cross_language harnesses (the unit tests already encode identical cases).
- Integrate the opt-in flag into agent execution (enable_error_tracking) — likely its own issue as it touches the agent API.

Per-language CI gates (Go/Rust/C++/Zig build, TS build) all green on this branch.
