### PR TITLE
feat(ts/llm): typed token Usage + Bedrock prompt-cache counts (part of #669)

### DIFF
--- a/agenkit-ts/src/adapters/bedrock.ts
+++ b/agenkit-ts/src/adapters/bedrock.ts
@@ -200,6 +200,14 @@ export class BedrockAdapter implements Agent {
           prompt_tokens: response.usage?.inputTokens || 0,
           completion_tokens: response.usage?.outputTokens || 0,
           total_tokens: response.usage?.totalTokens || 0,
+          // Prompt-cache token counts (Anthropic-on-Bedrock), billed at a
+          // reduced rate. Only present when prompt caching is active.
+          ...(response.usage?.cacheReadInputTokens
+            ? { cache_read_tokens: response.usage.cacheReadInputTokens }
+            : {}),
+          ...(response.usage?.cacheWriteInputTokens
+            ? { cache_creation_tokens: response.usage.cacheWriteInputTokens }
+            : {}),
         },
         stop_reason: response.stopReason || 'end_turn',
       },
@@ -366,6 +374,14 @@ export class BedrockAdapter implements Agent {
           prompt_tokens: response.usage?.inputTokens || 0,
           completion_tokens: response.usage?.outputTokens || 0,
           total_tokens: response.usage?.totalTokens || 0,
+          // Prompt-cache token counts (Anthropic-on-Bedrock), billed at a
+          // reduced rate. Only present when prompt caching is active.
+          ...(response.usage?.cacheReadInputTokens
+            ? { cache_read_tokens: response.usage.cacheReadInputTokens }
+            : {}),
+          ...(response.usage?.cacheWriteInputTokens
+            ? { cache_creation_tokens: response.usage.cacheWriteInputTokens }
+            : {}),
         },
         stop_reason: response.stopReason || 'end_turn',
       },

--- a/agenkit-ts/src/index.ts
+++ b/agenkit-ts/src/index.ts
@@ -116,6 +116,8 @@ export {
 export { OpenAIAgent, OpenAIConfig } from './llm/openai';
 export { AnthropicAgent, AnthropicConfig } from './llm/anthropic';
 export { OpenAICompatibleAgent, OpenAICompatibleConfig } from './llm/openai-compatible';
+export { usageFromMessage } from './llm/usage';
+export type { Usage, UsageReporter } from './llm/usage';
 
 // Composition Patterns
 export { SequentialAgent } from './composition/sequential';

--- a/agenkit-ts/src/llm/__tests__/usage.test.ts
+++ b/agenkit-ts/src/llm/__tests__/usage.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Tests for typed token usage normalization.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { usageFromMessage, Usage } from '../usage';
+import { createMessage, Message } from '../../core/interfaces';
+
+function msg(metadata?: Record<string, unknown>): Message {
+  return createMessage('assistant', 'hi', metadata);
+}
+
+const zero: Usage = {
+  promptTokens: 0,
+  completionTokens: 0,
+  totalTokens: 0,
+  cacheReadTokens: 0,
+  cacheCreationTokens: 0,
+};
+
+describe('usageFromMessage', () => {
+  it('returns ok=false for null/undefined message', () => {
+    expect(usageFromMessage(null)).toEqual([zero, false]);
+    expect(usageFromMessage(undefined)).toEqual([zero, false]);
+  });
+
+  it('returns ok=false when no usage metadata is present', () => {
+    expect(usageFromMessage(msg({ model: 'x' }))).toEqual([zero, false]);
+    expect(usageFromMessage(msg())).toEqual([zero, false]);
+  });
+
+  it('normalizes nested usage object (adapters convention)', () => {
+    const [u, ok] = usageFromMessage(
+      msg({ usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 } }),
+    );
+    expect(ok).toBe(true);
+    expect(u).toEqual({ ...zero, promptTokens: 10, completionTokens: 5, totalTokens: 15 });
+  });
+
+  it('normalizes flat top-level token keys (llm convention)', () => {
+    const [u, ok] = usageFromMessage(
+      msg({ input_tokens: 30, output_tokens: 7, total_tokens: 37, model: 'x' }),
+    );
+    expect(ok).toBe(true);
+    expect(u).toEqual({ ...zero, promptTokens: 30, completionTokens: 7, totalTokens: 37 });
+  });
+
+  it('derives total when absent', () => {
+    const [u, ok] = usageFromMessage(msg({ usage: { prompt_tokens: 8, completion_tokens: 2 } }));
+    expect(ok).toBe(true);
+    expect(u.totalTokens).toBe(10);
+  });
+
+  it('reads Bedrock-style normalized cache keys', () => {
+    const [u, ok] = usageFromMessage(
+      msg({
+        usage: {
+          prompt_tokens: 1000,
+          completion_tokens: 50,
+          total_tokens: 1050,
+          cache_read_tokens: 900,
+          cache_creation_tokens: 100,
+        },
+      }),
+    );
+    expect(ok).toBe(true);
+    expect(u.cacheReadTokens).toBe(900);
+    expect(u.cacheCreationTokens).toBe(100);
+  });
+
+  it('reads raw provider cache key aliases', () => {
+    const [u, ok] = usageFromMessage(
+      msg({
+        usage: {
+          input_tokens: 20,
+          output_tokens: 4,
+          cache_read_input_tokens: 15,
+          cache_creation_input_tokens: 5,
+        },
+      }),
+    );
+    expect(ok).toBe(true);
+    expect(u).toEqual({
+      promptTokens: 20,
+      completionTokens: 4,
+      totalTokens: 24,
+      cacheReadTokens: 15,
+      cacheCreationTokens: 5,
+    });
+  });
+
+  it('ignores non-numeric values', () => {
+    const [u, ok] = usageFromMessage(
+      msg({ usage: { prompt_tokens: 'x', completion_tokens: 5 } }),
+    );
+    expect(ok).toBe(true);
+    expect(u.promptTokens).toBe(0);
+    expect(u.completionTokens).toBe(5);
+  });
+});

