### PR TITLE
feat(observability): OTel error metrics — p_a + P_error histograms (#322)

### DIFF
--- a/agenkit/observability/__init__.py
+++ b/agenkit/observability/__init__.py
@@ -16,6 +16,7 @@ from .audit import (
     FileAuditAdapter,
     StructuredAuditAdapter,
 )
+from .error_metrics import ErrorMetrics
 from .logging import configure_logging, get_logger_with_trace
 from .metrics import MetricsMiddleware, get_meter, init_metrics, init_resource_metrics
 from .tracing import TracingMiddleware, get_tracer, init_tracing
@@ -28,6 +29,8 @@ __all__ = [
     "AuditLogger",
     "AuditSeverity",
     "ConsoleAuditAdapter",
+    # Error metrics
+    "ErrorMetrics",
     "FileAuditAdapter",
     # Metrics
     "MetricsMiddleware",

--- a/agenkit/observability/error_metrics.py
+++ b/agenkit/observability/error_metrics.py
@@ -1,0 +1,95 @@
+"""
+OpenTelemetry metrics for error tracking — per-step error rate and compounding.
+
+Bridges :class:`agenkit.evaluation.ErrorTracker` to OpenTelemetry so the two
+core failure-rate quantities can be exported (e.g. to Prometheus) and alerted
+on:
+
+- ``agenkit.agent.per_step_error_rate`` — histogram of ``p_a``
+  (``failed_steps / total_steps``).
+- ``agenkit.agent.cumulative_failure_probability`` — histogram of ``P_error``
+  (``1 - (1 - p_a) ** n``).
+
+Both are recorded by :meth:`ErrorMetrics.record`, which reads the values
+straight off an ``ErrorTracker``. Recording is decoupled from the agent step
+loop on purpose: callers (or, once wired, the agent's
+``enable_error_tracking`` path) decide when to emit — typically once per run
+after the tracker has observed all steps.
+
+Example Prometheus queries (also in docs/ERROR_METRICS.md)::
+
+    # Average per-step error rate over the last day
+    avg_over_time(agenkit_agent_per_step_error_rate_sum[24h])
+      / avg_over_time(agenkit_agent_per_step_error_rate_count[24h])
+
+    # 95th-percentile cumulative failure probability
+    histogram_quantile(
+        0.95,
+        rate(agenkit_agent_cumulative_failure_probability_bucket[24h]),
+    )
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from .metrics import get_meter
+
+if TYPE_CHECKING:
+    from agenkit.evaluation import ErrorTracker
+
+PER_STEP_ERROR_RATE_METRIC = "agenkit.agent.per_step_error_rate"
+CUMULATIVE_FAILURE_PROBABILITY_METRIC = "agenkit.agent.cumulative_failure_probability"
+
+
+class ErrorMetrics:
+    """Records ErrorTracker quantities (``p_a``, ``P_error``) to OpenTelemetry.
+
+    Creates the two histograms once on construction (from the current meter
+    provider) and records to them on demand.
+
+    Example:
+        >>> from agenkit.evaluation import ErrorTracker
+        >>> tracker = ErrorTracker(enabled=True)
+        >>> tracker.record_step(True)
+        >>> tracker.record_step(False, error="timeout")
+        >>> metrics = ErrorMetrics()           # doctest: +SKIP
+        >>> metrics.record(tracker)             # doctest: +SKIP
+    """
+
+    def __init__(self) -> None:
+        meter = get_meter()
+        self._per_step_error_rate = meter.create_histogram(
+            name=PER_STEP_ERROR_RATE_METRIC,
+            description="Per-step error rate (p_a) = failed_steps / total_steps",
+            unit="1",
+        )
+        self._cumulative_failure_probability = meter.create_histogram(
+            name=CUMULATIVE_FAILURE_PROBABILITY_METRIC,
+            description="Cumulative failure probability (P_error) = 1 - (1 - p_a)^n",
+            unit="1",
+        )
+
+    def record(
+        self,
+        tracker: ErrorTracker,
+        *,
+        steps: int | None = None,
+        attributes: dict[str, str] | None = None,
+    ) -> None:
+        """Record ``tracker``'s current ``p_a`` and ``P_error`` to the histograms.
+
+        Args:
+            tracker: The :class:`ErrorTracker` to read values from.
+            steps: Passed through to
+                :meth:`ErrorTracker.cumulative_failure_probability` — project
+                the compounding over this many steps (defaults to the recorded
+                step count).
+            attributes: Optional metric attributes (e.g. ``{"agent": name}``)
+                applied to both recordings.
+        """
+        attrs = attributes or {}
+        self._per_step_error_rate.record(tracker.per_step_error_rate(), attributes=attrs)
+        self._cumulative_failure_probability.record(
+            tracker.cumulative_failure_probability(steps=steps), attributes=attrs
+        )

--- a/docs/ERROR_METRICS.md
+++ b/docs/ERROR_METRICS.md
@@ -1,0 +1,79 @@
+# Error Metrics (p_a, P_error)
+
+Agenkit can export the two core agent-failure-rate quantities via OpenTelemetry
+so you can chart and alert on them (e.g. in Prometheus + Grafana):
+
+| Metric | Meaning |
+|--------|---------|
+| `agenkit.agent.per_step_error_rate` | **p_a** — per-step error rate, `failed_steps / total_steps` |
+| `agenkit.agent.cumulative_failure_probability` | **P_error** — probability of ≥1 failure across `n` steps, `1 - (1 - p_a)^n` |
+
+Both are recorded as **histograms**. The OTel→Prometheus exporter renames the
+metric (dots → underscores) and adds `_sum` / `_count` / `_bucket` series, so in
+PromQL they appear as `agenkit_agent_per_step_error_rate_*` and
+`agenkit_agent_cumulative_failure_probability_*`.
+
+## Recording the metrics
+
+The values come from an [`ErrorTracker`](../agenkit/evaluation/error_tracker.py);
+[`ErrorMetrics`](../agenkit/observability/error_metrics.py) records them to OTel.
+
+```python
+from agenkit.evaluation import ErrorTracker
+from agenkit.observability import ErrorMetrics, init_metrics
+
+init_metrics()  # sets up the meter provider / Prometheus exporter
+
+tracker = ErrorTracker(enabled=True)
+# ... record each step as the agent runs ...
+tracker.record_step(True)
+tracker.record_step(False, error="timeout")
+
+metrics = ErrorMetrics()
+# Emit once per run (typically after the run completes). Project the
+# compounding over a planned horizon with steps=N; attach attributes for
+# per-agent breakdowns.
+metrics.record(tracker, steps=100, attributes={"agent": "researcher"})
+```
+
+> Once `enable_error_tracking` is wired into agent execution
+> ([#653](https://github.com/scttfrdmn/agenkit/issues/653)), this recording
+> happens automatically at the end of a tracked run.
+
+## Prometheus queries
+
+```promql
+# Average per-step error rate over the last 24h
+  avg_over_time(agenkit_agent_per_step_error_rate_sum[24h])
+/ avg_over_time(agenkit_agent_per_step_error_rate_count[24h])
+
+# 95th-percentile cumulative failure probability over 24h
+histogram_quantile(
+  0.95,
+  rate(agenkit_agent_cumulative_failure_probability_bucket[24h])
+)
+
+# Per-agent average per-step error rate (uses the `agent` attribute)
+  sum by (agent) (rate(agenkit_agent_per_step_error_rate_sum[1h]))
+/ sum by (agent) (rate(agenkit_agent_per_step_error_rate_count[1h]))
+```
+
+## Grafana
+
+- **Per-step error rate (p_a)** — time series of the average query above; a
+  small p_a compounds, so trend matters more than the absolute value.
+- **Cumulative failure probability (P_error)** — the p95 `histogram_quantile`
+  query; a stat panel with thresholds (e.g. green < 0.3, amber < 0.6, red ≥ 0.6)
+  surfaces runs likely to fail.
+- **Per-agent breakdown** — table panel grouped by the `agent` attribute.
+
+Alerting rule example (fire when projected failure probability is high):
+
+```yaml
+- alert: HighCumulativeFailureProbability
+  expr: histogram_quantile(0.95, rate(agenkit_agent_cumulative_failure_probability_bucket[1h])) > 0.6
+  for: 15m
+  labels: { severity: warning }
+  annotations:
+    summary: "Agent runs have a >60% projected failure probability (p95)"
+```

--- a/tests/observability/test_error_metrics.py
+++ b/tests/observability/test_error_metrics.py
@@ -1,0 +1,101 @@
+"""Tests for ErrorMetrics — OTel export of ErrorTracker p_a / P_error (#322).
+
+OpenTelemetry's meter provider is process-global and only the first
+``set_meter_provider`` wins, so (like tests/observability/test_metrics.py) we
+use a single module-scoped reader. To keep tests independent despite the shared
+histograms, each test tags its recording with a unique ``case`` attribute and
+asserts on the data point carrying that attribute.
+"""
+
+import pytest
+from opentelemetry import metrics as otel_metrics
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import InMemoryMetricReader
+
+from agenkit.evaluation import ErrorTracker
+from agenkit.observability.error_metrics import (
+    CUMULATIVE_FAILURE_PROBABILITY_METRIC,
+    PER_STEP_ERROR_RATE_METRIC,
+    ErrorMetrics,
+)
+
+
+@pytest.fixture(scope="module")
+def metric_reader():
+    reader = InMemoryMetricReader()
+    provider = MeterProvider(metric_readers=[reader])
+    otel_metrics.set_meter_provider(provider)
+    return reader
+
+
+def _data_point(reader, metric_name, case):
+    """Return the data point for ``metric_name`` tagged with ``case=<case>``."""
+    for resource_metric in reader.get_metrics_data().resource_metrics:
+        for scope_metric in resource_metric.scope_metrics:
+            for metric in scope_metric.metrics:
+                if metric.name != metric_name:
+                    continue
+                for dp in metric.data.data_points:
+                    if dp.attributes.get("case") == case:
+                        return dp
+    return None
+
+
+def _tracker_half():
+    """1 fail of 2 -> p_a = 0.5."""
+    t = ErrorTracker(enabled=True)
+    t.record_step(True)
+    t.record_step(False, error="timeout")
+    return t
+
+
+def test_records_both_histograms(metric_reader):
+    ErrorMetrics().record(_tracker_half(), attributes={"case": "both"})
+    assert _data_point(metric_reader, PER_STEP_ERROR_RATE_METRIC, "both") is not None
+    assert _data_point(metric_reader, CUMULATIVE_FAILURE_PROBABILITY_METRIC, "both") is not None
+
+
+def test_records_per_step_error_rate_value(metric_reader):
+    ErrorMetrics().record(_tracker_half(), attributes={"case": "p_a"})
+    dp = _data_point(metric_reader, PER_STEP_ERROR_RATE_METRIC, "p_a")
+    assert dp is not None
+    assert dp.count == 1
+    assert dp.sum == pytest.approx(0.5)
+
+
+def test_records_cumulative_observed(metric_reader):
+    # observed n=2 -> 1 - 0.5^2 = 0.75
+    ErrorMetrics().record(_tracker_half(), attributes={"case": "observed"})
+    dp = _data_point(metric_reader, CUMULATIVE_FAILURE_PROBABILITY_METRIC, "observed")
+    assert dp is not None
+    assert dp.sum == pytest.approx(0.75)
+
+
+def test_records_cumulative_projected_steps(metric_reader):
+    ErrorMetrics().record(_tracker_half(), steps=10, attributes={"case": "projected"})
+    dp = _data_point(metric_reader, CUMULATIVE_FAILURE_PROBABILITY_METRIC, "projected")
+    assert dp is not None
+    assert dp.sum == pytest.approx(1 - 0.5**10)
+
+
+def test_zero_error_rate_records_zero(metric_reader):
+    t = ErrorTracker(enabled=True)
+    for _ in range(5):
+        t.record_step(True)
+    ErrorMetrics().record(t, attributes={"case": "zero"})
+    p_a_dp = _data_point(metric_reader, PER_STEP_ERROR_RATE_METRIC, "zero")
+    p_err_dp = _data_point(metric_reader, CUMULATIVE_FAILURE_PROBABILITY_METRIC, "zero")
+    assert p_a_dp.sum == pytest.approx(0.0)
+    assert p_err_dp.sum == pytest.approx(0.0)
+
+
+def test_attributes_applied(metric_reader):
+    ErrorMetrics().record(_tracker_half(), attributes={"case": "attrs", "agent": "agent-1"})
+    dp = _data_point(metric_reader, PER_STEP_ERROR_RATE_METRIC, "attrs")
+    assert dp is not None
+    assert dp.attributes.get("agent") == "agent-1"
+
+
+def test_metric_names_are_canonical():
+    assert PER_STEP_ERROR_RATE_METRIC == "agenkit.agent.per_step_error_rate"
+    assert CUMULATIVE_FAILURE_PROBABILITY_METRIC == "agenkit.agent.cumulative_failure_probability"


### PR DESCRIPTION
Part of #322. Bridges ErrorTracker (#321, done) to OpenTelemetry — **Python reference**.

## API (agenkit/observability/error_metrics.py)
`ErrorMetrics` creates two histograms and records an `ErrorTracker`'s values:
- `agenkit.agent.per_step_error_rate` — **p_a**
- `agenkit.agent.cumulative_failure_probability` — **P_error** = 1-(1-p_a)^n

`record(tracker, steps=None, attributes=None)` — `steps` projects the compounding over a planned horizon; `attributes` enable per-agent breakdowns. Exported as `agenkit.observability.ErrorMetrics`.

## Docs
`docs/ERROR_METRICS.md` — Prometheus queries (avg p_a, p95 P_error via `histogram_quantile`, per-agent), Grafana panel guidance, and an alerting-rule example. (OTel→Prom renames to `agenkit_agent_*_{sum,count,bucket}`.)

## Tests
7 tests using `InMemoryMetricReader`, asserting the actual recorded histogram values (p_a=0.5, observed P_error=0.75, projected 1−0.5^10, zero-rate, attributes). Module-scoped reader + per-test `case` attribute to stay independent under OTel's process-global provider.

- Full observability suite: **48 passed**; ruff clean.

## Scope note
This is the **emission API**. The "automatic recording when error_tracking enabled" bullet depends on agent-execution integration, split into #653. Cross-language fan-out to follow (like #321).
