### PR TITLE
fix(zig): deterministic seed for optimizer tests (closes #656)

### DIFF
--- a/agenkit-zig/src/evaluation/bayesian_optimizer.zig
+++ b/agenkit-zig/src/evaluation/bayesian_optimizer.zig
@@ -400,7 +400,7 @@ test "PerformanceEstimate basic" {
 test "BayesianOptimizer initialization" {
     const allocator = std.testing.allocator;
 
-    const space = try SearchSpace.init(allocator);
+    const space = try SearchSpace.initSeeded(allocator, 42);
     defer space.deinit();
 
     try space.addContinuous("x", 0.0, 10.0);
@@ -423,7 +423,7 @@ test "BayesianOptimizer initialization" {
 test "BayesianOptimizer optimize simple" {
     const allocator = std.testing.allocator;
 
-    const space = try SearchSpace.init(allocator);
+    const space = try SearchSpace.initSeeded(allocator, 42);
     defer space.deinit();
 
     try space.addContinuous("x", -10.0, 10.0);
@@ -458,7 +458,7 @@ test "BayesianOptimizer optimize simple" {
 test "BayesianOptimizer similarity calculation" {
     const allocator = std.testing.allocator;
 
-    const space = try SearchSpace.init(allocator);
+    const space = try SearchSpace.initSeeded(allocator, 42);
     defer space.deinit();
 
     const config = BayesianConfig{
@@ -500,7 +500,7 @@ test "BayesianOptimizer similarity calculation" {
 test "BayesianOptimizer acquisition functions" {
     const allocator = std.testing.allocator;
 
-    const space = try SearchSpace.init(allocator);
+    const space = try SearchSpace.initSeeded(allocator, 42);
     defer space.deinit();
 
     const config_ei = BayesianConfig{
@@ -551,7 +551,7 @@ test "normalPDF approximation" {
 test "BayesianOptimizer estimatePerformance" {
     const allocator = std.testing.allocator;
 
-    const space = try SearchSpace.init(allocator);
+    const space = try SearchSpace.initSeeded(allocator, 42);
     defer space.deinit();
 
     try space.addContinuous("x", 0.0, 10.0);

--- a/agenkit-zig/src/evaluation/optimizer.zig
+++ b/agenkit-zig/src/evaluation/optimizer.zig
@@ -84,8 +84,14 @@ pub const SearchSpace = struct {
     rng: std.Random.DefaultPrng,
 
     pub fn init(allocator: Allocator) !*SearchSpace {
+        // Production: seed from wall-clock so each run explores differently.
+        return initSeeded(allocator, @as(u64, @intCast(agktime.timestamp())));
+    }
+
+    /// Like `init` but with an explicit RNG seed. Use in tests for
+    /// deterministic, non-flaky behavior; production uses `init` (time-seeded).
+    pub fn initSeeded(allocator: Allocator, seed: u64) !*SearchSpace {
         const self = try allocator.create(SearchSpace);
-        const seed = @as(u64, @intCast(agktime.timestamp()));
         self.* = SearchSpace{
             .parameters = std.ArrayList(Parameter).empty,
             .allocator = allocator,
@@ -385,7 +391,7 @@ pub const RandomSearchOptimizer = struct {
 test "SearchSpace continuous parameter" {
     const allocator = std.testing.allocator;
 
-    const space = try SearchSpace.init(allocator);
+    const space = try SearchSpace.initSeeded(allocator, 42);
     defer space.deinit();
 
     try space.addContinuous("temperature", 0.0, 1.0);
@@ -397,7 +403,7 @@ test "SearchSpace continuous parameter" {
 test "SearchSpace sample" {
     const allocator = std.testing.allocator;
 
-    const space = try SearchSpace.init(allocator);
+    const space = try SearchSpace.initSeeded(allocator, 42);
     defer space.deinit();
 
     try space.addContinuous("x", 0.0, 10.0);
@@ -427,7 +433,7 @@ test "SearchSpace sample" {
 test "SearchSpace validate" {
     const allocator = std.testing.allocator;
 
-    const space = try SearchSpace.init(allocator);
+    const space = try SearchSpace.initSeeded(allocator, 42);
     defer space.deinit();
 
     try space.addContinuous("x", 0.0, 10.0);
@@ -449,7 +455,7 @@ test "SearchSpace validate" {
 test "RandomSearchOptimizer simple" {
     const allocator = std.testing.allocator;
 
-    const space = try SearchSpace.init(allocator);
+    const space = try SearchSpace.initSeeded(allocator, 42);
     defer space.deinit();
 
     try space.addContinuous("x", -10.0, 10.0);


### PR DESCRIPTION
Closes #656. Fixes the flaky Zig `BayesianOptimizer optimize simple` test that's been intermittently red-failing the **blocking** Zig CI gate (#647) on unrelated PRs (e.g. it just blocked #655, which is pure-Python).

## Root cause
`SearchSpace` seeded its RNG from `agktime.timestamp()` (wall-clock) → different seed every run. The bayesian test minimizes `(x-5)^2` over x∈[-10,10] in 10 iterations and asserts `best_score < 100.0`; an unlucky random draw occasionally exceeds it (worst case x=-10 → 225).

## Fix
- Add `SearchSpace.initSeeded(allocator, seed)`; `init()` keeps the timestamp seed → **production behavior unchanged**.
- All optimizer/bayesian **test** call sites use `initSeeded(allocator, 42)` for determinism — mirrors the Python `RandomSearchOptimizer` fix (`random.seed(42)`).

## Verified
- 8× clean-cache `zig build test` → **23/23 steps, 490/490 tests passed** every run (was intermittently 489/490).
- `prompt_optimizer` tests assert structure (`config.contains`, string equality), not random values, so its time-seed is harmless and left as-is.