--- a/agenkit-ts/src/llm/usage.ts
+++ b/agenkit-ts/src/llm/usage.ts
@@ -1,0 +1,116 @@
+/**
+ * Typed token usage for LLM adapter responses.
+ *
+ * Adapters record token counts in `Message.metadata`, but the shape varies:
+ * some use a nested `usage` object (`src/adapters/*`), some place counts as
+ * flat top-level keys (`src/llm/*`), and key names differ between the
+ * `prompt_tokens`/`completion_tokens` and Anthropic `input_tokens`/`output_tokens`
+ * conventions. `usageFromMessage` normalizes all of these into one struct so
+ * cost-metering and budgeting layers consume a single shape.
+ *
+ * Mirrors the Go reference (`agenkit-go/adapter/llm/usage.go`).
+ */
+
+import { Message } from '../core/interfaces';
+
+/**
+ * Normalized, typed token usage. Fields are 0 when the provider does not
+ * report them. The cache fields are provider-dependent (e.g. Anthropic prompt
+ * caching, including via Bedrock) and are 0 when caching is inactive.
+ */
+export interface Usage {
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+  /** Prompt tokens served from a provider cache (billed at a reduced rate). */
+  cacheReadTokens: number;
+  /** Prompt tokens written to a provider cache on this request. */
+  cacheCreationTokens: number;
+}
+
+/**
+ * Optional interface an adapter (or a wrapper around one) may implement so
+ * consumers can detect typed-usage support at compile time. The core LLM/Agent
+ * contract stays unchanged; usage support is additive.
+ */
+export interface UsageReporter {
+  /** Returns the most recent token usage, or undefined if unavailable. */
+  usage(): Usage | undefined;
+}
+
+/** Coerce an unknown numeric metadata value to a number; 0 when not numeric. */
+function toNum(v: unknown): number {
+  return typeof v === 'number' && Number.isFinite(v) ? v : 0;
+}
+
+/**
+ * Extract normalized token usage from an adapter response message.
+ *
+ * Reads either a nested `metadata.usage` object or flat top-level `metadata`
+ * token keys, normalizing both naming conventions:
+ *   - prompt_tokens / completion_tokens (OpenAI, Bedrock, Gemini, Ollama, LiteLLM)
+ *   - input_tokens / output_tokens      (Anthropic)
+ * and the cache keys (cache_read_tokens / cache_creation_tokens, plus the raw
+ * provider aliases cache_read_input_tokens / cache_creation_input_tokens).
+ *
+ * @returns the Usage and `true`, or `[zeroUsage, false]` when no usage is present.
+ */
+export function usageFromMessage(message: Message | null | undefined): [Usage, boolean] {
+  const zero: Usage = {
+    promptTokens: 0,
+    completionTokens: 0,
+    totalTokens: 0,
+    cacheReadTokens: 0,
+    cacheCreationTokens: 0,
+  };
+
+  const metadata = message?.metadata;
+  if (!metadata || typeof metadata !== 'object') {
+    return [zero, false];
+  }
+
+  // Counts may live under metadata.usage (nested) or directly on metadata (flat).
+  const nested = (metadata as Record<string, unknown>).usage;
+  const source =
+    nested && typeof nested === 'object'
+      ? (nested as Record<string, unknown>)
+      : (metadata as Record<string, unknown>);
+
+  // Detect presence of any recognized token key before reporting ok=true.
+  const tokenKeys = [
+    'prompt_tokens',
+    'input_tokens',
+    'completion_tokens',
+    'output_tokens',
+    'total_tokens',
+  ];
+  const hasUsage = tokenKeys.some((k) => k in source);
+  if (!hasUsage) {
+    return [zero, false];
+  }
+
+  const pick = (...keys: string[]): number => {
+    for (const k of keys) {
+      if (k in source) return toNum(source[k]);
+    }
+    return 0;
+  };
+
+  const usage: Usage = {
+    promptTokens: pick('prompt_tokens', 'input_tokens'),
+    completionTokens: pick('completion_tokens', 'output_tokens'),
+    totalTokens: pick('total_tokens'),
+    cacheReadTokens: pick('cache_read_tokens', 'cache_read_input_tokens'),
+    cacheCreationTokens: pick(
+      'cache_creation_tokens',
+      'cache_creation_input_tokens',
+      'cache_write_tokens',
+    ),
+  };
+
+  if (usage.totalTokens === 0) {
+    usage.totalTokens = usage.promptTokens + usage.completionTokens;
+  }
+
+  return [usage, true];
+}


