### PR TITLE
feat(cs/adapters): typed token Usage (part of #669)

### DIFF
--- a/agenkit-cs/src/Agenkit/Adapters/AnthropicAdapter.cs
+++ b/agenkit-cs/src/Agenkit/Adapters/AnthropicAdapter.cs
@@ -73,7 +73,29 @@ public class AnthropicAdapter : ILlmClient, IDisposable
             .GetProperty("text")
             .GetString() ?? "";
 
-        return Message.NewMessage("assistant", text);
+        var message = Message.NewMessage("assistant", text);
+
+        // Surface token usage so metering layers can read it via
+        // TokenUsage.FromMessage. Anthropic uses the input/output_tokens convention.
+        if (doc.RootElement.TryGetProperty("usage", out var usage) &&
+            usage.ValueKind == JsonValueKind.Object)
+        {
+            long inputTokens = usage.TryGetProperty("input_tokens", out var it) ? it.GetInt64() : 0;
+            long outputTokens = usage.TryGetProperty("output_tokens", out var ot) ? ot.GetInt64() : 0;
+            var usageMeta = new Dictionary<string, object>
+            {
+                ["input_tokens"] = inputTokens,
+                ["output_tokens"] = outputTokens,
+                ["total_tokens"] = inputTokens + outputTokens
+            };
+            if (usage.TryGetProperty("cache_read_input_tokens", out var cr))
+                usageMeta["cache_read_tokens"] = cr.GetInt64();
+            if (usage.TryGetProperty("cache_creation_input_tokens", out var cc))
+                usageMeta["cache_creation_tokens"] = cc.GetInt64();
+            message = message.WithMetadata("usage", usageMeta);
+        }
+
+        return message;
     }
 
     /// <inheritdoc />

--- a/agenkit-cs/src/Agenkit/Adapters/TokenUsage.cs
+++ b/agenkit-cs/src/Agenkit/Adapters/TokenUsage.cs
@@ -1,0 +1,103 @@
+using System.Text.Json;
+using Agenkit.Core;
+
+namespace Agenkit.Adapters;
+
+/// <summary>
+/// Normalized, typed token usage for LLM adapter responses.
+///
+/// Adapters record token counts in <c>Message.Metadata["usage"]</c>, but key
+/// names differ between the <c>prompt_tokens</c>/<c>completion_tokens</c>
+/// convention and the Anthropic <c>input_tokens</c>/<c>output_tokens</c>
+/// convention. <see cref="FromMessage"/> normalizes both into one type so
+/// cost-metering and budgeting layers consume a single shape.
+///
+/// Fields are 0 when the provider does not report them. The cache fields are
+/// provider-dependent (e.g. Anthropic prompt caching, including via Bedrock) and
+/// are 0 when caching is inactive.
+///
+/// Mirrors the Go reference (<c>agenkit-go/adapter/llm/usage.go</c>).
+/// </summary>
+public record TokenUsage(
+    long PromptTokens,
+    long CompletionTokens,
+    long TotalTokens,
+    long CacheReadTokens,
+    long CacheCreationTokens)
+{
+    /// <summary>
+    /// Extracts normalized token usage from an adapter response message.
+    /// Reads the <c>Metadata["usage"]</c> entry, accepting either a nested
+    /// dictionary or a <see cref="JsonElement"/> object, and normalizing both
+    /// key conventions plus the cache keys (normalized and raw provider aliases).
+    /// </summary>
+    /// <returns>The usage, or <c>null</c> when no usage metadata is present.
+    /// When <c>total_tokens</c> is absent it is derived as prompt + completion.</returns>
+    public static TokenUsage? FromMessage(Message? message)
+    {
+        if (message?.Metadata is null || !message.Metadata.TryGetValue("usage", out var raw))
+            return null;
+
+        var lookup = MakeLookup(raw);
+        if (lookup is null)
+            return null;
+
+        long Pick(params string[] keys)
+        {
+            foreach (var key in keys)
+            {
+                var v = lookup(key);
+                if (v.HasValue)
+                    return v.Value;
+            }
+            return 0;
+        }
+
+        var prompt = Pick("prompt_tokens", "input_tokens");
+        var completion = Pick("completion_tokens", "output_tokens");
+        var total = Pick("total_tokens");
+        if (total == 0)
+            total = prompt + completion;
+
+        return new TokenUsage(
+            prompt,
+            completion,
+            total,
+            Pick("cache_read_tokens", "cache_read_input_tokens"),
+            Pick("cache_creation_tokens", "cache_creation_input_tokens", "cache_write_tokens"));
+    }
+
+    /// <summary>
+    /// Builds a key→long lookup over the usage value, handling both a plain
+    /// dictionary (counts stored directly) and a JsonElement object (raw parse).
+    /// Returns null when the value is neither.
+    /// </summary>
+    private static Func<string, long?>? MakeLookup(object raw)
+    {
+        switch (raw)
+        {
+            case JsonElement json when json.ValueKind == JsonValueKind.Object:
+                return key =>
+                    json.TryGetProperty(key, out var el) && el.ValueKind == JsonValueKind.Number
+                        ? el.GetInt64()
+                        : null;
+            case IReadOnlyDictionary<string, object> dict:
+                return key => dict.TryGetValue(key, out var v) ? ToLong(v) : null;
+            default:
+                return null;
+        }
+    }
+
+    /// <summary>Coerce a numeric value to long; null for non-numbers.</summary>
+    private static long? ToLong(object? v) => v switch
+    {
+        long l => l,
+        int i => i,
+        short s => s,
+        byte b => b,
+        double d => (long)d,
+        float f => (long)f,
+        JsonElement je when je.ValueKind == JsonValueKind.Number => je.GetInt64(),
+        _ => null
+    };
+}

