### PR TITLE
feat(adapter/llm): typed token Usage + Bedrock prompt-cache counts (#664, #665)

### DIFF
--- a/agenkit-go/adapter/llm/bedrock.go
+++ b/agenkit-go/adapter/llm/bedrock.go
@@ -249,11 +249,21 @@ func (b *BedrockLLM) Complete(ctx context.Context, messages []*agenkit.Message, 
 
 	// Add usage if available
 	if output.Usage != nil {
-		response.Metadata["usage"] = map[string]interface{}{
+		usage := map[string]interface{}{
 			"prompt_tokens":     aws.ToInt32(output.Usage.InputTokens),
 			"completion_tokens": aws.ToInt32(output.Usage.OutputTokens),
 			"total_tokens":      aws.ToInt32(output.Usage.TotalTokens),
 		}
+		// Prompt-cache token counts (Anthropic-on-Bedrock). Billed at very
+		// different rates from normal input tokens, so surface them when the
+		// provider reports them. Only present when prompt caching is active.
+		if n := aws.ToInt32(output.Usage.CacheReadInputTokens); n > 0 {
+			usage["cache_read_tokens"] = n
+		}
+		if n := aws.ToInt32(output.Usage.CacheWriteInputTokens); n > 0 {
+			usage["cache_creation_tokens"] = n
+		}
+		response.Metadata["usage"] = usage
 	}
 
 	// Add stop reason

--- a/agenkit-go/adapter/llm/usage.go
+++ b/agenkit-go/adapter/llm/usage.go
@@ -1,0 +1,105 @@
+package llm
+
+import "github.com/scttfrdmn/agenkit/agenkit-go/agenkit"
+
+// Usage is a normalized, typed view of the token usage an LLM adapter records
+// on a response. It exists so cost-metering, budgeting, and routing layers can
+// consume a single struct instead of re-parsing the per-provider
+// Metadata["usage"] map (which varies in both key names and value types across
+// providers).
+//
+// Fields are zero when the provider does not report them. The cache fields are
+// provider-dependent (e.g. Anthropic prompt caching, including via Bedrock) and
+// are zero when caching is inactive or unsupported.
+type Usage struct {
+	PromptTokens     int
+	CompletionTokens int
+	TotalTokens      int
+
+	// CacheReadTokens is the number of prompt tokens served from a provider
+	// prompt cache. These are typically billed at a fraction of normal input
+	// token cost. Zero when unknown or caching is inactive.
+	CacheReadTokens int
+
+	// CacheCreationTokens is the number of prompt tokens written to a provider
+	// prompt cache on this request. Zero when unknown or caching is inactive.
+	CacheCreationTokens int
+}
+
+// UsageReporter is an optional interface an LLM adapter may implement to let
+// consumers detect typed-usage support at compile time. The core LLM interface
+// deliberately stays minimal (Complete/Stream/Model/Unwrap); adapters that can
+// report usage do so additively.
+//
+// Adapters in this package report usage via response Metadata rather than this
+// interface; UsageFromMessage is the primary accessor. UsageReporter is
+// provided for consumers that wrap an LLM and want to expose aggregate usage.
+type UsageReporter interface {
+	// Usage returns the most recent token usage and true if available.
+	Usage() (Usage, bool)
+}
+
+// UsageFromMessage extracts normalized token usage from an adapter response.
+//
+// It reads the Metadata["usage"] map populated by the adapters in this package,
+// normalizing the two naming conventions in use today:
+//   - prompt_tokens / completion_tokens (OpenAI, Bedrock, Gemini, Ollama, LiteLLM, ...)
+//   - input_tokens / output_tokens      (Anthropic native)
+//
+// and the value types in use (int and int32). cache_read_tokens /
+// cache_creation_tokens are read when present.
+//
+// ok is false when the message is nil or carries no usage metadata. When
+// total_tokens is absent it is derived as prompt+completion.
+func UsageFromMessage(m *agenkit.Message) (Usage, bool) {
+	if m == nil || m.Metadata == nil {
+		return Usage{}, false
+	}
+
+	raw, ok := m.Metadata["usage"].(map[string]interface{})
+	if !ok {
+		return Usage{}, false
+	}
+
+	// pick returns the first present key, coerced to int.
+	pick := func(keys ...string) int {
+		for _, k := range keys {
+			if v, present := raw[k]; present {
+				return toInt(v)
+			}
+		}
+		return 0
+	}
+
+	u := Usage{
+		PromptTokens:        pick("prompt_tokens", "input_tokens"),
+		CompletionTokens:    pick("completion_tokens", "output_tokens"),
+		TotalTokens:         pick("total_tokens"),
+		CacheReadTokens:     pick("cache_read_tokens", "cache_read_input_tokens"),
+		CacheCreationTokens: pick("cache_creation_tokens", "cache_creation_input_tokens", "cache_write_tokens"),
+	}
+
+	if u.TotalTokens == 0 {
+		u.TotalTokens = u.PromptTokens + u.CompletionTokens
+	}
+
+	return u, true
+}
+
+// toInt coerces the numeric types adapters store in usage metadata (int, int32,
+// int64, and the float64 produced by JSON round-trips) to int. Unknown types
+// yield 0.
+func toInt(v interface{}) int {
+	switch n := v.(type) {
+	case int:
+		return n
+	case int32:
+		return int(n)
+	case int64:
+		return int(n)
+	case float64:
+		return int(n)
+	default:
+		return 0
+	}
+}

--- a/agenkit-go/adapter/llm/usage_test.go
+++ b/agenkit-go/adapter/llm/usage_test.go
@@ -1,0 +1,118 @@
+package llm
+
+import (
+	"testing"
+
+	"github.com/scttfrdmn/agenkit/agenkit-go/agenkit"
+)
+
+func msgWithUsage(usage map[string]interface{}) *agenkit.Message {
+	m := agenkit.NewMessage("agent", "hi")
+	if usage != nil {
+		m.Metadata["usage"] = usage
+	}
+	return m
+}
+
+func TestUsageFromMessage(t *testing.T) {
+	tests := []struct {
+		name   string
+		msg    *agenkit.Message
+		wantOK bool
+		want   Usage
+	}{
+		{
+			name:   "nil message",
+			msg:    nil,
+			wantOK: false,
+		},
+		{
+			name:   "no usage metadata",
+			msg:    msgWithUsage(nil),
+			wantOK: false,
+		},
+		{
+			name: "openai-style prompt/completion, int",
+			msg: msgWithUsage(map[string]interface{}{
+				"prompt_tokens":     10,
+				"completion_tokens": 5,
+				"total_tokens":      15,
+			}),
+			wantOK: true,
+			want:   Usage{PromptTokens: 10, CompletionTokens: 5, TotalTokens: 15},
+		},
+		{
+			name: "bedrock-style int32",
+			msg: msgWithUsage(map[string]interface{}{
+				"prompt_tokens":     int32(100),
+				"completion_tokens": int32(20),
+				"total_tokens":      int32(120),
+			}),
+			wantOK: true,
+			want:   Usage{PromptTokens: 100, CompletionTokens: 20, TotalTokens: 120},
+		},
+		{
+			name: "anthropic-style input/output keys",
+			msg: msgWithUsage(map[string]interface{}{
+				"input_tokens":  30,
+				"output_tokens": 7,
+			}),
+			wantOK: true,
+			// total derived from prompt+completion when absent
+			want: Usage{PromptTokens: 30, CompletionTokens: 7, TotalTokens: 37},
+		},
+		{
+			name: "float64 values (JSON round-trip)",
+			msg: msgWithUsage(map[string]interface{}{
+				"prompt_tokens":     float64(8),
+				"completion_tokens": float64(2),
+			}),
+			wantOK: true,
+			want:   Usage{PromptTokens: 8, CompletionTokens: 2, TotalTokens: 10},
+		},
+		{
+			name: "bedrock cache tokens (normalized keys)",
+			msg: msgWithUsage(map[string]interface{}{
+				"prompt_tokens":         int32(1000),
+				"completion_tokens":     int32(50),
+				"total_tokens":          int32(1050),
+				"cache_read_tokens":     int32(900),
+				"cache_creation_tokens": int32(100),
+			}),
+			wantOK: true,
+			want: Usage{
+				PromptTokens: 1000, CompletionTokens: 50, TotalTokens: 1050,
+				CacheReadTokens: 900, CacheCreationTokens: 100,
+			},
+		},
+		{
+			name: "raw provider cache key aliases",
+			msg: msgWithUsage(map[string]interface{}{
+				"input_tokens":                20,
+				"output_tokens":               4,
+				"cache_read_input_tokens":     15,
+				"cache_creation_input_tokens": 5,
+			}),
+			wantOK: true,
+			want: Usage{
+				PromptTokens: 20, CompletionTokens: 4, TotalTokens: 24,
+				CacheReadTokens: 15, CacheCreationTokens: 5,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := UsageFromMessage(tt.msg)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if !tt.wantOK {
+				return
+			}
+			if got != tt.want {
+				t.Errorf("Usage = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Implements **#664** (typed `Usage`) and **#665** (Bedrock prompt-cache token counts) for the Go adapter.

## #664 — typed `Usage` + normalizer

New `adapter/llm/usage.go`:
- `type Usage struct { PromptTokens, CompletionTokens, TotalTokens, CacheReadTokens, CacheCreationTokens int }`
- `UsageFromMessage(*agenkit.Message) (Usage, bool)` — normalizes the per-provider `Metadata["usage"]` map into one struct.
- `UsageReporter` interface for consumers that want compile-time detection.

The core `LLM` interface (`Complete`/`Stream`/`Model`/`Unwrap`) is **unchanged** — usage is additive, preserving the minimal-interface design principle the package documents.

**Normalization handles real divergence found in the adapters:**
- Key names: most adapters use `prompt_tokens`/`completion_tokens`, but the **Anthropic adapter uses `input_tokens`/`output_tokens`** — so the "shape is consistent today" assumption in #664 isn't fully true. The helper reads both.
- Value types: Bedrock stores `int32` (via `aws.ToInt32`), others store `int`; JSON round-trips yield `float64`. All coerced.
- Derives `total_tokens` when absent.

## #665 — Bedrock cache tokens

The AWS SDK `types.TokenUsage` already exposes `CacheReadInputTokens` and `CacheWriteInputTokens` (`*int32`) — the adapter just wasn't forwarding them. Now surfaced as `cache_read_tokens` / `cache_creation_tokens` when present (`>0`), so a metering layer can bill warm-prefix requests at the cache rate.

## Tests

`usage_test.go` — 8 cases: both key conventions, int/int32/float64 values, cache fields (normalized + raw provider aliases), total derivation, nil/absent. All pass. `go build`, `go vet`, full `adapter/llm` suite green locally.

## Notes

- This is in `agenkit-go/`, so on merge the distribution mirror auto-syncs (per the sync workflow).
- **Cross-language parity:** these changes need to propagate to the other language implementations — tracked in #669.
