### PR TITLE
feat(cpp/adapters): typed token Usage + Bedrock prompt-cache counts (part of #669)

### DIFF
--- a/agenkit-cpp/include/agenkit/adapters/usage.hpp
+++ b/agenkit-cpp/include/agenkit/adapters/usage.hpp
@@ -1,0 +1,103 @@
+#ifndef AGENKIT_ADAPTERS_USAGE_HPP
+#define AGENKIT_ADAPTERS_USAGE_HPP
+
+#include <cstdint>
+#include <optional>
+
+#include <nlohmann/json.hpp>
+
+#include "agenkit/core/message.hpp"
+
+/**
+ * @file usage.hpp
+ * @brief Typed token usage for LLM adapter responses.
+ *
+ * Adapters record token counts in `Message::metadata()["usage"]` as a JSON
+ * object, but key names differ between the prompt_tokens/completion_tokens
+ * convention and the Anthropic input_tokens/output_tokens convention.
+ * usage_from_message() normalizes both into one struct so cost-metering and
+ * budgeting layers consume a single shape.
+ *
+ * Mirrors the Go reference (agenkit-go/adapter/llm/usage.go).
+ */
+
+namespace agenkit {
+namespace adapters {
+
+/**
+ * @brief Normalized, typed token usage.
+ *
+ * Fields are 0 when the provider does not report them. The cache fields are
+ * provider-dependent (e.g. Anthropic prompt caching, including via Bedrock) and
+ * are 0 when caching is inactive.
+ */
+struct Usage {
+    std::int64_t prompt_tokens = 0;
+    std::int64_t completion_tokens = 0;
+    std::int64_t total_tokens = 0;
+    std::int64_t cache_read_tokens = 0;
+    std::int64_t cache_creation_tokens = 0;
+
+    bool operator==(const Usage& other) const {
+        return prompt_tokens == other.prompt_tokens &&
+               completion_tokens == other.completion_tokens &&
+               total_tokens == other.total_tokens &&
+               cache_read_tokens == other.cache_read_tokens &&
+               cache_creation_tokens == other.cache_creation_tokens;
+    }
+};
+
+namespace detail {
+
+/// First present integer-valued key, or 0 if none.
+template <typename... Keys>
+inline std::int64_t pick_token(const nlohmann::json& usage, Keys... keys) {
+    for (const char* key : {keys...}) {
+        auto it = usage.find(key);
+        if (it != usage.end() && it->is_number()) {
+            return it->get<std::int64_t>();
+        }
+    }
+    return 0;
+}
+
+}  // namespace detail
+
+/**
+ * @brief Extract normalized token usage from an adapter response message.
+ *
+ * Reads the `metadata()["usage"]` object, normalizing both naming conventions
+ * (prompt_tokens/completion_tokens and Anthropic input_tokens/output_tokens) and
+ * the cache keys (cache_read_tokens/cache_creation_tokens, plus the raw provider
+ * aliases cache_read_input_tokens/cache_creation_input_tokens).
+ *
+ * @return the Usage, or std::nullopt when no usage metadata is present. When
+ *   total_tokens is absent it is derived as prompt + completion.
+ */
+inline std::optional<Usage> usage_from_message(const core::Message& message) {
+    const nlohmann::json& metadata = message.metadata();
+    auto it = metadata.find("usage");
+    if (it == metadata.end() || !it->is_object()) {
+        return std::nullopt;
+    }
+    const nlohmann::json& usage = *it;
+
+    Usage result;
+    result.prompt_tokens = detail::pick_token(usage, "prompt_tokens", "input_tokens");
+    result.completion_tokens = detail::pick_token(usage, "completion_tokens", "output_tokens");
+    result.total_tokens = detail::pick_token(usage, "total_tokens");
+    if (result.total_tokens == 0) {
+        result.total_tokens = result.prompt_tokens + result.completion_tokens;
+    }
+    result.cache_read_tokens =
+        detail::pick_token(usage, "cache_read_tokens", "cache_read_input_tokens");
+    result.cache_creation_tokens = detail::pick_token(
+        usage, "cache_creation_tokens", "cache_creation_input_tokens", "cache_write_tokens");
+
+    return result;
+}
+
+}  // namespace adapters
+}  // namespace agenkit
+
+#endif  // AGENKIT_ADAPTERS_USAGE_HPP

--- a/agenkit-cpp/src/adapters/bedrock_agent.cpp
+++ b/agenkit-cpp/src/adapters/bedrock_agent.cpp
@@ -200,6 +200,15 @@ BedrockAgent::call_converse_api(const core::Message& message) {
             usage_metadata["prompt_tokens"] = result.GetUsage().GetInputTokens();
             usage_metadata["completion_tokens"] = result.GetUsage().GetOutputTokens();
             usage_metadata["total_tokens"] = result.GetUsage().GetTotalTokens();
+            // Prompt-cache token counts (Anthropic-on-Bedrock), billed at a
+            // reduced rate. Only present when prompt caching is active.
+            if (result.GetUsage().CacheReadInputTokensHasBeenSet()) {
+                usage_metadata["cache_read_tokens"] = result.GetUsage().GetCacheReadInputTokens();
+            }
+            if (result.GetUsage().CacheWriteInputTokensHasBeenSet()) {
+                usage_metadata["cache_creation_tokens"] =
+                    result.GetUsage().GetCacheWriteInputTokens();
+            }
             response_msg.with_metadata("usage", usage_metadata);
         }
 

--- a/agenkit-cpp/tests/CMakeLists.txt
+++ b/agenkit-cpp/tests/CMakeLists.txt
@@ -37,6 +37,11 @@ add_executable(test_message test_message.cpp)
 target_link_libraries(test_message agenkit gtest_main)
 add_test(NAME message_tests COMMAND test_message)
 
+# Token usage normalization tests
+add_executable(test_usage test_usage.cpp)
+target_link_libraries(test_usage agenkit gtest_main)
+add_test(NAME usage_tests COMMAND test_usage)
+
 # Cross-language message serialization tests
 add_executable(test_cross_language_message_serialization test_cross_language_message_serialization.cpp)
 target_link_libraries(test_cross_language_message_serialization agenkit gtest_main)

--- a/agenkit-cpp/tests/test_usage.cpp
+++ b/agenkit-cpp/tests/test_usage.cpp
@@ -1,0 +1,72 @@
+/**
+ * @file test_usage.cpp
+ * @brief Tests for typed token usage normalization.
+ */
+
+#include <gtest/gtest.h>
+
+#include "agenkit/adapters/usage.hpp"
+#include "agenkit/core/message.hpp"
+
+using agenkit::adapters::Usage;
+using agenkit::adapters::usage_from_message;
+using agenkit::core::Message;
+
+namespace {
+
+Message msg_with(const nlohmann::json& usage) {
+    Message m = Message::with_text("assistant", "hi");
+    m.with_metadata("usage", usage);
+    return m;
+}
+
+}  // namespace
+
+TEST(UsageTest, NulloptWhenNoUsage) {
+    Message m = Message::with_text("assistant", "hi");
+    EXPECT_FALSE(usage_from_message(m).has_value());
+}
+
+TEST(UsageTest, PromptCompletionConvention) {
+    auto u = usage_from_message(msg_with(
+        {{"prompt_tokens", 10}, {"completion_tokens", 5}, {"total_tokens", 15}}));
+    ASSERT_TRUE(u.has_value());
+    EXPECT_EQ(u->prompt_tokens, 10);
+    EXPECT_EQ(u->completion_tokens, 5);
+    EXPECT_EQ(u->total_tokens, 15);
+}
+
+TEST(UsageTest, AnthropicConventionDerivesTotal) {
+    auto u = usage_from_message(msg_with({{"input_tokens", 30}, {"output_tokens", 7}}));
+    ASSERT_TRUE(u.has_value());
+    EXPECT_EQ(u->prompt_tokens, 30);
+    EXPECT_EQ(u->completion_tokens, 7);
+    EXPECT_EQ(u->total_tokens, 37);
+}
+
+TEST(UsageTest, NormalizedCacheKeys) {
+    auto u = usage_from_message(msg_with({{"prompt_tokens", 1000},
+                                          {"completion_tokens", 50},
+                                          {"total_tokens", 1050},
+                                          {"cache_read_tokens", 900},
+                                          {"cache_creation_tokens", 100}}));
+    ASSERT_TRUE(u.has_value());
+    EXPECT_EQ(u->cache_read_tokens, 900);
+    EXPECT_EQ(u->cache_creation_tokens, 100);
+}
+
+TEST(UsageTest, RawProviderCacheAliases) {
+    auto u = usage_from_message(msg_with({{"input_tokens", 20},
+                                          {"output_tokens", 4},
+                                          {"cache_read_input_tokens", 15},
+                                          {"cache_creation_input_tokens", 5}}));
+    ASSERT_TRUE(u.has_value());
+    EXPECT_EQ(*u, (Usage{20, 4, 24, 15, 5}));
+}
+
+TEST(UsageTest, IgnoresNonNumeric) {
+    auto u = usage_from_message(msg_with({{"prompt_tokens", "x"}, {"completion_tokens", 5}}));
+    ASSERT_TRUE(u.has_value());
+    EXPECT_EQ(u->prompt_tokens, 0);
+    EXPECT_EQ(u->completion_tokens, 5);
+}


### PR DESCRIPTION
C++ port of #664/#665 (tracked in **#669**), after TypeScript (#670), Rust (#671), JVM (#672), C# (#673).

## Changes

- **`include/agenkit/adapters/usage.hpp`** (new, header-only): `Usage` struct + `usage_from_message(const core::Message&) -> std::optional<Usage>`. Normalizes both key conventions (`prompt/completion_tokens` and Anthropic `input/output_tokens`) and the cache keys (normalized + raw aliases) from the `nlohmann::json` `metadata["usage"]` object. No AWS SDK dependency → builds regardless of `AGENKIT_HAS_AWS_SDK`.
- **`src/adapters/bedrock_agent.cpp`**: forward `GetCacheReadInputTokens` / `GetCacheWriteInputTokens` (guarded by `...HasBeenSet()`) as `cache_read_tokens` / `cache_creation_tokens`. SDK accessor names verified against the installed `aws-sdk-cpp` `TokenUsage.h`. (This path compiles only when `AGENKIT_HAS_AWS_SDK=ON`.)
- **`tests/test_usage.cpp`** + CMakeLists: 6 gtest cases.

## Verification (local)

- Configured + built the `test_usage` target via CMake (default options, AWS SDK off) and ran it → **6/6 PASSED**.
- The existing C++ claude_agent already stores raw `usage` into metadata; the new `usage_from_message` typed-reads it (Anthropic `input/output_tokens` convention included).

## Notes

- `agenkit-cpp` CI (`cpp-ci.yml`) is currently `.disabled` in this repo, so there's no C++ smoke gate on the PR; verified locally instead.
- Bedrock cache code is behind the off-by-default `AGENKIT_HAS_AWS_SDK` option, matching how the Bedrock adapter is already gated.

#669 progress: TS ✅, Rust ✅, Java ✅, Scala ✅, C# (#673), C++ (this). Remaining: Zig.