### PR TITLE
feat(java,scala/adapters): typed token Usage (part of #669)

### DIFF
--- a/agenkit-java/src/main/java/io/agenkit/adapters/AnthropicAdapter.java
+++ b/agenkit-java/src/main/java/io/agenkit/adapters/AnthropicAdapter.java
@@ -13,7 +13,9 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
@@ -82,7 +84,31 @@ public final class AnthropicAdapter implements LlmClient {
                         try {
                             JsonNode root = objectMapper.readTree(response.body());
                             String content = root.at("/content/0/text").asText("");
-                            return Message.of("assistant", content);
+                            Message message = Message.of("assistant", content);
+
+                            // Surface token usage so metering layers can read it
+                            // via TokenUsage.fromMessage. Anthropic uses the
+                            // input_tokens/output_tokens convention.
+                            JsonNode usage = root.get("usage");
+                            if (usage != null && usage.isObject()) {
+                                Map<String, Object> usageMeta = new HashMap<>();
+                                long inputTokens = usage.path("input_tokens").asLong(0);
+                                long outputTokens = usage.path("output_tokens").asLong(0);
+                                usageMeta.put("input_tokens", inputTokens);
+                                usageMeta.put("output_tokens", outputTokens);
+                                usageMeta.put("total_tokens", inputTokens + outputTokens);
+                                // Prompt-cache token counts, when present.
+                                if (usage.has("cache_read_input_tokens")) {
+                                    usageMeta.put("cache_read_tokens",
+                                            usage.path("cache_read_input_tokens").asLong(0));
+                                }
+                                if (usage.has("cache_creation_input_tokens")) {
+                                    usageMeta.put("cache_creation_tokens",
+                                            usage.path("cache_creation_input_tokens").asLong(0));
+                                }
+                                message = message.withMetadata("usage", usageMeta);
+                            }
+                            return message;
                         } catch (Exception e) {
                             log.error("failed to parse Anthropic response: {}", e.getMessage());
                             return Message.of("assistant", "Error: failed to parse response");

--- a/agenkit-java/src/main/java/io/agenkit/adapters/TokenUsage.java
+++ b/agenkit-java/src/main/java/io/agenkit/adapters/TokenUsage.java
@@ -1,0 +1,75 @@
+package io.agenkit.adapters;
+
+import io.agenkit.core.Message;
+
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Normalized, typed token usage for LLM adapter responses.
+ *
+ * <p>Adapters record token counts in {@code Message.metadata["usage"]} as a map,
+ * but key names differ between the {@code prompt_tokens}/{@code completion_tokens}
+ * convention and the Anthropic {@code input_tokens}/{@code output_tokens}
+ * convention. {@link #fromMessage(Message)} normalizes both into one type so
+ * cost-metering and budgeting layers consume a single shape.
+ *
+ * <p>Fields are {@code 0} when the provider does not report them. The cache
+ * fields are provider-dependent (e.g. Anthropic prompt caching, including via
+ * Bedrock) and are {@code 0} when caching is inactive.
+ *
+ * <p>Mirrors the Go reference ({@code agenkit-go/adapter/llm/usage.go}).
+ */
+public record TokenUsage(
+        long promptTokens,
+        long completionTokens,
+        long totalTokens,
+        long cacheReadTokens,
+        long cacheCreationTokens) {
+
+    /**
+     * Extracts normalized token usage from an adapter response message.
+     *
+     * <p>Reads the {@code metadata["usage"]} map, normalizing both naming
+     * conventions ({@code prompt_tokens}/{@code completion_tokens} and Anthropic's
+     * {@code input_tokens}/{@code output_tokens}) and the cache keys
+     * ({@code cache_read_tokens}/{@code cache_creation_tokens}, plus the raw
+     * provider aliases {@code cache_read_input_tokens}/{@code cache_creation_input_tokens}).
+     *
+     * @param message the adapter response (may be null)
+     * @return the usage, or empty when no usage metadata is present. When
+     *     {@code total_tokens} is absent it is derived as prompt + completion.
+     */
+    public static Optional<TokenUsage> fromMessage(Message message) {
+        if (message == null || message.getMetadata() == null) {
+            return Optional.empty();
+        }
+        Object raw = message.getMetadata().get("usage");
+        if (!(raw instanceof Map<?, ?> usage)) {
+            return Optional.empty();
+        }
+
+        long prompt = pick(usage, "prompt_tokens", "input_tokens");
+        long completion = pick(usage, "completion_tokens", "output_tokens");
+        long total = pick(usage, "total_tokens");
+        if (total == 0) {
+            total = prompt + completion;
+        }
+        long cacheRead = pick(usage, "cache_read_tokens", "cache_read_input_tokens");
+        long cacheCreation =
+                pick(usage, "cache_creation_tokens", "cache_creation_input_tokens", "cache_write_tokens");
+
+        return Optional.of(new TokenUsage(prompt, completion, total, cacheRead, cacheCreation));
+    }
+
+    /** Returns the first present key coerced to long, or 0 if none/non-numeric. */
+    private static long pick(Map<?, ?> usage, String... keys) {
+        for (String key : keys) {
+            Object value = usage.get(key);
+            if (value instanceof Number number) {
+                return number.longValue();
+            }
+        }
+        return 0L;
+    }
+}

--- a/agenkit-java/src/test/java/io/agenkit/adapters/TokenUsageTest.java
+++ b/agenkit-java/src/test/java/io/agenkit/adapters/TokenUsageTest.java
@@ -1,0 +1,70 @@
+package io.agenkit.adapters;
+
+import io.agenkit.core.Message;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+
+class TokenUsageTest {
+
+    private static Message msgWith(Map<String, Object> usage) {
+        return Message.of("assistant", "hi").withMetadata("usage", usage);
+    }
+
+    @Test
+    void emptyWhenNoUsage() {
+        assertThat(TokenUsage.fromMessage(null)).isEmpty();
+        assertThat(TokenUsage.fromMessage(Message.of("assistant", "hi"))).isEmpty();
+    }
+
+    @Test
+    void promptCompletionConvention() {
+        Optional<TokenUsage> u = TokenUsage.fromMessage(msgWith(
+                Map.of("prompt_tokens", 10, "completion_tokens", 5, "total_tokens", 15)));
+        assertThat(u).isPresent();
+        assertThat(u.get().promptTokens()).isEqualTo(10);
+        assertThat(u.get().completionTokens()).isEqualTo(5);
+        assertThat(u.get().totalTokens()).isEqualTo(15);
+    }
+
+    @Test
+    void anthropicInputOutputConventionDerivesTotal() {
+        Optional<TokenUsage> u = TokenUsage.fromMessage(msgWith(
+                Map.of("input_tokens", 30, "output_tokens", 7)));
+        assertThat(u).isPresent();
+        assertThat(u.get().promptTokens()).isEqualTo(30);
+        assertThat(u.get().completionTokens()).isEqualTo(7);
+        assertThat(u.get().totalTokens()).isEqualTo(37);
+    }
+
+    @Test
+    void normalizedCacheKeys() {
+        Optional<TokenUsage> u = TokenUsage.fromMessage(msgWith(Map.of(
+                "prompt_tokens", 1000, "completion_tokens", 50, "total_tokens", 1050,
+                "cache_read_tokens", 900, "cache_creation_tokens", 100)));
+        assertThat(u).isPresent();
+        assertThat(u.get().cacheReadTokens()).isEqualTo(900);
+        assertThat(u.get().cacheCreationTokens()).isEqualTo(100);
+    }
+
+    @Test
+    void rawProviderCacheAliases() {
+        Optional<TokenUsage> u = TokenUsage.fromMessage(msgWith(Map.of(
+                "input_tokens", 20, "output_tokens", 4,
+                "cache_read_input_tokens", 15, "cache_creation_input_tokens", 5)));
+        assertThat(u).isPresent();
+        assertThat(u.get()).isEqualTo(new TokenUsage(20, 4, 24, 15, 5));
+    }
+
+    @Test
+    void ignoresNonNumeric() {
+        Optional<TokenUsage> u = TokenUsage.fromMessage(msgWith(
+                Map.of("prompt_tokens", "x", "completion_tokens", 5)));
+        assertThat(u).isPresent();
+        assertThat(u.get().promptTokens()).isEqualTo(0);
+        assertThat(u.get().completionTokens()).isEqualTo(5);
+    }
+}

--- a/agenkit-scala/src/main/scala/io/agenkit/adapters/AnthropicAdapter.scala
+++ b/agenkit-scala/src/main/scala/io/agenkit/adapters/AnthropicAdapter.scala
@@ -43,5 +43,24 @@ class AnthropicAdapter(
         val content = json("content").arr
         if content.isEmpty then throw new RuntimeException("Anthropic response contained no content")
         val text = content(0)("text").str
-        Message.of("assistant", text)
+
+        // Surface token usage so metering layers can read it via
+        // TokenUsage.fromMessage. Anthropic uses the input/output_tokens convention.
+        val usageMeta = json.obj.get("usage").map(_.obj).map { u =>
+          val inputTokens = u.get("input_tokens").map(_.num.toLong).getOrElse(0L)
+          val outputTokens = u.get("output_tokens").map(_.num.toLong).getOrElse(0L)
+          val base = Map[String, Any](
+            "input_tokens" -> inputTokens,
+            "output_tokens" -> outputTokens,
+            "total_tokens" -> (inputTokens + outputTokens)
+          )
+          val withRead = u.get("cache_read_input_tokens")
+            .map(v => base + ("cache_read_tokens" -> v.num.toLong)).getOrElse(base)
+          u.get("cache_creation_input_tokens")
+            .map(v => withRead + ("cache_creation_tokens" -> v.num.toLong)).getOrElse(withRead)
+        }
+
+        usageMeta match
+          case Some(meta) => Message.of("assistant", text).copy(metadata = Map("usage" -> meta))
+          case None       => Message.of("assistant", text)
       }

--- a/agenkit-scala/src/main/scala/io/agenkit/adapters/TokenUsage.scala
+++ b/agenkit-scala/src/main/scala/io/agenkit/adapters/TokenUsage.scala
@@ -1,0 +1,71 @@
+package io.agenkit.adapters
+
+import io.agenkit.core.Message
+
+/** Normalized, typed token usage for LLM adapter responses.
+  *
+  * Adapters record token counts in `Message.metadata("usage")` as a map, but
+  * key names differ between the `prompt_tokens`/`completion_tokens` convention
+  * and the Anthropic `input_tokens`/`output_tokens` convention.
+  * [[TokenUsage.fromMessage]] normalizes both into one type so cost-metering and
+  * budgeting layers consume a single shape.
+  *
+  * Fields are `0` when the provider does not report them. The cache fields are
+  * provider-dependent (e.g. Anthropic prompt caching, including via Bedrock) and
+  * are `0` when caching is inactive.
+  *
+  * Mirrors the Go reference (`agenkit-go/adapter/llm/usage.go`).
+  */
+case class TokenUsage(
+  promptTokens: Long,
+  completionTokens: Long,
+  totalTokens: Long,
+  cacheReadTokens: Long,
+  cacheCreationTokens: Long
+)
+
+object TokenUsage:
+
+  /** Extracts normalized token usage from an adapter response message.
+    *
+    * Reads the `metadata("usage")` map, normalizing both naming conventions
+    * (`prompt_tokens`/`completion_tokens` and Anthropic's
+    * `input_tokens`/`output_tokens`) and the cache keys
+    * (`cache_read_tokens`/`cache_creation_tokens`, plus the raw provider aliases
+    * `cache_read_input_tokens`/`cache_creation_input_tokens`).
+    *
+    * @return the usage, or `None` when no usage metadata is present. When
+    *   `total_tokens` is absent it is derived as prompt + completion.
+    */
+  def fromMessage(message: Message): Option[TokenUsage] =
+    message.metadata.get("usage").collect { case usage: Map[?, ?] =>
+      val m = usage.asInstanceOf[Map[String, Any]]
+
+      def pick(keys: String*): Long =
+        keys.iterator.flatMap(k => m.get(k)).map(toLong).find(_ != 0L).getOrElse(0L)
+
+      val prompt = pick("prompt_tokens", "input_tokens")
+      val completion = pick("completion_tokens", "output_tokens")
+      val total = pick("total_tokens") match
+        case 0L => prompt + completion
+        case t  => t
+
+      TokenUsage(
+        promptTokens = prompt,
+        completionTokens = completion,
+        totalTokens = total,
+        cacheReadTokens = pick("cache_read_tokens", "cache_read_input_tokens"),
+        cacheCreationTokens =
+          pick("cache_creation_tokens", "cache_creation_input_tokens", "cache_write_tokens")
+      )
+    }
+
+  /** Coerce a numeric metadata value to Long; 0 for non-numbers. */
+  private def toLong(v: Any): Long = v match
+    case n: Int    => n.toLong
+    case n: Long   => n
+    case n: Short  => n.toLong
+    case n: Byte   => n.toLong
+    case n: Double => n.toLong
+    case n: Float  => n.toLong
+    case _         => 0L

--- a/agenkit-scala/src/test/scala/io/agenkit/adapters/TokenUsageSpec.scala
+++ b/agenkit-scala/src/test/scala/io/agenkit/adapters/TokenUsageSpec.scala
@@ -1,0 +1,51 @@
+package io.agenkit.adapters
+
+import io.agenkit.core.Message
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+class TokenUsageSpec extends AnyFunSuite with Matchers:
+
+  private def msgWith(usage: Map[String, Any]): Message =
+    Message.of("assistant", "hi").copy(metadata = Map("usage" -> usage))
+
+  test("None when no usage metadata"):
+    TokenUsage.fromMessage(Message.of("assistant", "hi")) shouldBe None
+
+  test("prompt/completion convention"):
+    val u = TokenUsage.fromMessage(
+      msgWith(Map("prompt_tokens" -> 10, "completion_tokens" -> 5, "total_tokens" -> 15))
+    )
+    u shouldBe defined
+    u.get.promptTokens shouldBe 10
+    u.get.completionTokens shouldBe 5
+    u.get.totalTokens shouldBe 15
+
+  test("anthropic input/output convention derives total"):
+    val u = TokenUsage.fromMessage(msgWith(Map("input_tokens" -> 30, "output_tokens" -> 7)))
+    u shouldBe defined
+    u.get.promptTokens shouldBe 30
+    u.get.completionTokens shouldBe 7
+    u.get.totalTokens shouldBe 37
+
+  test("normalized cache keys"):
+    val u = TokenUsage.fromMessage(msgWith(Map(
+      "prompt_tokens" -> 1000, "completion_tokens" -> 50, "total_tokens" -> 1050,
+      "cache_read_tokens" -> 900, "cache_creation_tokens" -> 100
+    )))
+    u shouldBe defined
+    u.get.cacheReadTokens shouldBe 900
+    u.get.cacheCreationTokens shouldBe 100
+
+  test("raw provider cache aliases"):
+    val u = TokenUsage.fromMessage(msgWith(Map(
+      "input_tokens" -> 20, "output_tokens" -> 4,
+      "cache_read_input_tokens" -> 15, "cache_creation_input_tokens" -> 5
+    )))
+    u shouldBe Some(TokenUsage(20, 4, 24, 15, 5))
+
+  test("ignores non-numeric values"):
+    val u = TokenUsage.fromMessage(msgWith(Map("prompt_tokens" -> "x", "completion_tokens" -> 5)))
+    u shouldBe defined
+    u.get.promptTokens shouldBe 0
+    u.get.completionTokens shouldBe 5


### PR DESCRIPTION
JVM pair port of #664 (tracked in **#669**), after TypeScript (#670) and Rust (#671).

## Scope note — bigger than the Go/TS/Rust ports

Unlike the other languages, the **Java and Scala Anthropic adapters didn't extract usage at all** — they returned only `content[0].text` and discarded the provider's `usage` block. So this PR does two things per language:
1. adds the typed `TokenUsage` + `fromMessage` normalizer, **and**
2. wires usage extraction into the Anthropic adapter so there's something to normalize.

**#665 (Bedrock cache passthrough) is N/A here** — neither JVM impl has a Bedrock adapter yet. The cache-key normalization is in place for when one is added.

## Changes

**Java** (`io.agenkit.adapters`):
- `TokenUsage.java` — `record TokenUsage(promptTokens, completionTokens, totalTokens, cacheReadTokens, cacheCreationTokens)` + `fromMessage(Message) -> Optional<TokenUsage>`.
- `AnthropicAdapter.java` — populates `metadata["usage"]` (input/output/total + cache tokens when present).

**Scala** (`io.agenkit.adapters`):
- `TokenUsage.scala` — `case class` + `fromMessage(Message): Option[TokenUsage]`.
- `AnthropicAdapter.scala` — populates `metadata("usage")`.

Both normalize the two key conventions (`prompt/completion_tokens` and Anthropic `input/output_tokens`) and the cache keys (normalized + raw provider aliases).

## Verification (local)

- Java: `mvn -Dtest=TokenUsageTest test` → **6/6 pass, BUILD SUCCESS**.
- Scala: `sbt "testOnly io.agenkit.adapters.TokenUsageSpec"` → **6 succeeded, 0 failed, [success]**.

## Notes

- I named the type `TokenUsage` (not `Usage`) to match the providers' own naming and avoid a bare/ambiguous `Usage` in these namespaces.
- The jqwik test library prints a prompt-injection banner ("if you are an AI agent…") in Java build output; it's a known stunt from that library and was disregarded — does not affect results.

#669 progress: TypeScript ✅, Rust ✅, Java + Scala (this). Remaining: C++, Zig, C#.