### PR DESCRIPTION
First cross-language port of #664/#665 (tracked in **#669**) — TypeScript, mirroring the Go reference landed in #668.

## Changes

- **`src/llm/usage.ts`** (new): `Usage` interface + `usageFromMessage(message)` normalizer + optional `UsageReporter`.
- **`src/adapters/bedrock.ts`**: forward `cacheReadInputTokens` / `cacheWriteInputTokens` → `cache_read_tokens` / `cache_creation_tokens` when present, on **both** the Converse and ConverseStream paths.
- **`src/index.ts`**: export `usageFromMessage` + `Usage`/`UsageReporter` types.

## TS-specific wrinkle handled

agenkit-ts has **two adapter trees with different metadata layouts**:
- `src/adapters/*` — nested `metadata.usage` object (matches Go)
- `src/llm/*` — flat top-level token keys (`input_tokens` directly on metadata)

`usageFromMessage` normalizes **both** layouts, plus both key conventions (`prompt/completion_tokens` and Anthropic `input/output_tokens`) and the cache keys (normalized + raw provider aliases). This drift is exactly the fragility #664 is about.

## Verification

- `npm run build` (tsc) clean — confirms the Bedrock cache fields type-check against the AWS SDK.
- `vitest run src/llm src/adapters` → **30 passing** (8 new usage tests + 22 existing). Scoped to the touched packages; the repo's full TS suite is marked non-blocking in CI due to known non-hermetic tests elsewhere.

## Notes

- In `agenkit-ts/`, so it does **not** trigger the agenkit-go mirror sync.
- Pre-existing repo-wide ESLint misconfig (`eslint.config.js` missing under ESLint v10) means `npm run lint` errors independent of this change — not touched here.

Part of #669. Remaining: Rust, Java, C++, Zig, C#, Scala.