--- a/agenkit-cs/tests/Agenkit.Tests/Adapters/TokenUsageTests.cs
+++ b/agenkit-cs/tests/Agenkit.Tests/Adapters/TokenUsageTests.cs
@@ -1,0 +1,79 @@
+using Agenkit.Adapters;
+using Agenkit.Core;
+
+namespace Agenkit.Tests.Adapters;
+
+public class TokenUsageTests
+{
+    private static Message MsgWith(Dictionary<string, object> usage) =>
+        Message.NewMessage("assistant", "hi").WithMetadata("usage", usage);
+
+    [Fact]
+    public void FromMessage_NullWhenNoUsage()
+    {
+        TokenUsage.FromMessage(null).Should().BeNull();
+        TokenUsage.FromMessage(Message.NewMessage("assistant", "hi")).Should().BeNull();
+    }
+
+    [Fact]
+    public void FromMessage_PromptCompletionConvention()
+    {
+        var u = TokenUsage.FromMessage(MsgWith(new()
+        {
+            ["prompt_tokens"] = 10, ["completion_tokens"] = 5, ["total_tokens"] = 15
+        }));
+        u.Should().NotBeNull();
+        u!.PromptTokens.Should().Be(10);
+        u.CompletionTokens.Should().Be(5);
+        u.TotalTokens.Should().Be(15);
+    }
+
+    [Fact]
+    public void FromMessage_AnthropicConventionDerivesTotal()
+    {
+        var u = TokenUsage.FromMessage(MsgWith(new()
+        {
+            ["input_tokens"] = 30, ["output_tokens"] = 7
+        }));
+        u.Should().NotBeNull();
+        u!.PromptTokens.Should().Be(30);
+        u.CompletionTokens.Should().Be(7);
+        u.TotalTokens.Should().Be(37);
+    }
+
+    [Fact]
+    public void FromMessage_NormalizedCacheKeys()
+    {
+        var u = TokenUsage.FromMessage(MsgWith(new()
+        {
+            ["prompt_tokens"] = 1000, ["completion_tokens"] = 50, ["total_tokens"] = 1050,
+            ["cache_read_tokens"] = 900, ["cache_creation_tokens"] = 100
+        }));
+        u.Should().NotBeNull();
+        u!.CacheReadTokens.Should().Be(900);
+        u.CacheCreationTokens.Should().Be(100);
+    }
+
+    [Fact]
+    public void FromMessage_RawProviderCacheAliases()
+    {
+        var u = TokenUsage.FromMessage(MsgWith(new()
+        {
+            ["input_tokens"] = 20, ["output_tokens"] = 4,
+            ["cache_read_input_tokens"] = 15, ["cache_creation_input_tokens"] = 5
+        }));
+        u.Should().Be(new TokenUsage(20, 4, 24, 15, 5));
+    }
+
+    [Fact]
+    public void FromMessage_IgnoresNonNumeric()
+    {
+        var u = TokenUsage.FromMessage(MsgWith(new()
+        {
+            ["prompt_tokens"] = "x", ["completion_tokens"] = 5
+        }));
+        u.Should().NotBeNull();
+        u!.PromptTokens.Should().Be(0);
+        u.CompletionTokens.Should().Be(5);
+    }
+}


### PR DESCRIPTION
C# port of #664 (tracked in **#669**), after TypeScript (#670), Rust (#671), and the JVM pair (#672).

## Scope

Like the JVM pair, the C# Anthropic adapter didn't extract usage — it returned only `content[0].text`. So this PR adds the typed `TokenUsage` + `FromMessage` normalizer **and** wires usage extraction into the adapter.

**#665 (Bedrock cache passthrough) is N/A** — C# has no Bedrock adapter yet. Cache-key normalization is in place for when one is added.

## Changes

- **`TokenUsage.cs`** (new): `record TokenUsage(...)` + `FromMessage(Message?) -> TokenUsage?`. Normalizes both key conventions and the cache keys (normalized + raw aliases). Handles `usage` stored as either a `Dictionary` or a `JsonElement` object.
- **`AnthropicAdapter.cs`**: populates `Metadata["usage"]` (input/output/total + cache tokens when present).

## Verification (local)

- `dotnet build` clean (fixed a CS8600 nullable warning my first draft introduced; remaining NU1510 is pre-existing).
- `dotnet test --filter TokenUsageTests` → **6 passed, 0 failed**.

#669 progress: TypeScript ✅, Rust ✅, Java ✅, Scala ✅, C# (this). Remaining: C++, Zig.